### PR TITLE
Build struct cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking change
+
+- Updated some struct fields to remove Option wrappers to make the values easier to use.
+
 ## [0.3.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking change
 
 - Updated some struct fields to remove Option wrappers to make the values easier to use.
+- Updated some `links` fields to have a struct with known fields, rather than a Json `Value`.
 
 ## [0.3.1]
 

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -32,6 +32,7 @@ base64 = "0.13"
 [dev-dependencies]
 azure_identity = "0.4"
 tokio = { version = "1.0", features = ["full"] }
+anyhow = "1"
 
 [features]
 accounts = []

--- a/azure_devops_rust_api/examples/build_list.rs
+++ b/azure_devops_rust_api/examples/build_list.rs
@@ -3,14 +3,14 @@
 
 // build_list.rs
 // Repository list example.
+use anyhow::Result;
 use azure_devops_rust_api::build;
 use azure_devops_rust_api::Credential;
 use std::env;
-use std::error::Error;
 use std::sync::Arc;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn main() -> Result<()> {
     // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
     let credential = match env::var("ADO_TOKEN") {
         Ok(token) => {

--- a/azure_devops_rust_api/examples/git_repo_get.rs
+++ b/azure_devops_rust_api/examples/git_repo_get.rs
@@ -3,14 +3,14 @@
 
 // git_repo_get.rs
 // Repository get example.
+use anyhow::Result;
 use azure_devops_rust_api::git;
 use azure_devops_rust_api::Credential;
 use std::env;
-use std::error::Error;
 use std::sync::Arc;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn main() -> Result<()> {
     // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
     let credential = match env::var("ADO_TOKEN") {
         Ok(token) => {

--- a/azure_devops_rust_api/examples/git_repo_list.rs
+++ b/azure_devops_rust_api/examples/git_repo_list.rs
@@ -3,14 +3,14 @@
 
 // git_repo_list.rs
 // Repository list example.
+use anyhow::Result;
 use azure_devops_rust_api::git;
 use azure_devops_rust_api::Credential;
 use std::env;
-use std::error::Error;
 use std::sync::Arc;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn main() -> Result<()> {
     // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
     let credential = match env::var("ADO_TOKEN") {
         Ok(token) => {

--- a/azure_devops_rust_api/examples/graph_query.rs
+++ b/azure_devops_rust_api/examples/graph_query.rs
@@ -3,15 +3,15 @@
 
 // graph_query.rs
 // Graph example.
+use anyhow::Result;
 use azure_devops_rust_api::graph;
 use azure_devops_rust_api::graph::models::GraphSubjectQuery;
 use azure_devops_rust_api::Credential;
 use std::env;
-use std::error::Error;
 use std::sync::Arc;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn main() -> Result<()> {
     // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
     let credential = match env::var("ADO_TOKEN") {
         Ok(token) => {

--- a/azure_devops_rust_api/examples/pipelines.rs
+++ b/azure_devops_rust_api/examples/pipelines.rs
@@ -3,15 +3,15 @@
 
 // pipelines.rs
 // Pipelines example.
+use anyhow::Result;
 use azure_devops_rust_api::pipelines;
 use azure_devops_rust_api::pipelines::models::{Pipeline, RunPipelineParameters};
 use azure_devops_rust_api::Credential;
 use std::env;
-use std::error::Error;
 use std::sync::Arc;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn main() -> Result<()> {
     // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
     let credential = match env::var("ADO_TOKEN") {
         Ok(token) => {

--- a/azure_devops_rust_api/examples/service_endpoint.rs
+++ b/azure_devops_rust_api/examples/service_endpoint.rs
@@ -3,14 +3,14 @@
 
 // service_endpoint.rs
 // Service Endpoint (aka "Service Connection") example.
+use anyhow::Result;
 use azure_devops_rust_api::service_endpoint;
 use azure_devops_rust_api::Credential;
 use std::env;
-use std::error::Error;
 use std::sync::Arc;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn main() -> Result<()> {
     // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
     let credential = match env::var("ADO_TOKEN") {
         Ok(token) => {

--- a/azure_devops_rust_api/src/artifacts/models.rs
+++ b/azure_devops_rust_api/src/artifacts/models.rs
@@ -200,9 +200,9 @@ pub mod feed_change {
 #[doc = "A result set containing the feed changes for the range that was requested."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct FeedChangesResponse {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "The number of changes in this set."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub count: Option<i32>,

--- a/azure_devops_rust_api/src/build/models.rs
+++ b/azure_devops_rust_api/src/build/models.rs
@@ -7,27 +7,30 @@ use serde::de::{value, Deserializer, IntoDeserializer};
 use serde::{Deserialize, Serialize, Serializer};
 use std::str::FromStr;
 #[doc = "Represents a queue for running builds."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AgentPoolQueue {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "The ID of the queue."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<i32>,
+    pub id: i32,
     #[doc = "The name of the queue."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     #[doc = "Represents a reference to an agent pool."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pool: Option<TaskAgentPoolReference>,
+    pub pool: TaskAgentPoolReference,
     #[doc = "The full http link to the resource."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
 impl AgentPoolQueue {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(id: i32, name: String, pool: TaskAgentPoolReference) -> Self {
+        Self {
+            links: None,
+            id,
+            name,
+            pool,
+            url: None,
+        }
     }
 }
 #[doc = "Represents a reference to an agent queue."]
@@ -343,9 +346,9 @@ pub mod aggregated_runs_by_state {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ArtifactResource {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "Type-specific data about the artifact."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<String>,
@@ -407,9 +410,9 @@ impl AssociatedWorkItem {
 #[doc = "Represents an attachment to a build."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct Attachment {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "The name of the attachment."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -446,11 +449,11 @@ impl AuthorizationHeader {
     }
 }
 #[doc = "Data representation of a build."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Build {
-    #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[doc = "The class to represent a collection of REST reference links."]
+    #[serde(rename = "_links")]
+    pub links: ReferenceLinks,
     #[doc = "Specification of the agent defined by the pool provider."]
     #[serde(
         rename = "agentSpecification",
@@ -459,12 +462,8 @@ pub struct Build {
     )]
     pub agent_specification: Option<AgentSpecification>,
     #[doc = "The build number/name of the build."]
-    #[serde(
-        rename = "buildNumber",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub build_number: Option<String>,
+    #[serde(rename = "buildNumber")]
+    pub build_number: String,
     #[doc = "The build number revision."]
     #[serde(
         rename = "buildNumberRevision",
@@ -476,8 +475,7 @@ pub struct Build {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub controller: Option<BuildController>,
     #[doc = "Represents a reference to a definition."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub definition: Option<DefinitionReference>,
+    pub definition: DefinitionReference,
     #[doc = "Indicates whether the build has been deleted."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deleted: Option<bool>,
@@ -509,47 +507,29 @@ pub struct Build {
     )]
     pub finish_time: Option<String>,
     #[doc = "The ID of the build."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<i32>,
+    pub id: i32,
     #[doc = ""]
-    #[serde(
-        rename = "lastChangedBy",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub last_changed_by: Option<IdentityRef>,
+    #[serde(rename = "lastChangedBy")]
+    pub last_changed_by: IdentityRef,
     #[doc = "The date the build was last changed."]
-    #[serde(
-        rename = "lastChangedDate",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub last_changed_date: Option<String>,
+    #[serde(rename = "lastChangedDate")]
+    pub last_changed_date: String,
     #[doc = "Represents a reference to a build log."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub logs: Option<BuildLogReference>,
+    pub logs: BuildLogReference,
     #[doc = "Represents a reference to an orchestration plan."]
-    #[serde(
-        rename = "orchestrationPlan",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub orchestration_plan: Option<TaskOrchestrationPlanReference>,
+    #[serde(rename = "orchestrationPlan")]
+    pub orchestration_plan: TaskOrchestrationPlanReference,
     #[doc = "The parameters for the build."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parameters: Option<String>,
     #[doc = "Orchestration plans associated with the build (build, cleanup)"]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub plans: Vec<TaskOrchestrationPlanReference>,
     #[doc = "The build's priority."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub priority: Option<build::Priority>,
+    pub priority: build::Priority,
     #[doc = "Represents a shallow reference to a TeamProject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub project: Option<TeamProjectReference>,
+    pub project: TeamProjectReference,
     #[doc = "The class represents a property bag as a collection of key-value pairs. Values of all primitive types (any type with a `TypeCode != TypeCode.Object`) except for `DBNull` are accepted. Values of type Byte[], Int32, Double, DateType and String preserve their type, other primitives are retuned as a String. Byte[] expected as base64 encoded string."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub properties: Option<PropertiesCollection>,
+    pub properties: PropertiesCollection,
     #[doc = "The quality of the xaml build (good, bad, etc.)"]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quality: Option<String>,
@@ -574,56 +554,32 @@ pub struct Build {
     #[serde(rename = "queueTime", default, skip_serializing_if = "Option::is_none")]
     pub queue_time: Option<String>,
     #[doc = "The reason that the build was created."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reason: Option<build::Reason>,
+    pub reason: build::Reason,
     #[doc = "Represents a repository used by a build definition."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<BuildRepository>,
+    pub repository: BuildRepository,
     #[doc = ""]
-    #[serde(
-        rename = "requestedBy",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub requested_by: Option<IdentityRef>,
+    #[serde(rename = "requestedBy")]
+    pub requested_by: IdentityRef,
     #[doc = ""]
-    #[serde(
-        rename = "requestedFor",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub requested_for: Option<IdentityRef>,
+    #[serde(rename = "requestedFor")]
+    pub requested_for: IdentityRef,
     #[doc = "The build result."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result: Option<build::Result>,
     #[doc = "Indicates whether the build is retained by a release."]
-    #[serde(
-        rename = "retainedByRelease",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub retained_by_release: Option<bool>,
+    #[serde(rename = "retainedByRelease")]
+    pub retained_by_release: bool,
     #[doc = "The source branch."]
-    #[serde(
-        rename = "sourceBranch",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub source_branch: Option<String>,
+    #[serde(rename = "sourceBranch")]
+    pub source_branch: String,
     #[doc = "The source version."]
-    #[serde(
-        rename = "sourceVersion",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub source_version: Option<String>,
+    #[serde(rename = "sourceVersion")]
+    pub source_version: String,
     #[doc = "The time that the build was started."]
     #[serde(rename = "startTime", default, skip_serializing_if = "Option::is_none")]
     pub start_time: Option<String>,
     #[doc = "The status of the build."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub status: Option<build::Status>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub status: build::Status,
     pub tags: Vec<String>,
     #[doc = "Parameters to template expression evaluation"]
     #[serde(
@@ -647,21 +603,85 @@ pub struct Build {
     )]
     pub trigger_info: Option<serde_json::Value>,
     #[doc = "The URI of the build."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub uri: Option<String>,
+    pub uri: String,
     #[doc = "The REST URL of the build."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    #[serde(
-        rename = "validationResults",
-        default,
-        skip_serializing_if = "Vec::is_empty"
-    )]
+    pub url: String,
+    #[serde(rename = "validationResults")]
     pub validation_results: Vec<BuildRequestValidationResult>,
 }
 impl Build {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: ReferenceLinks,
+        build_number: String,
+        definition: DefinitionReference,
+        id: i32,
+        last_changed_by: IdentityRef,
+        last_changed_date: String,
+        logs: BuildLogReference,
+        orchestration_plan: TaskOrchestrationPlanReference,
+        plans: Vec<TaskOrchestrationPlanReference>,
+        priority: build::Priority,
+        project: TeamProjectReference,
+        properties: PropertiesCollection,
+        reason: build::Reason,
+        repository: BuildRepository,
+        requested_by: IdentityRef,
+        requested_for: IdentityRef,
+        retained_by_release: bool,
+        source_branch: String,
+        source_version: String,
+        status: build::Status,
+        tags: Vec<String>,
+        uri: String,
+        url: String,
+        validation_results: Vec<BuildRequestValidationResult>,
+    ) -> Self {
+        Self {
+            links,
+            agent_specification: None,
+            build_number,
+            build_number_revision: None,
+            controller: None,
+            definition,
+            deleted: None,
+            deleted_by: None,
+            deleted_date: None,
+            deleted_reason: None,
+            demands: Vec::new(),
+            finish_time: None,
+            id,
+            last_changed_by,
+            last_changed_date,
+            logs,
+            orchestration_plan,
+            parameters: None,
+            plans,
+            priority,
+            project,
+            properties,
+            quality: None,
+            queue: None,
+            queue_options: None,
+            queue_position: None,
+            queue_time: None,
+            reason,
+            repository,
+            requested_by,
+            requested_for,
+            result: None,
+            retained_by_release,
+            source_branch,
+            source_version,
+            start_time: None,
+            status,
+            tags,
+            template_parameters: None,
+            triggered_by_build: Box::new(None),
+            trigger_info: None,
+            uri,
+            url,
+            validation_results,
+        }
     }
 }
 pub mod build {
@@ -966,9 +986,9 @@ impl BuildCompletionTrigger {
 pub struct BuildController {
     #[serde(flatten)]
     pub xaml_build_controller_reference: XamlBuildControllerReference,
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "The date the controller was created."]
     #[serde(
         rename = "createdDate",
@@ -1028,7 +1048,7 @@ impl BuildControllerList {
     }
 }
 #[doc = "Represents a build definition."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BuildDefinition {
     #[serde(flatten)]
     pub build_definition_reference: BuildDefinitionReference,
@@ -1120,8 +1140,29 @@ pub struct BuildDefinition {
     pub variables: Option<serde_json::Value>,
 }
 impl BuildDefinition {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(build_definition_reference: BuildDefinitionReference) -> Self {
+        Self {
+            build_definition_reference,
+            badge_enabled: None,
+            build_number_format: None,
+            comment: None,
+            demands: Vec::new(),
+            description: None,
+            drop_location: None,
+            job_authorization_scope: None,
+            job_cancel_timeout_in_minutes: None,
+            job_timeout_in_minutes: None,
+            options: Vec::new(),
+            process: None,
+            process_parameters: None,
+            properties: None,
+            repository: None,
+            retention_rules: Vec::new(),
+            tags: Vec::new(),
+            triggers: Vec::new(),
+            variable_groups: Vec::new(),
+            variables: None,
+        }
     }
 }
 pub mod build_definition {
@@ -1136,7 +1177,7 @@ pub mod build_definition {
     }
 }
 #[doc = "For back-compat with extensions that use the old Steps format instead of Process and Phases"]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BuildDefinition32 {
     #[serde(flatten)]
     pub build_definition_reference3_2: BuildDefinitionReference32,
@@ -1235,8 +1276,30 @@ pub struct BuildDefinition32 {
     pub variables: Option<serde_json::Value>,
 }
 impl BuildDefinition32 {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(build_definition_reference3_2: BuildDefinitionReference32) -> Self {
+        Self {
+            build_definition_reference3_2,
+            badge_enabled: None,
+            build: Vec::new(),
+            build_number_format: None,
+            comment: None,
+            demands: Vec::new(),
+            description: None,
+            drop_location: None,
+            job_authorization_scope: None,
+            job_cancel_timeout_in_minutes: None,
+            job_timeout_in_minutes: None,
+            latest_build: None,
+            latest_completed_build: None,
+            options: Vec::new(),
+            process_parameters: None,
+            properties: None,
+            repository: None,
+            retention_rules: Vec::new(),
+            tags: Vec::new(),
+            triggers: Vec::new(),
+            variables: None,
+        }
     }
 }
 pub mod build_definition3_2 {
@@ -1251,13 +1314,13 @@ pub mod build_definition3_2 {
     }
 }
 #[doc = "Represents a reference to a build definition."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BuildDefinitionReference {
     #[serde(flatten)]
     pub definition_reference: DefinitionReference,
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = ""]
     #[serde(
         rename = "authoredBy",
@@ -1295,8 +1358,19 @@ pub struct BuildDefinitionReference {
     pub queue: Option<AgentPoolQueue>,
 }
 impl BuildDefinitionReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(definition_reference: DefinitionReference) -> Self {
+        Self {
+            definition_reference,
+            links: None,
+            authored_by: None,
+            draft_of: None,
+            drafts: Vec::new(),
+            latest_build: None,
+            latest_completed_build: None,
+            metrics: Vec::new(),
+            quality: None,
+            queue: None,
+        }
     }
 }
 pub mod build_definition_reference {
@@ -1311,13 +1385,13 @@ pub mod build_definition_reference {
     }
 }
 #[doc = "For back-compat with extensions that use the old Steps format instead of Process and Phases"]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BuildDefinitionReference32 {
     #[serde(flatten)]
     pub definition_reference: DefinitionReference,
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = ""]
     #[serde(
         rename = "authoredBy",
@@ -1341,8 +1415,17 @@ pub struct BuildDefinitionReference32 {
     pub queue: Option<AgentPoolQueue>,
 }
 impl BuildDefinitionReference32 {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(definition_reference: DefinitionReference) -> Self {
+        Self {
+            definition_reference,
+            links: None,
+            authored_by: None,
+            draft_of: None,
+            drafts: Vec::new(),
+            metrics: Vec::new(),
+            quality: None,
+            queue: None,
+        }
     }
 }
 pub mod build_definition_reference3_2 {
@@ -1731,7 +1814,7 @@ impl BuildList {
     }
 }
 #[doc = "Represents a build log."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BuildLog {
     #[serde(flatten)]
     pub build_log_reference: BuildLogReference,
@@ -1750,8 +1833,13 @@ pub struct BuildLog {
     pub line_count: Option<i64>,
 }
 impl BuildLog {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(build_log_reference: BuildLogReference) -> Self {
+        Self {
+            build_log_reference,
+            created_on: None,
+            last_changed_on: None,
+            line_count: None,
+        }
     }
 }
 #[doc = ""]
@@ -1768,21 +1856,19 @@ impl BuildLogList {
     }
 }
 #[doc = "Represents a reference to a build log."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BuildLogReference {
     #[doc = "The ID of the log."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<i32>,
+    pub id: i32,
     #[doc = "The type of the log location."]
-    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
-    pub type_: Option<String>,
+    #[serde(rename = "type")]
+    pub type_: String,
     #[doc = "A full link to the log resource."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl BuildLogReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(id: i32, type_: String, url: String) -> Self {
+        Self { id, type_, url }
     }
 }
 #[doc = "Represents metadata about builds in the system."]
@@ -2115,9 +2201,9 @@ impl BuildQueuedEvent {
 #[doc = "Represents a reference to a build."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BuildReference {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "The build number."]
     #[serde(
         rename = "buildNumber",
@@ -2217,7 +2303,7 @@ impl BuildReportMetadata {
     }
 }
 #[doc = "Represents a repository used by a build definition."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BuildRepository {
     #[doc = "Indicates whether to checkout submodules."]
     #[serde(
@@ -2237,8 +2323,7 @@ pub struct BuildRepository {
     )]
     pub default_branch: Option<String>,
     #[doc = "The ID of the repository."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "The friendly name of the repository."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -2252,15 +2337,25 @@ pub struct BuildRepository {
     )]
     pub root_folder: Option<String>,
     #[doc = "The type of the repository."]
-    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
-    pub type_: Option<String>,
+    #[serde(rename = "type")]
+    pub type_: String,
     #[doc = "The URL of the repository."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
 impl BuildRepository {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(id: String, type_: String) -> Self {
+        Self {
+            checkout_submodules: None,
+            clean: None,
+            default_branch: None,
+            id,
+            name: None,
+            properties: None,
+            root_folder: None,
+            type_,
+            url: None,
+        }
     }
 }
 #[doc = "Represents the result of validating a build request."]
@@ -2940,7 +3035,7 @@ impl DataSourceBindingBase {
     }
 }
 #[doc = "Represents a reference to a definition."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DefinitionReference {
     #[doc = "The date this version of the definition was created."]
     #[serde(
@@ -2950,40 +3045,50 @@ pub struct DefinitionReference {
     )]
     pub created_date: Option<String>,
     #[doc = "The ID of the referenced definition."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<i32>,
+    pub id: i32,
     #[doc = "The name of the referenced definition."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     #[doc = "The folder path of the definition."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub path: Option<String>,
+    pub path: String,
     #[doc = "Represents a shallow reference to a TeamProject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub project: Option<TeamProjectReference>,
+    pub project: TeamProjectReference,
     #[doc = "A value that indicates whether builds can be queued against this definition."]
-    #[serde(
-        rename = "queueStatus",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub queue_status: Option<definition_reference::QueueStatus>,
+    #[serde(rename = "queueStatus")]
+    pub queue_status: definition_reference::QueueStatus,
     #[doc = "The definition revision number."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub revision: Option<i32>,
+    pub revision: i32,
     #[doc = "The type of the definition."]
-    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
-    pub type_: Option<definition_reference::Type>,
+    #[serde(rename = "type")]
+    pub type_: definition_reference::Type,
     #[doc = "The definition's URI."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub uri: Option<String>,
+    pub uri: String,
     #[doc = "The REST URL of the definition."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl DefinitionReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        id: i32,
+        name: String,
+        path: String,
+        project: TeamProjectReference,
+        queue_status: definition_reference::QueueStatus,
+        revision: i32,
+        type_: definition_reference::Type,
+        uri: String,
+        url: String,
+    ) -> Self {
+        Self {
+            created_date: None,
+            id,
+            name,
+            path,
+            project,
+            queue_status,
+            revision,
+            type_,
+            uri,
+            url,
+        }
     }
 }
 pub mod definition_reference {
@@ -3283,32 +3388,36 @@ impl GatedCheckInTrigger {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -3319,8 +3428,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -3355,16 +3463,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = "Data representation of an information node associated with a build"]
@@ -3505,6 +3620,16 @@ pub struct JustInTimeProcess {
 impl JustInTimeProcess {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Link URL"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Link {
+    pub href: String,
+}
+impl Link {
+    pub fn new(href: String) -> Self {
+        Self { href }
     }
 }
 #[doc = "Represents an entry in a workspace mapping."]
@@ -3998,9 +4123,25 @@ impl RealtimeBuildEvent {
 #[doc = "The class to represent a collection of REST reference links."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReferenceLinks {
-    #[doc = "The readonly view of the links.  Because Reference links are readonly, we only want to expose them as read only."]
+    #[doc = "Link URL"]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub badge: Option<Link>,
+    #[doc = "Link URL"]
+    #[serde(rename = "self", default, skip_serializing_if = "Option::is_none")]
+    pub self_: Option<Link>,
+    #[doc = "Link URL"]
+    #[serde(
+        rename = "sourceVersionDisplayUri",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub source_version_display_uri: Option<Link>,
+    #[doc = "Link URL"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeline: Option<Link>,
+    #[doc = "Link URL"]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web: Option<Link>,
 }
 impl ReferenceLinks {
     pub fn new() -> Self {
@@ -4473,9 +4614,9 @@ impl SourceProviderAttributesList {
 #[doc = "Represents a work item related to some source item. These are retrieved from Source Providers."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct SourceRelatedWorkItem {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = ""]
     #[serde(
         rename = "assignedTo",
@@ -4740,21 +4881,23 @@ impl SvnWorkspace {
     }
 }
 #[doc = "Represents a reference to an agent pool."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TaskAgentPoolReference {
     #[doc = "The pool ID."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<i32>,
+    pub id: i32,
     #[doc = "A value indicating whether or not this pool is managed by the service."]
     #[serde(rename = "isHosted", default, skip_serializing_if = "Option::is_none")]
     pub is_hosted: Option<bool>,
     #[doc = "The pool name."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
 }
 impl TaskAgentPoolReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(id: i32, name: String) -> Self {
+        Self {
+            id,
+            is_hosted: None,
+            name,
+        }
     }
 }
 #[doc = "A reference to a task definition."]
@@ -4871,7 +5014,7 @@ impl TaskOrchestrationPlanGroupsStartedEvent {
     }
 }
 #[doc = "Represents a reference to an orchestration plan."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TaskOrchestrationPlanReference {
     #[doc = "The type of the plan."]
     #[serde(
@@ -4881,12 +5024,15 @@ pub struct TaskOrchestrationPlanReference {
     )]
     pub orchestration_type: Option<i32>,
     #[doc = "The ID of the plan."]
-    #[serde(rename = "planId", default, skip_serializing_if = "Option::is_none")]
-    pub plan_id: Option<String>,
+    #[serde(rename = "planId")]
+    pub plan_id: String,
 }
 impl TaskOrchestrationPlanReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(plan_id: String) -> Self {
+        Self {
+            orchestration_type: None,
+            plan_id,
+        }
     }
 }
 #[doc = "Represents a reference to a task."]
@@ -4931,7 +5077,7 @@ impl TaskSourceDefinitionBase {
     }
 }
 #[doc = "Represents a shallow reference to a TeamProject."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TeamProjectReference {
     #[doc = "Project abbreviation."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -4947,34 +5093,43 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Project last update time."]
-    #[serde(
-        rename = "lastUpdateTime",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub last_update_time: Option<String>,
+    #[serde(rename = "lastUpdateTime")]
+    pub last_update_time: String,
     #[doc = "Project name."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state: Option<team_project_reference::State>,
+    pub state: team_project_reference::State,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     #[doc = "Project visibility."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub visibility: Option<team_project_reference::Visibility>,
+    pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        id: String,
+        last_update_time: String,
+        name: String,
+        state: team_project_reference::State,
+        visibility: team_project_reference::Visibility,
+    ) -> Self {
+        Self {
+            abbreviation: None,
+            default_team_image_url: None,
+            description: None,
+            id,
+            last_update_time,
+            name,
+            revision: None,
+            state,
+            url: None,
+            visibility,
+        }
     }
 }
 pub mod team_project_reference {
@@ -5102,9 +5257,9 @@ impl TimelineAttempt {
 #[doc = "Represents an entry in a build's timeline."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TimelineRecord {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "Attempt number of record."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attempt: Option<i32>,
@@ -5620,13 +5775,13 @@ impl XamlBuildControllerReference {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct XamlBuildDefinition {
     #[serde(flatten)]
     pub definition_reference: DefinitionReference,
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "Batch size of the definition"]
     #[serde(rename = "batchSize", default, skip_serializing_if = "Option::is_none")]
     pub batch_size: Option<i32>,
@@ -5677,8 +5832,22 @@ pub struct XamlBuildDefinition {
     pub trigger_type: Option<xaml_build_definition::TriggerType>,
 }
 impl XamlBuildDefinition {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(definition_reference: DefinitionReference) -> Self {
+        Self {
+            definition_reference,
+            links: None,
+            batch_size: None,
+            build_args: None,
+            continuous_integration_quiet_period: None,
+            controller: None,
+            created_on: None,
+            default_drop_location: None,
+            description: None,
+            last_build: None,
+            repository: None,
+            supported_reasons: None,
+            trigger_type: None,
+        }
     }
 }
 pub mod xaml_build_definition {

--- a/azure_devops_rust_api/src/clt/models.rs
+++ b/azure_devops_rust_api/src/clt/models.rs
@@ -516,29 +516,33 @@ impl ErrorDetails {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
-    #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    #[doc = ""]
+    #[serde(rename = "_links")]
+    pub links: ReferenceLinks,
+    pub descriptor: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: ReferenceLinks,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -548,8 +552,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -578,16 +581,23 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub profile_url: Option<String>,
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = ""]

--- a/azure_devops_rust_api/src/core/models.rs
+++ b/azure_devops_rust_api/src/core/models.rs
@@ -7,28 +7,32 @@ use serde::de::{value, Deserializer, IntoDeserializer};
 use serde::{Deserialize, Serialize, Serializer};
 use std::str::FromStr;
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
@@ -155,7 +159,7 @@ impl IdentityDescriptor {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -166,8 +170,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -202,16 +205,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = "The JSON model for JSON Patch Operations"]
@@ -307,9 +317,9 @@ pub mod operation_reference {
 pub struct Process {
     #[serde(flatten)]
     pub process_reference: ProcessReference,
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -693,7 +703,7 @@ impl TeamMemberList {
     }
 }
 #[doc = "Represents a Team Project object."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TeamProject {
     #[serde(flatten)]
     pub team_project_reference: TeamProjectReference,
@@ -712,8 +722,13 @@ pub struct TeamProject {
     pub default_team: Option<WebApiTeamRef>,
 }
 impl TeamProject {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(team_project_reference: TeamProjectReference) -> Self {
+        Self {
+            team_project_reference,
+            links: None,
+            capabilities: None,
+            default_team: None,
+        }
     }
 }
 #[doc = "Data contract for a TeamProjectCollection."]
@@ -775,7 +790,7 @@ impl TeamProjectCollectionReference {
     }
 }
 #[doc = "Represents a shallow reference to a TeamProject."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TeamProjectReference {
     #[doc = "Project abbreviation."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -791,34 +806,43 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Project last update time."]
-    #[serde(
-        rename = "lastUpdateTime",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub last_update_time: Option<String>,
+    #[serde(rename = "lastUpdateTime")]
+    pub last_update_time: String,
     #[doc = "Project name."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state: Option<team_project_reference::State>,
+    pub state: team_project_reference::State,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     #[doc = "Project visibility."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub visibility: Option<team_project_reference::Visibility>,
+    pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        id: String,
+        last_update_time: String,
+        name: String,
+        state: team_project_reference::State,
+        visibility: team_project_reference::Visibility,
+    ) -> Self {
+        Self {
+            abbreviation: None,
+            default_team_image_url: None,
+            description: None,
+            id,
+            last_update_time,
+            name,
+            revision: None,
+            state,
+            url: None,
+            visibility,
+        }
     }
 }
 pub mod team_project_reference {
@@ -1044,7 +1068,7 @@ impl WebApiCreateTagRequestData {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct WebApiProject {
     #[serde(flatten)]
     pub team_project_reference: TeamProjectReference,
@@ -1063,8 +1087,13 @@ pub struct WebApiProject {
     pub default_team: Option<WebApiTeamRef>,
 }
 impl WebApiProject {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(team_project_reference: TeamProjectReference) -> Self {
+        Self {
+            team_project_reference,
+            capabilities: None,
+            collection: None,
+            default_team: None,
+        }
     }
 }
 #[doc = ""]

--- a/azure_devops_rust_api/src/dashboard/models.rs
+++ b/azure_devops_rust_api/src/dashboard/models.rs
@@ -80,9 +80,9 @@ impl CopyDashboardResponse {
 #[doc = "Model of a Dashboard."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct Dashboard {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "Entity to which the dashboard is scoped."]
     #[serde(
         rename = "dashboardScope",
@@ -145,9 +145,9 @@ pub mod dashboard {
 #[doc = "Describes a list of dashboards associated to an owner. Currently, teams own dashboard groups."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DashboardGroup {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "A list of Dashboards held by the Dashboard Group"]
     #[serde(
         rename = "dashboardEntries",
@@ -346,9 +346,9 @@ impl VssJsonCollectionWrapperBase {
 #[doc = "Widget data"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct Widget {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "Refers to the allowed sizes for the widget. This gets populated when user wants to configure the widget"]
     #[serde(
         rename = "allowedSizes",
@@ -669,9 +669,9 @@ impl WidgetSize {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct WidgetTypesResponse {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uri: Option<String>,
     #[serde(rename = "widgetTypes", default, skip_serializing_if = "Vec::is_empty")]

--- a/azure_devops_rust_api/src/distributed_task/models.rs
+++ b/azure_devops_rust_api/src/distributed_task/models.rs
@@ -1995,28 +1995,32 @@ impl ExpressionValidationItem {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
@@ -2033,7 +2037,7 @@ impl HelpLink {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -2044,8 +2048,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -2080,16 +2083,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = ""]
@@ -5096,9 +5106,9 @@ impl TaskAgentQueueList {
 #[doc = "A reference to an agent."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TaskAgentReference {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "This agent's access point."]
     #[serde(
         rename = "accessPoint",
@@ -5282,9 +5292,9 @@ impl TaskAssignedEvent {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TaskAttachment {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(rename = "createdOn", default, skip_serializing_if = "Option::is_none")]
     pub created_on: Option<String>,
     #[serde(
@@ -6376,9 +6386,9 @@ impl TaskOrchestrationJob {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TaskOrchestrationOwner {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/azure_devops_rust_api/src/extension_management/models.rs
+++ b/azure_devops_rust_api/src/extension_management/models.rs
@@ -1408,32 +1408,36 @@ pub mod extension_version {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -1444,8 +1448,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -1480,16 +1483,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = ""]

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -899,9 +899,9 @@ impl GitAnnotatedTag {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitAsyncRefOperation {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "Information about the progress of a cherry pick or revert operation."]
     #[serde(
         rename = "detailedStatus",
@@ -1109,9 +1109,9 @@ pub mod git_base_version_descriptor {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitBlobRef {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "SHA1 hash of git object"]
     #[serde(rename = "objectId", default, skip_serializing_if = "Option::is_none")]
     pub object_id: Option<String>,
@@ -1221,7 +1221,7 @@ impl GitCherryPick {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GitCommit {
     #[serde(flatten)]
     pub git_commit_ref: GitCommitRef,
@@ -1229,8 +1229,11 @@ pub struct GitCommit {
     pub tree_id: Option<String>,
 }
 impl GitCommit {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(git_commit_ref: GitCommitRef) -> Self {
+        Self {
+            git_commit_ref,
+            tree_id: None,
+        }
     }
 }
 #[doc = ""]
@@ -1305,7 +1308,7 @@ impl GitCommitDiffs {
     }
 }
 #[doc = "Provides properties that describe a Git commit and associated metadata."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GitCommitRef {
     #[doc = "Links"]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
@@ -1334,8 +1337,8 @@ pub struct GitCommitRef {
     )]
     pub comment_truncated: Option<bool>,
     #[doc = "ID (SHA-1) of the commit."]
-    #[serde(rename = "commitId", default, skip_serializing_if = "Option::is_none")]
-    pub commit_id: Option<String>,
+    #[serde(rename = "commitId")]
+    pub commit_id: String,
     #[doc = "User info and date for Git operations."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub committer: Option<GitUserDate>,
@@ -1359,8 +1362,23 @@ pub struct GitCommitRef {
     pub work_items: Vec<ResourceRef>,
 }
 impl GitCommitRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(commit_id: String) -> Self {
+        Self {
+            links: None,
+            author: None,
+            change_counts: None,
+            changes: Vec::new(),
+            comment: None,
+            comment_truncated: None,
+            commit_id,
+            committer: None,
+            parents: Vec::new(),
+            push: None,
+            remote_url: None,
+            statuses: Vec::new(),
+            url: None,
+            work_items: Vec::new(),
+        }
     }
 }
 #[doc = ""]
@@ -1395,9 +1413,9 @@ impl GitCommitToCreate {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitConflict {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(
         rename = "conflictId",
         default,
@@ -3557,9 +3575,9 @@ pub mod git_pull_request_query_input {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitPullRequestReviewFileContentInfo {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "The file change path."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
@@ -3734,9 +3752,9 @@ impl GitPushList {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitPushRef {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub date: Option<String>,
     #[doc = ""]
@@ -3979,9 +3997,9 @@ impl GitRecycleBinRepositoryDetails {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitRef {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = ""]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub creator: Option<IdentityRef>,
@@ -4017,9 +4035,9 @@ impl GitRef {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitRefFavorite {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,
     #[serde(
@@ -4230,9 +4248,9 @@ impl GitRefUpdateResultList {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GitRepository {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(
         rename = "defaultBranch",
         default,
@@ -4954,9 +4972,9 @@ pub mod git_tree_entry_ref {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitTreeRef {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "SHA1 hash of git object"]
     #[serde(rename = "objectId", default, skip_serializing_if = "Option::is_none")]
     pub object_id: Option<String>,
@@ -5072,28 +5090,32 @@ impl GlobalGitRepositoryKey {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
@@ -5218,9 +5240,9 @@ pub struct IdentityRef {
     pub unique_name: Option<String>,
 }
 impl IdentityRef {
-    pub fn new(id: String) -> Self {
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String) -> Self {
         Self {
-            graph_subject_base: GraphSubjectBase::default(),
+            graph_subject_base,
             directory_alias: None,
             id,
             image_url: None,
@@ -5439,9 +5461,9 @@ pub mod item_details_options {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ItemModel {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[doc = ""]

--- a/azure_devops_rust_api/src/graph/models.rs
+++ b/azure_devops_rust_api/src/graph/models.rs
@@ -120,7 +120,7 @@ impl GraphGlobalExtendedPropertyBatch {
     }
 }
 #[doc = "Graph group entity"]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphGroup {
     #[serde(flatten)]
     pub graph_member: GraphMember,
@@ -129,8 +129,11 @@ pub struct GraphGroup {
     pub description: Option<String>,
 }
 impl GraphGroup {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_member: GraphMember) -> Self {
+        Self {
+            graph_member,
+            description: None,
+        }
     }
 }
 #[doc = "Do not attempt to use this type to create a new group. This type does not contain sufficient fields to create a new group."]
@@ -239,7 +242,7 @@ impl GraphGroupVstsCreationContext {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphMember {
     #[serde(flatten)]
     pub graph_subject: GraphSubject,
@@ -262,8 +265,13 @@ pub struct GraphMember {
     pub principal_name: Option<String>,
 }
 impl GraphMember {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject: GraphSubject) -> Self {
+        Self {
+            graph_subject,
+            domain: None,
+            mail_address: None,
+            principal_name: None,
+        }
     }
 }
 #[doc = "Relationship between a container and a member"]
@@ -384,7 +392,7 @@ impl GraphProviderInfo {
     }
 }
 #[doc = "Container where a graph entity is defined (organization, project, team)"]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphScope {
     #[serde(flatten)]
     pub graph_subject: GraphSubject,
@@ -417,8 +425,15 @@ pub struct GraphScope {
     pub securing_host_descriptor: Option<String>,
 }
 impl GraphScope {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject: GraphSubject) -> Self {
+        Self {
+            graph_subject,
+            administrator_descriptor: None,
+            is_global: None,
+            parent_descriptor: None,
+            scope_type: None,
+            securing_host_descriptor: None,
+        }
     }
 }
 pub mod graph_scope {
@@ -501,7 +516,7 @@ impl GraphStorageKeyResult {
     }
 }
 #[doc = "Top-level graph entity"]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubject {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -527,33 +542,43 @@ pub struct GraphSubject {
     pub subject_kind: Option<String>,
 }
 impl GraphSubject {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase) -> Self {
+        Self {
+            graph_subject_base,
+            legacy_descriptor: None,
+            origin: None,
+            origin_id: None,
+            subject_kind: None,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
@@ -614,18 +639,18 @@ impl GraphSubjectQuery {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSystemSubject {
     #[serde(flatten)]
     pub graph_subject: GraphSubject,
 }
 impl GraphSystemSubject {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject: GraphSubject) -> Self {
+        Self { graph_subject }
     }
 }
 #[doc = "Graph user entity"]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphUser {
     #[serde(flatten)]
     pub graph_member: GraphMember,
@@ -648,8 +673,13 @@ pub struct GraphUser {
     pub meta_type: Option<String>,
 }
 impl GraphUser {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_member: GraphMember) -> Self {
+        Self {
+            graph_member,
+            directory_alias: None,
+            is_deleted_in_origin: None,
+            meta_type: None,
+        }
     }
 }
 #[doc = "Do not attempt to use this type to create a new user. Use one of the subclasses instead. This type does not contain sufficient fields to create a new user."]

--- a/azure_devops_rust_api/src/hooks/models.rs
+++ b/azure_devops_rust_api/src/hooks/models.rs
@@ -329,32 +329,36 @@ impl FormattedEventMessage {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -365,8 +369,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -401,16 +404,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = "Describes an input for subscriptions."]

--- a/azure_devops_rust_api/src/member_entitlement_management/models.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/models.rs
@@ -290,7 +290,7 @@ pub mod extension_summary_data {
     }
 }
 #[doc = "Graph group entity"]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphGroup {
     #[serde(flatten)]
     pub graph_member: GraphMember,
@@ -299,12 +299,15 @@ pub struct GraphGroup {
     pub description: Option<String>,
 }
 impl GraphGroup {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_member: GraphMember) -> Self {
+        Self {
+            graph_member,
+            description: None,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphMember {
     #[serde(flatten)]
     pub graph_subject: GraphSubject,
@@ -327,12 +330,17 @@ pub struct GraphMember {
     pub principal_name: Option<String>,
 }
 impl GraphMember {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject: GraphSubject) -> Self {
+        Self {
+            graph_subject,
+            domain: None,
+            mail_address: None,
+            principal_name: None,
+        }
     }
 }
 #[doc = "Top-level graph entity"]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubject {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -358,37 +366,47 @@ pub struct GraphSubject {
     pub subject_kind: Option<String>,
 }
 impl GraphSubject {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase) -> Self {
+        Self {
+            graph_subject_base,
+            legacy_descriptor: None,
+            origin: None,
+            origin_id: None,
+            subject_kind: None,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = "Graph user entity"]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphUser {
     #[serde(flatten)]
     pub graph_member: GraphMember,
@@ -411,8 +429,13 @@ pub struct GraphUser {
     pub meta_type: Option<String>,
 }
 impl GraphUser {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_member: GraphMember) -> Self {
+        Self {
+            graph_member,
+            directory_alias: None,
+            is_deleted_in_origin: None,
+            meta_type: None,
+        }
     }
 }
 #[doc = "Project Group (e.g. Contributor, Reader etc.)"]

--- a/azure_devops_rust_api/src/pipelines/models.rs
+++ b/azure_devops_rust_api/src/pipelines/models.rs
@@ -177,9 +177,9 @@ impl PackageResourceParameters {
 #[doc = "Definition of a pipeline."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Pipeline {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links")]
-    pub links: serde_json::Value,
+    pub links: ReferenceLinks,
     #[doc = ""]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub configuration: Option<PipelineConfiguration>,
@@ -196,7 +196,7 @@ pub struct Pipeline {
 }
 impl Pipeline {
     pub fn new(
-        links: serde_json::Value,
+        links: ReferenceLinks,
         url: String,
         folder: String,
         id: i32,
@@ -417,9 +417,9 @@ impl RepositoryResourceParameters {
 pub struct Run {
     #[serde(flatten)]
     pub run_reference: RunReference,
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links")]
-    pub links: serde_json::Value,
+    pub links: ReferenceLinks,
     #[serde(rename = "createdDate")]
     pub created_date: String,
     #[serde(rename = "finalYaml", default, skip_serializing_if = "Option::is_none")]
@@ -440,7 +440,7 @@ pub struct Run {
 impl Run {
     pub fn new(
         run_reference: RunReference,
-        links: serde_json::Value,
+        links: ReferenceLinks,
         created_date: String,
         finished_date: String,
         pipeline: PipelineReference,

--- a/azure_devops_rust_api/src/policy/models.rs
+++ b/azure_devops_rust_api/src/policy/models.rs
@@ -7,32 +7,36 @@ use serde::de::{value, Deserializer, IntoDeserializer};
 use serde::{Deserialize, Serialize, Serializer};
 use std::str::FromStr;
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -43,8 +47,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -79,16 +82,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = "Represents a JSON object."]

--- a/azure_devops_rust_api/src/release/models.rs
+++ b/azure_devops_rust_api/src/release/models.rs
@@ -2656,32 +2656,36 @@ impl GitHubArtifactDownloadInput {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -2692,8 +2696,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -2728,16 +2731,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = ""]

--- a/azure_devops_rust_api/src/service_endpoint/models.rs
+++ b/azure_devops_rust_api/src/service_endpoint/models.rs
@@ -1517,9 +1517,9 @@ pub mod service_endpoint_execution_data {
 #[doc = "Represents execution owner of the service endpoint."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ServiceEndpointExecutionOwner {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[doc = "Gets or sets the Id of service endpoint execution owner."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<i32>,

--- a/azure_devops_rust_api/src/test/models.rs
+++ b/azure_devops_rust_api/src/test/models.rs
@@ -1822,28 +1822,32 @@ impl FunctionCoverage2 {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
@@ -1876,7 +1880,7 @@ impl HttpPostedTcmAttachment {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -1887,8 +1891,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -1923,16 +1926,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = "Job in pipeline. This is related to matrixing in YAML."]
@@ -5285,7 +5295,7 @@ impl TeamContext {
     }
 }
 #[doc = "Represents a shallow reference to a TeamProject."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TeamProjectReference {
     #[doc = "Project abbreviation."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5301,34 +5311,43 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Project last update time."]
-    #[serde(
-        rename = "lastUpdateTime",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub last_update_time: Option<String>,
+    #[serde(rename = "lastUpdateTime")]
+    pub last_update_time: String,
     #[doc = "Project name."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state: Option<team_project_reference::State>,
+    pub state: team_project_reference::State,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     #[doc = "Project visibility."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub visibility: Option<team_project_reference::Visibility>,
+    pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        id: String,
+        last_update_time: String,
+        name: String,
+        state: team_project_reference::State,
+        visibility: team_project_reference::Visibility,
+    ) -> Self {
+        Self {
+            abbreviation: None,
+            default_team_image_url: None,
+            description: None,
+            id,
+            last_update_time,
+            name,
+            revision: None,
+            state,
+            url: None,
+            visibility,
+        }
     }
 }
 pub mod team_project_reference {

--- a/azure_devops_rust_api/src/test_plan/models.rs
+++ b/azure_devops_rust_api/src/test_plan/models.rs
@@ -474,32 +474,36 @@ impl DestinationTestSuiteInfo {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -510,8 +514,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -546,16 +549,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = "Last result details of test point."]
@@ -986,7 +996,7 @@ impl SuiteTestCaseCreateUpdateParameters {
     }
 }
 #[doc = "Represents a shallow reference to a TeamProject."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TeamProjectReference {
     #[doc = "Project abbreviation."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1002,34 +1012,43 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Project last update time."]
-    #[serde(
-        rename = "lastUpdateTime",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub last_update_time: Option<String>,
+    #[serde(rename = "lastUpdateTime")]
+    pub last_update_time: String,
     #[doc = "Project name."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state: Option<team_project_reference::State>,
+    pub state: team_project_reference::State,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     #[doc = "Project visibility."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub visibility: Option<team_project_reference::Visibility>,
+    pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        id: String,
+        last_update_time: String,
+        name: String,
+        state: team_project_reference::State,
+        visibility: team_project_reference::Visibility,
+    ) -> Self {
+        Self {
+            abbreviation: None,
+            default_team_image_url: None,
+            description: None,
+            id,
+            last_update_time,
+            name,
+            revision: None,
+            state,
+            url: None,
+            visibility,
+        }
     }
 }
 pub mod team_project_reference {

--- a/azure_devops_rust_api/src/test_results/models.rs
+++ b/azure_devops_rust_api/src/test_results/models.rs
@@ -893,29 +893,33 @@ impl FunctionCoverage {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
-    #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    #[doc = ""]
+    #[serde(rename = "_links")]
+    pub links: ReferenceLinks,
+    pub descriptor: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: ReferenceLinks,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -925,8 +929,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -955,16 +958,23 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub profile_url: Option<String>,
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = "Job in pipeline. This is related to matrixing in YAML."]
@@ -2015,7 +2025,7 @@ impl StageReference {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub abbreviation: Option<String>,
@@ -2027,28 +2037,37 @@ pub struct TeamProjectReference {
     pub default_team_image_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    #[serde(
-        rename = "lastUpdateTime",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub last_update_time: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub id: String,
+    #[serde(rename = "lastUpdateTime")]
+    pub last_update_time: String,
+    pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state: Option<team_project_reference::State>,
+    pub state: team_project_reference::State,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub visibility: Option<team_project_reference::Visibility>,
+    pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        id: String,
+        last_update_time: String,
+        name: String,
+        state: team_project_reference::State,
+        visibility: team_project_reference::Visibility,
+    ) -> Self {
+        Self {
+            abbreviation: None,
+            default_team_image_url: None,
+            description: None,
+            id,
+            last_update_time,
+            name,
+            revision: None,
+            state,
+            url: None,
+            visibility,
+        }
     }
 }
 pub mod team_project_reference {

--- a/azure_devops_rust_api/src/tfvc/models.rs
+++ b/azure_devops_rust_api/src/tfvc/models.rs
@@ -168,9 +168,9 @@ impl FileContentMetadata {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitRepository {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(
         rename = "defaultBranch",
         default,
@@ -253,32 +253,36 @@ impl GitRepositoryRef {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -289,8 +293,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -325,16 +328,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = ""]
@@ -367,9 +377,9 @@ pub mod item_content {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ItemModel {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[doc = ""]
@@ -424,7 +434,7 @@ impl TeamProjectCollectionReference {
     }
 }
 #[doc = "Represents a shallow reference to a TeamProject."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TeamProjectReference {
     #[doc = "Project abbreviation."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -440,34 +450,43 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Project last update time."]
-    #[serde(
-        rename = "lastUpdateTime",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub last_update_time: Option<String>,
+    #[serde(rename = "lastUpdateTime")]
+    pub last_update_time: String,
     #[doc = "Project name."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state: Option<team_project_reference::State>,
+    pub state: team_project_reference::State,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     #[doc = "Project visibility."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub visibility: Option<team_project_reference::Visibility>,
+    pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        id: String,
+        last_update_time: String,
+        name: String,
+        state: team_project_reference::State,
+        visibility: team_project_reference::Visibility,
+    ) -> Self {
+        Self {
+            abbreviation: None,
+            default_team_image_url: None,
+            description: None,
+            id,
+            last_update_time,
+            name,
+            revision: None,
+            state,
+            url: None,
+            visibility,
+        }
     }
 }
 pub mod team_project_reference {

--- a/azure_devops_rust_api/src/wiki/models.rs
+++ b/azure_devops_rust_api/src/wiki/models.rs
@@ -299,9 +299,9 @@ pub mod comment_update_parameters {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitRepository {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(
         rename = "defaultBranch",
         default,
@@ -433,32 +433,36 @@ pub mod git_version_descriptor {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -469,8 +473,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -505,16 +508,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = "The class to represent a collection of REST reference links."]
@@ -545,7 +555,7 @@ impl TeamProjectCollectionReference {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub abbreviation: Option<String>,
@@ -557,28 +567,37 @@ pub struct TeamProjectReference {
     pub default_team_image_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    #[serde(
-        rename = "lastUpdateTime",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub last_update_time: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub id: String,
+    #[serde(rename = "lastUpdateTime")]
+    pub last_update_time: String,
+    pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub state: Option<team_project_reference::State>,
+    pub state: team_project_reference::State,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub visibility: Option<team_project_reference::Visibility>,
+    pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        id: String,
+        last_update_time: String,
+        name: String,
+        state: team_project_reference::State,
+        visibility: team_project_reference::Visibility,
+    ) -> Self {
+        Self {
+            abbreviation: None,
+            default_team_image_url: None,
+            description: None,
+            id,
+            last_update_time,
+            name,
+            revision: None,
+            state,
+            url: None,
+            visibility,
+        }
     }
 }
 pub mod team_project_reference {

--- a/azure_devops_rust_api/src/wit/models.rs
+++ b/azure_devops_rust_api/src/wit/models.rs
@@ -726,32 +726,36 @@ impl FieldDependentRule {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -762,8 +766,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -798,16 +801,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = ""]
@@ -824,7 +834,7 @@ impl IdentityRefList {
     }
 }
 #[doc = "Describes a reference to an identity."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityReference {
     #[serde(flatten)]
     pub identity_ref: IdentityRef,
@@ -835,8 +845,12 @@ pub struct IdentityReference {
     pub name: Option<String>,
 }
 impl IdentityReference {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(identity_ref: IdentityRef) -> Self {
+        Self {
+            identity_ref,
+            id: None,
+            name: None,
+        }
     }
 }
 #[doc = "The JSON model for JSON Patch Operations"]

--- a/azure_devops_rust_api/src/work/models.rs
+++ b/azure_devops_rust_api/src/work/models.rs
@@ -279,9 +279,9 @@ impl BacklogLevelWorkItems {
 pub struct Board {
     #[serde(flatten)]
     pub board_reference: BoardReference,
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(
         rename = "allowedMappings",
         default,
@@ -325,9 +325,9 @@ impl BoardBadge {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BoardCardRuleSettings {
-    #[doc = "Links"]
+    #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    pub links: Option<ReferenceLinks>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rules: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -982,28 +982,32 @@ impl FilterGroup {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
-    #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
-    pub links: Option<serde_json::Value>,
+    #[serde(rename = "_links")]
+    pub links: serde_json::Value,
     #[doc = "The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<String>,
+    pub descriptor: String,
     #[doc = "This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider."]
-    #[serde(
-        rename = "displayName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub display_name: Option<String>,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
     #[doc = "This url is the full route to the source resource of this graph subject."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 }
 impl GraphSubjectBase {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(
+        links: serde_json::Value,
+        descriptor: String,
+        display_name: String,
+        url: String,
+    ) -> Self {
+        Self {
+            links,
+            descriptor,
+            display_name,
+            url,
+        }
     }
 }
 #[doc = ""]
@@ -1024,7 +1028,7 @@ impl ITaskboardColumnMapping {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdentityRef {
     #[serde(flatten)]
     pub graph_subject_base: GraphSubjectBase,
@@ -1035,8 +1039,7 @@ pub struct IdentityRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub directory_alias: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
     #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
@@ -1071,16 +1074,23 @@ pub struct IdentityRef {
     )]
     pub profile_url: Option<String>,
     #[doc = "Deprecated - use Domain+PrincipalName instead"]
-    #[serde(
-        rename = "uniqueName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub unique_name: Option<String>,
+    #[serde(rename = "uniqueName")]
+    pub unique_name: String,
 }
 impl IdentityRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(graph_subject_base: GraphSubjectBase, id: String, unique_name: String) -> Self {
+        Self {
+            graph_subject_base,
+            directory_alias: None,
+            id,
+            image_url: None,
+            inactive: None,
+            is_aad_identity: None,
+            is_container: None,
+            is_deleted_in_origin: None,
+            profile_url: None,
+            unique_name,
+        }
     }
 }
 #[doc = "Capacity and teams for all teams in an iteration"]

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -383,7 +383,7 @@ impl Patcher {
     }
 
     fn patch_build_reference_links(&mut self, key: &[&str], _value: &JsonValue) -> Option<JsonValue> {
-        // Only applies to git specs
+        // Only applies to build specs
         if !self.spec_path.ends_with("build.json") {
             return None;
         }


### PR DESCRIPTION
Improves https://github.com/microsoft/azure-devops-rust-api/issues/6

- Updated the `vsts-api-patcher` to flag more fields as `required`.  This removes the `Option` wrappers from the generated structs, making the values easier to use.
  - The changes are mainly focussed on the `build` structs.  I'll look at other areas when I use them or if requested (it is quite a slow process to make and test the changes).