### PR TITLE
git struct cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated some struct fields to remove Option wrappers to make the values easier to use.
 - Updated some `links` fields to have a struct with known fields, rather than a Json `Value`.
 
+### Added
+- `pipeline_preview` example
+
 ## [0.3.1]
 
 ### Added

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -88,6 +88,10 @@ name = "pipelines"
 required-features = ["pipelines"]
 
 [[example]]
+name = "pipeline_preview"
+required-features = ["pipelines"]
+
+[[example]]
 name = "service_endpoint"
 required-features = ["service_endpoint"]
 

--- a/azure_devops_rust_api/examples/git_repo_get.rs
+++ b/azure_devops_rust_api/examples/git_repo_get.rs
@@ -73,9 +73,7 @@ async fn main() -> Result<()> {
 
     println!("\nGot {} refs", git_refs.len());
     for git_ref in &git_refs {
-        if let Some(object_id) = &git_ref.object_id {
-            println!("{:<50}{}", git_ref.name, object_id);
-        }
+        println!("{:<50}{}", git_ref.name, git_ref.object_id);
     }
 
     if let Some(git_ref) = git_refs.iter().next() {

--- a/azure_devops_rust_api/examples/git_repo_get.rs
+++ b/azure_devops_rust_api/examples/git_repo_get.rs
@@ -43,18 +43,44 @@ async fn main() -> Result<()> {
         .await?;
     println!("{:#?}", repo);
 
-    // Use the client to get all pull requests on the specified repo
+    // Use the client to get up to 10 pull requests on the specified repo
     let prs = client
         .pull_requests()
         .get_pull_requests(&organization, &repo.id, &project)
+        .top(10)
         .into_future()
         .await?
         .value;
 
-    println!("Found {} pull requests", prs.len());
+    println!("\nFound {} pull requests", prs.len());
+    for pr in &prs {
+        println!("{:<8}{}", pr.pull_request_id, pr.title.as_ref().unwrap());
+    }
+
     if let Some(pr) = prs.iter().next() {
-        println!("Example PR struct:");
+        println!("\nExample PR struct:");
         println!("{:#?}", pr);
+    }
+
+    // Use the client to get up to 10 refs on the specified repo
+    let git_refs = client
+        .refs()
+        .list(&organization, &repo.id, &project)
+        .top(10)
+        .into_future()
+        .await?
+        .value;
+
+    println!("\nGot {} refs", git_refs.len());
+    for git_ref in &git_refs {
+        if let Some(object_id) = &git_ref.object_id {
+            println!("{:<50}{}", git_ref.name, object_id);
+        }
+    }
+
+    if let Some(git_ref) = git_refs.iter().next() {
+        println!("\nExample ref struct:");
+        println!("{:#?}", git_ref);
     }
 
     Ok(())

--- a/azure_devops_rust_api/examples/pipeline_preview.rs
+++ b/azure_devops_rust_api/examples/pipeline_preview.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// pipelines.rs
-// Pipelines example.
+// pipeline_preview.rs
+// Pipeline preview example.
 use anyhow::Result;
 use azure_devops_rust_api::pipelines;
-use azure_devops_rust_api::pipelines::models::Pipeline;
+use azure_devops_rust_api::pipelines::models::{Pipeline, RunPipelineParameters};
 use azure_devops_rust_api::Credential;
 use std::env;
 use std::sync::Arc;
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
         env::var("ADO_SERVICE_ENDPOINT").expect("Must define ADO_SERVICE_ENDPOINT");
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
     let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
-    let pipeline_name = env::args().nth(1).expect("Usage: pipelines <name>");
+    let pipeline_name = env::args().nth(1).expect("Usage: pipeline_preview <name>");
 
     // Create a `pipelines` client
     let client = pipelines::operations::Client::new(service_endpoint, credential, vec![]);
@@ -51,42 +51,30 @@ async fn main() -> Result<()> {
         .cloned()
         .collect();
 
-    for pipeline in matched_pipelines.iter() {
-        println!("{:4} {}", pipeline.id, pipeline.name);
-    }
-
     if let Some(pipeline) = matched_pipelines.iter().next() {
-        println!("\nExample pipeline struct from list:");
-        println!("{:#?}", pipeline);
+        // Demonstrate how to query a preview of pipeline YAML...
+        // Define the pipeline params
+        let run_pipeline_params = RunPipelineParameters {
+            preview_run: Some(true),
+            resources: None,
+            stages_to_skip: vec![],
+            template_parameters: None,
+            variables: None,
+            yaml_override: None,
+        };
 
-        // The pipeline struct returned from list is different from that returned by get.
-        // Query and display the struct returned by get for comparison.
-        let pipeline = client
-            .pipelines()
-            .get(&organization, &project, pipeline.id)
+        // Create a preview client
+        let preview_client = client.preview();
+
+        // Request a preview of the specified pipeline
+        let preview = preview_client
+            .preview(&organization, run_pipeline_params, &project, pipeline.id)
             .into_future()
             .await?;
-        println!("\nExample pipeline struct from get:");
-        println!("{:#?}", pipeline);
 
-        // Use the client to list all runs of the selected pipeline
-        let runs = client
-            .runs()
-            .list(&organization, &project, pipeline.id)
-            .into_future()
-            .await?
-            .value;
-
-        println!("\nPipeline runs: {}", runs.len());
-        // Display [result, state] for each pipeline run
-        for run in runs.iter() {
-            println!(
-                "{:8} {:16} {:14} {:14}",
-                run.run_reference.id,
-                run.run_reference.name,
-                format!("{:?}", run.result),
-                format!("{:?}", run.state)
-            );
+        // Display the full pipeline YAML
+        if let Some(final_yaml) = preview.final_yaml {
+            println!("Pipeline preview:\n{}", final_yaml);
         }
     }
 

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -1361,7 +1361,7 @@ pub struct GitCommitRef {
     pub work_items: Vec<ResourceRef>,
 }
 impl GitCommitRef {
-    pub fn new(commit_id: String) -> Self {
+    pub fn new(commit_id: String, url: String) -> Self {
         Self {
             links: None,
             author: None,
@@ -1369,13 +1369,13 @@ impl GitCommitRef {
             changes: Vec::new(),
             comment: None,
             comment_truncated: None,
-            commit_id: None,
+            commit_id,
             committer: None,
             parents: Vec::new(),
             push: None,
             remote_url: None,
             statuses: Vec::new(),
-            url: None,
+            url,
             work_items: Vec::new(),
         }
     }
@@ -3051,12 +3051,8 @@ pub struct GitPullRequest {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub reviewers: Vec<IdentityRefWithVote>,
     #[doc = "The name of the source branch of the pull request."]
-    #[serde(
-        rename = "sourceRefName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub source_ref_name: Option<String>,
+    #[serde(rename = "sourceRefName")]
+    pub source_ref_name: String,
     #[doc = "The status of the pull request."]
     pub status: git_pull_request::Status,
     #[doc = "If true, this pull request supports multiple iterations. Iteration support means individual pushes to the source branch of the pull request can be reviewed and comments left in one iteration will be tracked across future iterations."]
@@ -3067,12 +3063,8 @@ pub struct GitPullRequest {
     )]
     pub supports_iterations: Option<bool>,
     #[doc = "The name of the target branch of the pull request."]
-    #[serde(
-        rename = "targetRefName",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub target_ref_name: Option<String>,
+    #[serde(rename = "targetRefName")]
+    pub target_ref_name: String,
     #[doc = "The title of the pull request."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
@@ -3093,7 +3085,9 @@ impl GitPullRequest {
         is_draft: bool,
         pull_request_id: i32,
         repository: GitRepository,
+        source_ref_name: String,
         status: git_pull_request::Status,
+        target_ref_name: String,
         url: String,
     ) -> Self {
         Self {
@@ -3125,10 +3119,10 @@ impl GitPullRequest {
             remote_url: None,
             repository,
             reviewers: Vec::new(),
-            source_ref_name: None,
+            source_ref_name,
             status,
             supports_iterations: None,
-            target_ref_name: None,
+            target_ref_name,
             title: None,
             url,
             work_item_refs: Vec::new(),
@@ -4015,8 +4009,8 @@ pub struct GitRef {
     )]
     pub is_locked_by: Option<IdentityRef>,
     pub name: String,
-    #[serde(rename = "objectId", default, skip_serializing_if = "Option::is_none")]
-    pub object_id: Option<String>,
+    #[serde(rename = "objectId")]
+    pub object_id: String,
     #[serde(
         rename = "peeledObjectId",
         default,
@@ -4029,14 +4023,14 @@ pub struct GitRef {
     pub url: Option<String>,
 }
 impl GitRef {
-    pub fn new(name: String) -> Self {
+    pub fn new(name: String, object_id: String) -> Self {
         Self {
             links: None,
             creator: None,
             is_locked: None,
             is_locked_by: None,
             name,
-            object_id: None,
+            object_id,
             peeled_object_id: None,
             statuses: Vec::new(),
             url: None,

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -1355,8 +1355,7 @@ pub struct GitCommitRef {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub statuses: Vec<GitStatus>,
     #[doc = "REST URL for this resource."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
     #[doc = "A list of workitems associated with this commit."]
     #[serde(rename = "workItems", default, skip_serializing_if = "Vec::is_empty")]
     pub work_items: Vec<ResourceRef>,
@@ -1370,7 +1369,7 @@ impl GitCommitRef {
             changes: Vec::new(),
             comment: None,
             comment_truncated: None,
-            commit_id,
+            commit_id: None,
             committer: None,
             parents: Vec::new(),
             push: None,
@@ -2128,7 +2127,7 @@ impl GitForkOperationStatusDetail {
     }
 }
 #[doc = "Information about a fork ref."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GitForkRef {
     #[serde(flatten)]
     pub git_ref: GitRef,
@@ -2137,8 +2136,11 @@ pub struct GitForkRef {
     pub repository: Option<GitRepository>,
 }
 impl GitForkRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(git_ref: GitRef) -> Self {
+        Self {
+            git_ref,
+            repository: None,
+        }
     }
 }
 #[doc = "Request to sync data between two forks."]
@@ -3995,7 +3997,7 @@ impl GitRecycleBinRepositoryDetails {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GitRef {
     #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
@@ -4012,8 +4014,7 @@ pub struct GitRef {
         skip_serializing_if = "Option::is_none"
     )]
     pub is_locked_by: Option<IdentityRef>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
     #[serde(rename = "objectId", default, skip_serializing_if = "Option::is_none")]
     pub object_id: Option<String>,
     #[serde(
@@ -4028,8 +4029,18 @@ pub struct GitRef {
     pub url: Option<String>,
 }
 impl GitRef {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(name: String) -> Self {
+        Self {
+            links: None,
+            creator: None,
+            is_locked: None,
+            is_locked_by: None,
+            name,
+            object_id: None,
+            peeled_object_id: None,
+            statuses: Vec::new(),
+            url: None,
+        }
     }
 }
 #[doc = ""]

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -557,8 +557,8 @@ impl Patcher {
                     "pullRequestId",
                     "repository",
                     "status",
-                    "source_ref_name",
-                    "target_ref_name",
+                    "sourceRefName",
+                    "targetRefName",
                     "url"
                 ]"#,
             ),
@@ -567,14 +567,14 @@ impl Patcher {
                 "GitRef",
                 r#"[
                     "name",
-                    "object_id"
+                    "objectId"
                 ]"#,
             ),
             (
                 "git.json",
                 "GitCommitRef",
                 r#"[
-                    "commit_id",
+                    "commitId",
                     "url"
                 ]"#,
             ),

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -564,6 +564,22 @@ impl Patcher {
             ),
             (
                 "git.json",
+                "GitRef",
+                r#"[
+                    "name",
+                    "object_id"
+                ]"#,
+            ),
+            (
+                "git.json",
+                "GitCommitRef",
+                r#"[
+                    "commit_id",
+                    "url"
+                ]"#,
+            ),
+            (
+                "git.json",
                 "IdentityRef",
                 r#"[
                     "id"


### PR DESCRIPTION
- Fixed up a few `git` struct fields to remove `Option` wrappers
- Added `pipeline_preview` example
- Improved `git_repo_get` example