### PR TITLE
Move Credential definition to root of crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking change
+
+- Move `Credential` definition from `auth` module to root, to separate it from all the
+  feature modules. `auth` module is now private.
+  - To migrate change `use azure_devops_rust_api::auth::Credential` to `use azure_devops_rust_api::Credential`
+
 ### Added
 
 - API documentation: autogenerate function description and parameter descriptions from fields

--- a/autorust/codegen/src/codegen_operations.rs
+++ b/autorust/codegen/src/codegen_operations.rs
@@ -67,14 +67,14 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
         #[derive(Clone)]
         pub struct Client {
             endpoint: String,
-            credential: crate::auth::Credential,
+            credential: crate::Credential,
             scopes: Vec<String>,
             pipeline: azure_core::Pipeline,
         }
 
         #[derive(Clone)]
         pub struct ClientBuilder {
-            credential: crate::auth::Credential,
+            credential: crate::Credential,
             endpoint: Option<String>,
             scopes: Option<Vec<String>>,
         }
@@ -82,7 +82,7 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
         #default_endpoint_code
 
         impl ClientBuilder {
-            pub fn new(credential: crate::auth::Credential) -> Self {
+            pub fn new(credential: crate::Credential) -> Self {
                 Self {
                     credential,
                     endpoint: None,
@@ -111,7 +111,7 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
             pub(crate) fn endpoint(&self) -> &str {
                 self.endpoint.as_str()
             }
-            pub(crate) fn credential(&self) -> &crate::auth::Credential {
+            pub(crate) fn credential(&self) -> &crate::Credential {
                 &self.credential
             }
             pub(crate) async fn send(&self, request: impl Into<azure_core::Request>) -> azure_core::error::Result<azure_core::Response> {
@@ -119,7 +119,7 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
                 let mut request = request.into();
                 self.pipeline.send(&mut context, &mut request).await
             }
-            pub fn new(endpoint: impl Into<String>, credential: crate::auth::Credential, scopes: Vec<String>) -> Self {
+            pub fn new(endpoint: impl Into<String>, credential: crate::Credential, scopes: Vec<String>) -> Self {
                 let endpoint = endpoint.into();
                 let pipeline = azure_core::Pipeline::new(
                     option_env!("CARGO_PKG_NAME"),

--- a/azure_devops_rust_api/examples/build_list.rs
+++ b/azure_devops_rust_api/examples/build_list.rs
@@ -3,8 +3,8 @@
 
 // build_list.rs
 // Repository list example.
-use azure_devops_rust_api::auth::Credential;
 use azure_devops_rust_api::build;
+use azure_devops_rust_api::Credential;
 use std::env;
 use std::error::Error;
 use std::sync::Arc;

--- a/azure_devops_rust_api/examples/git_repo_get.rs
+++ b/azure_devops_rust_api/examples/git_repo_get.rs
@@ -3,8 +3,8 @@
 
 // git_repo_get.rs
 // Repository get example.
-use azure_devops_rust_api::auth::Credential;
 use azure_devops_rust_api::git;
+use azure_devops_rust_api::Credential;
 use std::env;
 use std::error::Error;
 use std::sync::Arc;

--- a/azure_devops_rust_api/examples/git_repo_list.rs
+++ b/azure_devops_rust_api/examples/git_repo_list.rs
@@ -3,8 +3,8 @@
 
 // git_repo_list.rs
 // Repository list example.
-use azure_devops_rust_api::auth::Credential;
 use azure_devops_rust_api::git;
+use azure_devops_rust_api::Credential;
 use std::env;
 use std::error::Error;
 use std::sync::Arc;

--- a/azure_devops_rust_api/examples/graph_query.rs
+++ b/azure_devops_rust_api/examples/graph_query.rs
@@ -3,9 +3,9 @@
 
 // graph_query.rs
 // Graph example.
-use azure_devops_rust_api::auth::Credential;
 use azure_devops_rust_api::graph;
 use azure_devops_rust_api::graph::models::GraphSubjectQuery;
+use azure_devops_rust_api::Credential;
 use std::env;
 use std::error::Error;
 use std::sync::Arc;

--- a/azure_devops_rust_api/examples/pipelines.rs
+++ b/azure_devops_rust_api/examples/pipelines.rs
@@ -3,9 +3,9 @@
 
 // pipelines.rs
 // Pipelines example.
-use azure_devops_rust_api::auth::Credential;
 use azure_devops_rust_api::pipelines;
 use azure_devops_rust_api::pipelines::models::{Pipeline, RunPipelineParameters};
+use azure_devops_rust_api::Credential;
 use std::env;
 use std::error::Error;
 use std::sync::Arc;

--- a/azure_devops_rust_api/examples/service_endpoint.rs
+++ b/azure_devops_rust_api/examples/service_endpoint.rs
@@ -3,8 +3,8 @@
 
 // service_endpoint.rs
 // Service Endpoint (aka "Service Connection") example.
-use azure_devops_rust_api::auth::Credential;
 use azure_devops_rust_api::service_endpoint;
+use azure_devops_rust_api::Credential;
 use std::env;
 use std::error::Error;
 use std::sync::Arc;

--- a/azure_devops_rust_api/src/accounts/operations.rs
+++ b/azure_devops_rust_api/src/accounts/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://app.vssps.visualstudio.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/artifacts/operations.rs
+++ b/azure_devops_rust_api/src/artifacts/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://feeds.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/artifacts_package_types/operations.rs
+++ b/azure_devops_rust_api/src/artifacts_package_types/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://pkgs.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/audit/operations.rs
+++ b/azure_devops_rust_api/src/audit/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://auditservice.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/build/operations.rs
+++ b/azure_devops_rust_api/src/build/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/clt/operations.rs
+++ b/azure_devops_rust_api/src/clt/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://vsclt.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/core/operations.rs
+++ b/azure_devops_rust_api/src/core/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/dashboard/operations.rs
+++ b/azure_devops_rust_api/src/dashboard/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/distributed_task/operations.rs
+++ b/azure_devops_rust_api/src/distributed_task/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/extension_management/operations.rs
+++ b/azure_devops_rust_api/src/extension_management/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://extmgmt.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/git/operations.rs
+++ b/azure_devops_rust_api/src/git/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/graph/operations.rs
+++ b/azure_devops_rust_api/src/graph/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://vssps.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/hooks/operations.rs
+++ b/azure_devops_rust_api/src/hooks/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/ims/operations.rs
+++ b/azure_devops_rust_api/src/ims/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://vssps.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/lib.rs
+++ b/azure_devops_rust_api/src/lib.rs
@@ -85,4 +85,5 @@ pub mod wit;
 #[cfg(feature = "work")]
 pub mod work;
 
-pub mod auth;
+mod auth;
+pub use auth::Credential;

--- a/azure_devops_rust_api/src/member_entitlement_management/operations.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://vsaex.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/operations/operations.rs
+++ b/azure_devops_rust_api/src/operations/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/permissions_report/operations.rs
+++ b/azure_devops_rust_api/src/permissions_report/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/pipelines/operations.rs
+++ b/azure_devops_rust_api/src/pipelines/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/policy/operations.rs
+++ b/azure_devops_rust_api/src/policy/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/processadmin/operations.rs
+++ b/azure_devops_rust_api/src/processadmin/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/processes/operations.rs
+++ b/azure_devops_rust_api/src/processes/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/profile/operations.rs
+++ b/azure_devops_rust_api/src/profile/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://app.vssps.visualstudio.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/release/operations.rs
+++ b/azure_devops_rust_api/src/release/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://vsrm.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/search/operations.rs
+++ b/azure_devops_rust_api/src/search/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://almsearch.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/security/operations.rs
+++ b/azure_devops_rust_api/src/security/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/service_endpoint/operations.rs
+++ b/azure_devops_rust_api/src/service_endpoint/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/status/operations.rs
+++ b/azure_devops_rust_api/src/status/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://status.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/symbol/operations.rs
+++ b/azure_devops_rust_api/src/symbol/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://artifacts.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/test/operations.rs
+++ b/azure_devops_rust_api/src/test/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/test_plan/operations.rs
+++ b/azure_devops_rust_api/src/test_plan/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/test_results/operations.rs
+++ b/azure_devops_rust_api/src/test_results/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://vstmr.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/tfvc/operations.rs
+++ b/azure_devops_rust_api/src/tfvc/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/token_admin/operations.rs
+++ b/azure_devops_rust_api/src/token_admin/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://vssps.dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/wiki/operations.rs
+++ b/azure_devops_rust_api/src/wiki/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/wit/operations.rs
+++ b/azure_devops_rust_api/src/wit/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();

--- a/azure_devops_rust_api/src/work/operations.rs
+++ b/azure_devops_rust_api/src/work/operations.rs
@@ -9,19 +9,19 @@ use super::models;
 #[derive(Clone)]
 pub struct Client {
     endpoint: String,
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     scopes: Vec<String>,
     pipeline: azure_core::Pipeline,
 }
 #[derive(Clone)]
 pub struct ClientBuilder {
-    credential: crate::auth::Credential,
+    credential: crate::Credential,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://dev.azure.com";
 impl ClientBuilder {
-    pub fn new(credential: crate::auth::Credential) -> Self {
+    pub fn new(credential: crate::Credential) -> Self {
         Self {
             credential,
             endpoint: None,
@@ -48,7 +48,7 @@ impl Client {
     pub(crate) fn endpoint(&self) -> &str {
         self.endpoint.as_str()
     }
-    pub(crate) fn credential(&self) -> &crate::auth::Credential {
+    pub(crate) fn credential(&self) -> &crate::Credential {
         &self.credential
     }
     pub(crate) async fn send(
@@ -61,7 +61,7 @@ impl Client {
     }
     pub fn new(
         endpoint: impl Into<String>,
-        credential: crate::auth::Credential,
+        credential: crate::Credential,
         scopes: Vec<String>,
     ) -> Self {
         let endpoint = endpoint.into();


### PR DESCRIPTION
Move `Credential` definition from `auth` module to root, to separate it from all the feature modules. `auth` module is now private.
- To migrate change `use azure_devops_rust_api::auth::Credential` to `use azure_devops_rust_api::Credential`.

Fixes https://github.com/microsoft/azure-devops-rust-api/issues/7