### PR TITLE
Added custom date-time serde implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Implement custom date-time serde module to gracefully handle `0001-01-01T00:00:00`
+
 ## [0.5.1]
 
 ## Breaking changes

--- a/autorust/codegen/src/codegen_models.rs
+++ b/autorust/codegen/src/codegen_models.rs
@@ -635,13 +635,13 @@ fn create_struct(cg: &CodeGen, schema: &SchemaGen, struct_name: &str, pageable: 
         #[allow(clippy::collapsible_else_if)]
         if is_required {
             if type_name.is_date_time() {
-                serde_attrs.push(quote! { with = "azure_core::date::rfc3339"});
+                serde_attrs.push(quote! { with = "crate::date_time::rfc3339"});
             } else if type_name.is_date_time_rfc1123() {
                 serde_attrs.push(quote! { with = "azure_core::date::rfc1123"});
             }
         } else {
             if type_name.is_date_time() {
-                serde_attrs.push(quote! { default, with = "azure_core::date::rfc3339::option"});
+                serde_attrs.push(quote! { default, with = "crate::date_time::rfc3339::option"});
             } else if type_name.is_date_time_rfc1123() {
                 serde_attrs.push(quote! { default, with = "azure_core::date::rfc1123::option"});
             } else if type_name.is_vec() {

--- a/azure_devops_rust_api/examples/client_pipeline_policy.rs
+++ b/azure_devops_rust_api/examples/client_pipeline_policy.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use azure_core::{Context, Policy, PolicyResult, Request};
+use env_logger::Env;
 use log::info;
 
 /// Basic request logger policy
@@ -48,8 +49,8 @@ impl azure_core::Policy for RequestLogger {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Initialize logging
-    env_logger::init();
+    // Initialize logging - set default log level to info
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
     let credential = match env::var("ADO_TOKEN") {
@@ -70,8 +71,9 @@ async fn main() -> Result<()> {
     let request_logger_policy = Arc::new(RequestLogger::new()) as Arc<dyn Policy>;
 
     // Create a git client with our custom policy
-    let git_client =
-        git::ClientBuilder::new(credential).per_call_policies(vec![request_logger_policy]).build();
+    let git_client = git::ClientBuilder::new(credential)
+        .per_call_policies(vec![request_logger_policy])
+        .build();
 
     // Get all repositories in the specified organization/project
     let _repos = git_client

--- a/azure_devops_rust_api/src/accounts/models.rs
+++ b/azure_devops_rust_api/src/accounts/models.rs
@@ -53,7 +53,7 @@ pub struct Account {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[serde(rename = "hasMoved", default, skip_serializing_if = "Option::is_none")]
@@ -69,7 +69,7 @@ pub struct Account {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Namespace for an account"]

--- a/azure_devops_rust_api/src/artifacts/models.rs
+++ b/azure_devops_rust_api/src/artifacts/models.rs
@@ -74,7 +74,7 @@ pub struct Feed {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "A description for the feed.  Descriptions must not exceed 255 characters."]
@@ -91,7 +91,7 @@ pub struct Feed {
     #[serde(
         rename = "permanentDeletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub permanent_deleted_date: Option<time::OffsetDateTime>,
     #[doc = "Explicit permissions for the feed."]
@@ -101,14 +101,14 @@ pub struct Feed {
     #[serde(
         rename = "scheduledPermanentDeleteDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_permanent_delete_date: Option<time::OffsetDateTime>,
     #[doc = "If set, time that the UpstreamEnabled property was changed. Will be null if UpstreamEnabled was never changed after Feed creation."]
     #[serde(
         rename = "upstreamEnabledChangedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub upstream_enabled_changed_date: Option<time::OffsetDateTime>,
     #[doc = "The URL of the base feed in GUID form."]
@@ -709,7 +709,7 @@ pub struct MinimalPackageVersion {
     #[serde(
         rename = "publishDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub publish_date: Option<time::OffsetDateTime>,
     #[doc = "Internal storage id."]
@@ -941,7 +941,7 @@ pub struct PackageMetrics {
     #[serde(
         rename = "lastDownloaded",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_downloaded: Option<time::OffsetDateTime>,
     #[doc = "Package id."]
@@ -993,7 +993,7 @@ pub struct PackageVersion {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "List of dependencies for this package version."]
@@ -1114,7 +1114,7 @@ pub struct PackageVersionMetrics {
     #[serde(
         rename = "lastDownloaded",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_downloaded: Option<time::OffsetDateTime>,
     #[doc = "Package id."]
@@ -1262,7 +1262,7 @@ pub struct RecycleBinPackageVersion {
     #[serde(
         rename = "scheduledPermanentDeleteDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_permanent_delete_date: Option<time::OffsetDateTime>,
 }
@@ -1363,7 +1363,7 @@ pub struct UpstreamSource {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "Locator for connecting to the upstream source in a user friendly format, that may potentially change over time"]

--- a/azure_devops_rust_api/src/artifacts_package_types/models.rs
+++ b/azure_devops_rust_api/src/artifacts_package_types/models.rs
@@ -144,7 +144,7 @@ pub struct MavenPackage {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "The class to represent a collection of REST reference links."]
@@ -201,7 +201,7 @@ pub struct MavenPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "Group Id of the package."]
@@ -644,7 +644,7 @@ pub struct NpmPackageVersionDeletionState {
     #[serde(
         rename = "unpublishedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub unpublished_date: Option<time::OffsetDateTime>,
     #[doc = "Version of the package."]
@@ -712,7 +712,7 @@ pub struct NuGetPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "Name of the package."]
@@ -784,7 +784,7 @@ pub struct Package {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "Package Id."]
@@ -797,7 +797,7 @@ pub struct Package {
     #[serde(
         rename = "permanentlyDeletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub permanently_deleted_date: Option<time::OffsetDateTime>,
     #[doc = "The history of upstream sources for this package. The first source in the list is the immediate source from which this package was saved."]
@@ -860,7 +860,7 @@ pub struct PyPiPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "Name of the package."]
@@ -950,7 +950,7 @@ pub struct UPackPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "Name of the package."]

--- a/azure_devops_rust_api/src/audit/models.rs
+++ b/azure_devops_rust_api/src/audit/models.rs
@@ -114,7 +114,7 @@ pub struct AuditLogEntry {
     #[serde(rename = "scopeType", default, skip_serializing_if = "Option::is_none")]
     pub scope_type: Option<audit_log_entry::ScopeType>,
     #[doc = "The time when the event occurred in UTC"]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub timestamp: Option<time::OffsetDateTime>,
     #[doc = "The user agent from the request"]
     #[serde(rename = "userAgent", default, skip_serializing_if = "Option::is_none")]
@@ -189,7 +189,7 @@ pub struct AuditStream {
     #[serde(
         rename = "createdTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_time: Option<time::OffsetDateTime>,
     #[doc = "Used to identify individual streams"]
@@ -216,7 +216,7 @@ pub struct AuditStream {
     #[serde(
         rename = "updatedTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub updated_time: Option<time::OffsetDateTime>,
 }
@@ -360,7 +360,7 @@ pub struct DecoratedAuditLogEntry {
     #[serde(rename = "scopeType", default, skip_serializing_if = "Option::is_none")]
     pub scope_type: Option<decorated_audit_log_entry::ScopeType>,
     #[doc = "The time when the event occurred in UTC"]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub timestamp: Option<time::OffsetDateTime>,
     #[doc = "The user agent from the request"]
     #[serde(rename = "userAgent", default, skip_serializing_if = "Option::is_none")]

--- a/azure_devops_rust_api/src/build/models.rs
+++ b/azure_devops_rust_api/src/build/models.rs
@@ -485,7 +485,7 @@ pub struct Build {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "The description of how the build was deleted."]
@@ -502,7 +502,7 @@ pub struct Build {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "The ID of the build."]
@@ -511,7 +511,7 @@ pub struct Build {
     #[serde(rename = "lastChangedBy")]
     pub last_changed_by: IdentityRef,
     #[doc = "The date the build was last changed."]
-    #[serde(rename = "lastChangedDate", with = "azure_core::date::rfc3339")]
+    #[serde(rename = "lastChangedDate", with = "crate::date_time::rfc3339")]
     pub last_changed_date: time::OffsetDateTime,
     #[doc = "Represents a reference to a build log."]
     pub logs: BuildLogReference,
@@ -553,7 +553,7 @@ pub struct Build {
     #[serde(
         rename = "queueTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
     #[doc = "The reason that the build was created."]
@@ -582,7 +582,7 @@ pub struct Build {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
     #[doc = "The status of the build."]
@@ -795,7 +795,7 @@ pub struct BuildAgent {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -832,7 +832,7 @@ pub struct BuildAgent {
     #[serde(
         rename = "updatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1000,7 +1000,7 @@ pub struct BuildController {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "The description of the controller."]
@@ -1016,7 +1016,7 @@ pub struct BuildController {
     #[serde(
         rename = "updatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
     #[doc = "The controller's URI."]
@@ -1469,7 +1469,7 @@ pub struct BuildDefinitionRevision {
     #[serde(
         rename = "changedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
     #[doc = "The change type (add, edit, delete)."]
@@ -1547,7 +1547,7 @@ pub struct BuildDefinitionSourceProvider {
     #[serde(
         rename = "lastModified",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified: Option<time::OffsetDateTime>,
     #[doc = "Name of the source provider"]
@@ -1829,14 +1829,14 @@ pub struct BuildLog {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "The date and time the log was last changed."]
     #[serde(
         rename = "lastChangedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
     #[doc = "The number of lines in the log."]
@@ -1886,7 +1886,7 @@ impl BuildLogReference {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BuildMetric {
     #[doc = "The date for the scope."]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "The value."]
     #[serde(rename = "intValue", default, skip_serializing_if = "Option::is_none")]
@@ -2229,7 +2229,7 @@ pub struct BuildReference {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "The ID of the build."]
@@ -2239,7 +2239,7 @@ pub struct BuildReference {
     #[serde(
         rename = "queueTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -2256,7 +2256,7 @@ pub struct BuildReference {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
     #[doc = "The build status."]
@@ -2474,7 +2474,7 @@ pub struct BuildRetentionSample {
     #[serde(
         rename = "sampleTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub sample_time: Option<time::OffsetDateTime>,
 }
@@ -2514,7 +2514,7 @@ pub struct BuildServer {
     #[serde(
         rename = "statusChangedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub status_changed_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2578,7 +2578,7 @@ pub struct BuildSummary {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[serde(
@@ -2601,7 +2601,7 @@ pub struct BuildSummary {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2809,7 +2809,7 @@ pub struct Change {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pusher: Option<String>,
     #[doc = "The timestamp for the change."]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub timestamp: Option<time::OffsetDateTime>,
     #[doc = "The type of change. \"commit\", \"changeset\", etc."]
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
@@ -3064,7 +3064,7 @@ pub struct DefinitionReference {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "The ID of the referenced definition."]
@@ -3316,7 +3316,7 @@ pub struct Folder {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "The description."]
@@ -3333,7 +3333,7 @@ pub struct Folder {
     #[serde(
         rename = "lastChangedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_date: Option<time::OffsetDateTime>,
     #[doc = "The full path."]
@@ -3526,7 +3526,7 @@ pub struct InformationNode {
     #[serde(
         rename = "lastModifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
     #[doc = "Node Id of this information node"]
@@ -4185,7 +4185,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[doc = "Release definition ID."]
@@ -4199,7 +4199,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
     #[doc = "Release environment definition ID."]
@@ -4317,7 +4317,7 @@ pub struct RetentionLease {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "The pipeline definition of the run."]
@@ -4347,7 +4347,7 @@ pub struct RetentionLease {
     #[serde(
         rename = "validUntil",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub valid_until: Option<time::OffsetDateTime>,
 }
@@ -5126,8 +5126,8 @@ pub struct TeamProjectReference {
     #[doc = "Project identifier."]
     pub id: String,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime")]
-    pub last_update_time: String,
+    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
+    pub last_update_time: time::OffsetDateTime,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
@@ -5144,7 +5144,7 @@ pub struct TeamProjectReference {
 impl TeamProjectReference {
     pub fn new(
         id: String,
-        last_update_time: String,
+        last_update_time: time::OffsetDateTime,
         name: String,
         state: team_project_reference::State,
         visibility: team_project_reference::Visibility,
@@ -5252,7 +5252,7 @@ pub struct Timeline {
     #[serde(
         rename = "lastChangedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -5318,7 +5318,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "The ID of the record."]
@@ -5333,7 +5333,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "lastModified",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified: Option<time::OffsetDateTime>,
     #[doc = "Represents a reference to a build log."]
@@ -5378,7 +5378,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
     #[doc = "The state of the record."]
@@ -5772,7 +5772,7 @@ pub struct WorkspaceTemplate {
     #[serde(
         rename = "lastModifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
     #[doc = "List of workspace mappings"]
@@ -5836,7 +5836,7 @@ pub struct XamlBuildDefinition {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Default drop location for builds from this definition"]

--- a/azure_devops_rust_api/src/clt/models.rs
+++ b/azure_devops_rust_api/src/clt/models.rs
@@ -15,7 +15,7 @@ pub struct AgentGroup {
     #[serde(
         rename = "creationTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_time: Option<time::OffsetDateTime>,
     #[doc = "Id of the agent group"]
@@ -301,7 +301,7 @@ pub struct CounterInstanceSamples {
     #[serde(
         rename = "nextRefreshTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub next_refresh_time: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -344,7 +344,7 @@ pub struct CounterSample {
     #[serde(
         rename = "intervalEndDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub interval_end_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -438,7 +438,7 @@ pub struct Diagnostics {
     #[serde(
         rename = "lastModifiedTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_time: Option<time::OffsetDateTime>,
     #[serde(
@@ -477,7 +477,7 @@ pub struct ErrorDetails {
     #[serde(
         rename = "lastErrorDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_error_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -1130,7 +1130,7 @@ pub struct TestDefinitionBasic {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1145,7 +1145,7 @@ pub struct TestDefinitionBasic {
     #[serde(
         rename = "lastModifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -1201,7 +1201,7 @@ pub struct TestDrop {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Identifies the type of drop"]
@@ -1377,21 +1377,21 @@ pub struct TestRun {
     #[serde(
         rename = "executionFinishedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub execution_finished_date: Option<time::OffsetDateTime>,
     #[doc = "Gets the time when the test run warmup finished(if warmup was specified) and load test started"]
     #[serde(
         rename = "executionStartedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub execution_started_date: Option<time::OffsetDateTime>,
     #[doc = "Gets the time when the test run was queued"]
     #[serde(
         rename = "queuedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queued_date: Option<time::OffsetDateTime>,
     #[doc = "Retention state of the run"]
@@ -1421,7 +1421,7 @@ pub struct TestRun {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -1451,7 +1451,7 @@ pub struct TestRun {
     #[serde(
         rename = "warmUpStartedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub warm_up_started_date: Option<time::OffsetDateTime>,
     #[doc = "The uri to the vso detailed result."]
@@ -1520,7 +1520,7 @@ pub struct TestRunAbortMessage {
     #[serde(
         rename = "loggedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub logged_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1541,7 +1541,7 @@ pub struct TestRunBasic {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -1551,14 +1551,14 @@ pub struct TestRunBasic {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[doc = "Gets the finish time of the test run"]
     #[serde(
         rename = "finishedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finished_date: Option<time::OffsetDateTime>,
     #[doc = "Gets the unique identifier for the test run definition."]
@@ -1739,7 +1739,7 @@ pub struct TestRunMessage {
     #[serde(
         rename = "loggedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub logged_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2061,7 +2061,7 @@ pub struct WebApiTestMachine {
     #[serde(
         rename = "lastHeartBeat",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_heart_beat: Option<time::OffsetDateTime>,
     #[serde(

--- a/azure_devops_rust_api/src/core/models.rs
+++ b/azure_devops_rust_api/src/core/models.rs
@@ -399,7 +399,7 @@ pub struct ProjectInfo {
     #[serde(
         rename = "lastUpdateTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
     #[doc = "The name of the project."]
@@ -807,8 +807,8 @@ pub struct TeamProjectReference {
     #[doc = "Project identifier."]
     pub id: String,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime")]
-    pub last_update_time: String,
+    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
+    pub last_update_time: time::OffsetDateTime,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
@@ -825,7 +825,7 @@ pub struct TeamProjectReference {
 impl TeamProjectReference {
     pub fn new(
         id: String,
-        last_update_time: String,
+        last_update_time: time::OffsetDateTime,
         name: String,
         state: team_project_reference::State,
         visibility: team_project_reference::Visibility,
@@ -898,7 +898,7 @@ pub struct TemporaryDataCreatedDto {
     #[serde(
         rename = "expirationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub expiration_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/azure_devops_rust_api/src/date_time.rs
+++ b/azure_devops_rust_api/src/date_time.rs
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Azure DevOps date-time serde support.
+//!
+//! Protocol date-time fields are usually RFC3339 format.
+//! However, there is one special case value where
+//! services sometimes send `0001-01-01T00:00:00` which
+//! is not RFC3339 compliant (no offset), so we need to
+//! have a custom deserializer to handle this gracefully.
+
+use serde::de;
+use std::fmt;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+pub mod rfc3339 {
+    use super::*;
+
+    pub use time::serde::rfc3339::serialize;
+
+    #[allow(dead_code)]
+    pub fn deserialize<'de, D>(d: D) -> Result<OffsetDateTime, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        d.deserialize_str(DateTimeVisitor)
+    }
+
+    struct DateTimeVisitor;
+
+    impl<'de> de::Visitor<'de> for DateTimeVisitor {
+        type Value = OffsetDateTime;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "RFC3339 datetime string or 0001-01-01T00:00:00")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let value = match value {
+                "0001-01-01T00:00:00" => "0001-01-01T00:00:00Z",
+                _ => value,
+            };
+
+            OffsetDateTime::parse(value, &Rfc3339)
+                .map_err(|e| E::custom(format!("Parse error {} for {}", e, value)))
+        }
+    }
+
+    pub mod option {
+        use super::*;
+        pub use time::serde::rfc3339::option::serialize;
+
+        #[allow(dead_code)]
+        pub fn deserialize<'de, D>(d: D) -> Result<Option<OffsetDateTime>, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            d.deserialize_option(OptionalDateTimeVisitor)
+        }
+
+        struct OptionalDateTimeVisitor;
+
+        impl<'de> de::Visitor<'de> for OptionalDateTimeVisitor {
+            type Value = Option<OffsetDateTime>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "null or a datetime string")
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(None)
+            }
+
+            fn visit_some<D>(self, d: D) -> Result<Option<OffsetDateTime>, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                Ok(Some(d.deserialize_str(DateTimeVisitor)?))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use azure_core::error::{ErrorKind, ResultExt};
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+
+    pub fn parse_rfc3339(s: &str) -> azure_core::Result<OffsetDateTime> {
+        OffsetDateTime::parse(s, &Rfc3339).with_context(ErrorKind::DataConversion, || {
+            format!("unable to parse rfc3339 date '{s}")
+        })
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct ExampleState {
+        #[serde(with = "crate::date_time::rfc3339")]
+        created_time: time::OffsetDateTime,
+
+        #[serde(default, with = "crate::date_time::rfc3339::option")]
+        deleted_time: Option<time::OffsetDateTime>,
+    }
+
+    #[test]
+    fn test_serde_datetime() {
+        let json_state = r#"{
+            "created_time": "2021-07-01T10:45:02Z"
+        }"#;
+        let state: ExampleState = serde_json::from_str(json_state).unwrap();
+        assert_eq!(
+            parse_rfc3339("2021-07-01T10:45:02Z").unwrap(),
+            state.created_time
+        );
+        assert_eq!(state.deleted_time, None);
+    }
+
+    #[test]
+    fn test_serde_datetime_beginning_of_time_without_offset() {
+        let json_state = r#"{
+            "created_time": "0001-01-01T00:00:00"
+        }"#;
+        let state: ExampleState = serde_json::from_str(json_state).unwrap();
+        assert_eq!(
+            parse_rfc3339("0001-01-01T00:00:00Z").unwrap(),
+            state.created_time
+        );
+        assert_eq!(state.deleted_time, None);
+    }
+
+    #[test]
+    fn test_serde_datetime_beginning_of_time_with_offset() {
+        let json_state = r#"{
+            "created_time": "0001-01-01T00:00:00Z"
+        }"#;
+        let state: ExampleState = serde_json::from_str(json_state).unwrap();
+        assert_eq!(
+            state.created_time,
+            parse_rfc3339("0001-01-01T00:00:00Z").unwrap()
+        );
+        assert_eq!(state.deleted_time, None);
+    }
+
+    #[test]
+    fn test_serde_datetime_invalid_time() {
+        let json_state = r#"{
+            "created_time": "0002-01-01T00:00:00"
+        }"#;
+        let result: Result<ExampleState, _> = serde_json::from_str(json_state);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_serde_datetime_optional_time() {
+        let json_state = r#"{
+            "created_time": "2022-03-04T00:01:02Z",
+            "deleted_time": "2022-03-04T01:02:03Z"
+        }"#;
+        let state: ExampleState = serde_json::from_str(json_state).unwrap();
+        assert_eq!(
+            state.created_time,
+            parse_rfc3339("2022-03-04T00:01:02Z").unwrap()
+        );
+        assert_eq!(
+            state.deleted_time,
+            Some(parse_rfc3339("2022-03-04T01:02:03Z").unwrap())
+        );
+    }
+
+    #[test]
+    fn test_serde_datetime_optional_beginning_of_time() {
+        let json_state = r#"{
+            "created_time": "2022-03-04T00:01:02Z",
+            "deleted_time": "0001-01-01T00:00:00"
+        }"#;
+        let state: ExampleState = serde_json::from_str(json_state).unwrap();
+        assert_eq!(
+            state.created_time,
+            parse_rfc3339("2022-03-04T00:01:02Z").unwrap()
+        );
+        assert_eq!(
+            state.deleted_time,
+            Some(parse_rfc3339("0001-01-01T00:00:00Z").unwrap())
+        );
+    }
+}

--- a/azure_devops_rust_api/src/distributed_task/models.rs
+++ b/azure_devops_rust_api/src/distributed_task/models.rs
@@ -68,7 +68,7 @@ pub struct AgentJobRequestMessage {
     #[serde(
         rename = "lockedUntil",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub locked_until: Option<time::OffsetDateTime>,
     #[serde(rename = "lockToken", default, skip_serializing_if = "Option::is_none")]
@@ -192,7 +192,7 @@ pub struct AzureKeyVaultVariableGroupProviderData {
     #[serde(
         rename = "lastRefreshedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_refreshed_on: Option<time::OffsetDateTime>,
     #[serde(
@@ -222,7 +222,7 @@ pub struct AzureKeyVaultVariableValue {
     pub content_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub expires: Option<time::OffsetDateTime>,
 }
 impl AzureKeyVaultVariableValue {
@@ -1113,7 +1113,7 @@ pub struct ElasticNode {
     #[serde(
         rename = "stateChangedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub state_changed_on: Option<time::OffsetDateTime>,
 }
@@ -1303,7 +1303,7 @@ pub struct ElasticPool {
     #[serde(
         rename = "offlineSince",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub offline_since: Option<time::OffsetDateTime>,
     #[doc = "Operating system type of the nodes in the pool"]
@@ -1424,7 +1424,7 @@ pub struct ElasticPoolLog {
     #[serde(rename = "poolId", default, skip_serializing_if = "Option::is_none")]
     pub pool_id: Option<i32>,
     #[doc = "Datetime that the log occurred"]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub timestamp: Option<time::OffsetDateTime>,
 }
 impl ElasticPoolLog {
@@ -1616,7 +1616,7 @@ pub struct EnvironmentDeploymentExecutionRecord {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "Id of the Environment deployment execution history record"]
@@ -1645,7 +1645,7 @@ pub struct EnvironmentDeploymentExecutionRecord {
     #[serde(
         rename = "queueTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
     #[doc = "Request identifier of the Environment deployment execution history record"]
@@ -1689,7 +1689,7 @@ pub struct EnvironmentDeploymentExecutionRecord {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
 }
@@ -1740,7 +1740,7 @@ pub struct EnvironmentInstance {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Description of the Environment."]
@@ -1760,7 +1760,7 @@ pub struct EnvironmentInstance {
     #[serde(
         rename = "lastModifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
     #[doc = "Name of the Environment."]
@@ -1827,7 +1827,7 @@ pub struct EnvironmentResource {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -1849,7 +1849,7 @@ pub struct EnvironmentResource {
     #[serde(
         rename = "lastModifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1895,7 +1895,7 @@ pub struct EnvironmentResourceDeploymentExecutionRecord {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "Id of the Environment deployment execution history record"]
@@ -1915,7 +1915,7 @@ pub struct EnvironmentResourceDeploymentExecutionRecord {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
 }
@@ -2943,7 +2943,7 @@ pub struct PackageMetadata {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "A direct link to download the package."]
@@ -3212,7 +3212,7 @@ pub struct ResourceLockRequest {
     #[serde(
         rename = "assignTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub assign_time: Option<time::OffsetDateTime>,
     #[doc = "The ID of the check run waiting on this request"]
@@ -3233,7 +3233,7 @@ pub struct ResourceLockRequest {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "The behavior this request should exhibit in relation to other lock requests"]
@@ -3259,7 +3259,7 @@ pub struct ResourceLockRequest {
     #[serde(
         rename = "queueTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
     #[doc = "ID of the request."]
@@ -3412,7 +3412,7 @@ pub struct SecureFile {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3427,7 +3427,7 @@ pub struct SecureFile {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3650,7 +3650,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "Gets the Id of service endpoint execution data."]
@@ -3669,7 +3669,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
 }
@@ -3989,7 +3989,7 @@ pub struct TaskAgent {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "A job request for an agent."]
@@ -4020,7 +4020,7 @@ pub struct TaskAgent {
     #[serde(
         rename = "statusChangedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub status_changed_on: Option<time::OffsetDateTime>,
     #[doc = "System-defined capabilities supported by this agent's host. Warning: To set capabilities use the PUT method, PUT will completely overwrite existing capabilities."]
@@ -4167,7 +4167,7 @@ pub struct TaskAgentCloudRequest {
     #[serde(
         rename = "agentConnectedTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub agent_connected_time: Option<time::OffsetDateTime>,
     #[doc = "Represents a JSON object."]
@@ -4186,19 +4186,19 @@ pub struct TaskAgentCloudRequest {
     #[serde(
         rename = "provisionedTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub provisioned_time: Option<time::OffsetDateTime>,
     #[serde(
         rename = "provisionRequestTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub provision_request_time: Option<time::OffsetDateTime>,
     #[serde(
         rename = "releaseRequestTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub release_request_time: Option<time::OffsetDateTime>,
     #[serde(rename = "requestId", default, skip_serializing_if = "Option::is_none")]
@@ -4311,7 +4311,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "assignTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub assign_time: Option<time::OffsetDateTime>,
     #[doc = "Additional data about the request."]
@@ -4327,7 +4327,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "The host which triggered this request."]
@@ -4343,7 +4343,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "lockedUntil",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub locked_until: Option<time::OffsetDateTime>,
     #[serde(
@@ -4387,14 +4387,14 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "queueTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
     #[doc = "The date/time this request was receieved by an agent."]
     #[serde(
         rename = "receiveTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub receive_time: Option<time::OffsetDateTime>,
     #[doc = "ID of the request."]
@@ -4654,7 +4654,7 @@ pub struct TaskAgentPool {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -4759,7 +4759,7 @@ pub struct TaskAgentPoolMaintenanceJob {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "Id of the maintenance job"]
@@ -4786,7 +4786,7 @@ pub struct TaskAgentPoolMaintenanceJob {
     #[serde(
         rename = "queueTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -4803,7 +4803,7 @@ pub struct TaskAgentPoolMaintenanceJob {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
     #[doc = "Status of the maintenance job"]
@@ -5287,7 +5287,7 @@ pub struct TaskAgentUpdate {
     #[serde(
         rename = "requestTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub request_time: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -5353,7 +5353,7 @@ pub struct TaskAttachment {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[serde(
@@ -5365,7 +5365,7 @@ pub struct TaskAttachment {
     #[serde(
         rename = "lastChangedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5718,7 +5718,7 @@ pub struct TaskGroup {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets as 'true' to indicate as deleted, 'false' otherwise."]
@@ -5735,7 +5735,7 @@ pub struct TaskGroup {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets the owner."]
@@ -5911,7 +5911,7 @@ pub struct TaskGroupRevision {
     #[serde(
         rename = "changedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -6317,7 +6317,7 @@ pub struct TaskLog {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[serde(
@@ -6329,7 +6329,7 @@ pub struct TaskLog {
     #[serde(
         rename = "lastChangedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
     #[serde(rename = "lineCount", default, skip_serializing_if = "Option::is_none")]
@@ -6484,7 +6484,7 @@ pub struct TaskOrchestrationPlan {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -6520,7 +6520,7 @@ pub struct TaskOrchestrationPlan {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6655,7 +6655,7 @@ pub struct TaskOrchestrationQueuedPlan {
     #[serde(
         rename = "assignTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub assign_time: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -6679,7 +6679,7 @@ pub struct TaskOrchestrationQueuedPlan {
     #[serde(
         rename = "queueTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
     #[serde(
@@ -6876,7 +6876,7 @@ pub struct Timeline {
     #[serde(
         rename = "lastChangedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -6944,7 +6944,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6956,7 +6956,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "lastModified",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6997,7 +6997,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -7119,7 +7119,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets description of the variable group."]
@@ -7142,7 +7142,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets name of the variable group."]

--- a/azure_devops_rust_api/src/extension_management/models.rs
+++ b/azure_devops_rust_api/src/extension_management/models.rs
@@ -661,7 +661,7 @@ pub struct ExtensionAuditLogEntry {
     #[serde(
         rename = "auditDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub audit_date: Option<time::OffsetDateTime>,
     #[doc = "Extra information about the change"]
@@ -1096,7 +1096,7 @@ pub struct ExtensionRequest {
     #[serde(
         rename = "requestDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub request_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -1124,7 +1124,7 @@ pub struct ExtensionRequest {
     #[serde(
         rename = "resolveDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub resolve_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -1292,7 +1292,7 @@ pub struct ExtensionState {
     #[serde(
         rename = "lastVersionCheck",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_version_check: Option<time::OffsetDateTime>,
     #[serde(
@@ -1369,7 +1369,7 @@ pub struct ExtensionVersion {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1564,7 +1564,7 @@ pub struct InstalledExtension {
     #[serde(
         rename = "lastPublished",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_published: Option<time::OffsetDateTime>,
     #[doc = "Unique id of the publisher of this extension"]
@@ -1651,7 +1651,7 @@ pub struct InstalledExtensionState {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
 }
@@ -1800,7 +1800,7 @@ pub struct PublishedExtension {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(
@@ -1813,7 +1813,7 @@ pub struct PublishedExtension {
     #[serde(
         rename = "publishedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub published_date: Option<time::OffsetDateTime>,
     #[doc = "High-level information about the publisher, like id's and names"]
@@ -1823,7 +1823,7 @@ pub struct PublishedExtension {
     #[serde(
         rename = "releaseDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub release_date: Option<time::OffsetDateTime>,
     #[serde(rename = "sharedWith", default, skip_serializing_if = "Vec::is_empty")]

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -151,7 +151,7 @@ pub struct Attachment {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "The description of the attachment."]
@@ -330,7 +330,7 @@ pub struct ChangeList {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -348,7 +348,7 @@ pub struct ChangeList {
     #[serde(
         rename = "sortDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub sort_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -469,14 +469,14 @@ pub struct Comment {
     #[serde(
         rename = "lastContentUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_content_updated_date: Option<time::OffsetDateTime>,
     #[doc = "The date the comment was last updated."]
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "The ID of the parent comment. This is used for replies."]
@@ -490,7 +490,7 @@ pub struct Comment {
     #[serde(
         rename = "publishedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub published_date: Option<time::OffsetDateTime>,
     #[doc = "A list of the users who have liked this comment."]
@@ -590,7 +590,7 @@ pub struct CommentThread {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "The class represents a property bag as a collection of key-value pairs. Values of all primitive types (any type with a `TypeCode != TypeCode.Object`) except for `DBNull` are accepted. Values of type Byte[], Int32, Double, DateType and String preserve their type, other primitives are retuned as a String. Byte[] expected as base64 encoded string."]
@@ -600,7 +600,7 @@ pub struct CommentThread {
     #[serde(
         rename = "publishedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub published_date: Option<time::OffsetDateTime>,
     #[doc = "The status of the comment thread."]
@@ -1486,7 +1486,7 @@ pub struct GitConflict {
     #[serde(
         rename = "resolvedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub resolved_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2050,7 +2050,7 @@ pub struct GitDeletedRepository {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -2059,7 +2059,7 @@ pub struct GitDeletedRepository {
     #[serde(
         rename = "deletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2667,7 +2667,7 @@ pub struct GitLastChangeTreeItems {
     #[serde(
         rename = "lastExploredTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_explored_time: Option<time::OffsetDateTime>,
 }
@@ -2934,7 +2934,7 @@ pub struct GitPullRequest {
     #[serde(
         rename = "closedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub closed_date: Option<time::OffsetDateTime>,
     #[doc = "The code review ID of the pull request. Used internally."]
@@ -2958,14 +2958,14 @@ pub struct GitPullRequest {
     #[serde(
         rename = "completionQueueTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completion_queue_time: Option<time::OffsetDateTime>,
     #[doc = ""]
     #[serde(rename = "createdBy")]
     pub created_by: IdentityRef,
     #[doc = "The date when the pull request was created."]
-    #[serde(rename = "creationDate", with = "azure_core::date::rfc3339")]
+    #[serde(rename = "creationDate", with = "crate::date_time::rfc3339")]
     pub creation_date: time::OffsetDateTime,
     #[doc = "The description of the pull request."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3369,7 +3369,7 @@ pub struct GitPullRequestIteration {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Description of the pull request iteration."]
@@ -3423,7 +3423,7 @@ pub struct GitPullRequestIteration {
     #[serde(
         rename = "updatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
 }
@@ -3754,7 +3754,7 @@ pub struct GitPushRef {
     #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
     pub links: Option<ReferenceLinks>,
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub date: Option<time::OffsetDateTime>,
     #[doc = ""]
     #[serde(rename = "pushedBy", default, skip_serializing_if = "Option::is_none")]
@@ -3775,7 +3775,7 @@ pub struct GitPushSearchCriteria {
     #[serde(
         rename = "fromDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub from_date: Option<time::OffsetDateTime>,
     #[doc = "Whether to include the _links field on the shallow references"]
@@ -3795,7 +3795,7 @@ pub struct GitPushSearchCriteria {
     pub pusher_id: Option<String>,
     #[serde(rename = "refName", default, skip_serializing_if = "Option::is_none")]
     pub ref_name: Option<String>,
-    #[serde(rename = "toDate", default, with = "azure_core::date::rfc3339::option")]
+    #[serde(rename = "toDate", default, with = "crate::date_time::rfc3339::option")]
     pub to_date: Option<time::OffsetDateTime>,
 }
 impl GitPushSearchCriteria {
@@ -4605,7 +4605,7 @@ pub struct GitStatus {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[doc = "Status description. Typically describes current state of the status."]
@@ -4624,7 +4624,7 @@ pub struct GitStatus {
     #[serde(
         rename = "updatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
 }
@@ -5009,7 +5009,7 @@ impl GitTreeRef {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitUserDate {
     #[doc = "Date of the Git operation."]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Email address of the user performing the Git operation."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5373,7 +5373,7 @@ pub struct IncludedGitCommit {
     #[serde(
         rename = "commitTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub commit_time: Option<time::OffsetDateTime>,
     #[serde(
@@ -5653,7 +5653,7 @@ pub struct PolicyConfiguration {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Indicates whether the policy is blocking."]
@@ -6103,8 +6103,8 @@ pub struct TeamProjectReference {
     #[doc = "Project identifier."]
     pub id: String,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime")]
-    pub last_update_time: String,
+    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
+    pub last_update_time: time::OffsetDateTime,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
@@ -6121,7 +6121,7 @@ pub struct TeamProjectReference {
 impl TeamProjectReference {
     pub fn new(
         id: String,
-        last_update_time: String,
+        last_update_time: time::OffsetDateTime,
         name: String,
         state: team_project_reference::State,
         visibility: team_project_reference::Visibility,
@@ -6234,7 +6234,7 @@ pub struct TfvcBranchRef {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Branch description."]
@@ -6372,7 +6372,7 @@ pub struct TfvcChangesetRef {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "URL to retrieve the item."]
@@ -6498,7 +6498,7 @@ pub struct TfvcItem {
     #[serde(
         rename = "changeDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub change_date: Option<time::OffsetDateTime>,
     #[doc = "Greater than 0 if item is deleted."]
@@ -6701,7 +6701,7 @@ pub struct TfvcLabelRef {
     #[serde(
         rename = "modifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
     #[doc = "Label name."]
@@ -6902,7 +6902,7 @@ pub struct TfvcShelvesetRef {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Shelveset Id."]

--- a/azure_devops_rust_api/src/graph/models.rs
+++ b/azure_devops_rust_api/src/graph/models.rs
@@ -19,7 +19,7 @@ pub struct Avatar {
     #[serde(
         rename = "timeStamp",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/azure_devops_rust_api/src/hooks/models.rs
+++ b/azure_devops_rust_api/src/hooks/models.rs
@@ -168,7 +168,7 @@ pub struct Event {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Provides different formats of an event message"]
@@ -734,7 +734,7 @@ pub struct Notification {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Defines the data contract of notification details."]
@@ -750,7 +750,7 @@ pub struct Notification {
     #[serde(
         rename = "modifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
     #[doc = "Result of the notification"]
@@ -813,7 +813,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets this notification detail's consumer action identifier."]
@@ -841,7 +841,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "dequeuedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub dequeued_date: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets this notification detail's error detail."]
@@ -868,7 +868,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "processedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub processed_date: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets this notification detail's publisher identifier."]
@@ -889,7 +889,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "queuedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queued_date: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets this notification detail's request."]
@@ -1005,7 +1005,7 @@ pub struct NotificationsQuery {
     #[serde(
         rename = "maxCreatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub max_created_date: Option<time::OffsetDateTime>,
     #[doc = "Optional maximum number of overall results to include"]
@@ -1026,7 +1026,7 @@ pub struct NotificationsQuery {
     #[serde(
         rename = "minCreatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub min_created_date: Option<time::OffsetDateTime>,
     #[doc = "Optional publisher id to restrict the results to"]
@@ -1268,7 +1268,7 @@ pub struct SessionToken {
     #[serde(
         rename = "validTo",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
 }
@@ -1314,7 +1314,7 @@ pub struct Subscription {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -1330,7 +1330,7 @@ pub struct Subscription {
     #[serde(
         rename = "lastProbationRetryDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_probation_retry_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -1343,7 +1343,7 @@ pub struct Subscription {
     #[serde(
         rename = "modifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -1482,7 +1482,7 @@ pub struct SubscriptionTracing {
     #[serde(
         rename = "endDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
     #[doc = "The maximum number of result details to trace."]
@@ -1496,7 +1496,7 @@ pub struct SubscriptionTracing {
     #[serde(
         rename = "startDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
     #[doc = "Trace until remaining count reaches 0."]

--- a/azure_devops_rust_api/src/ims/models.rs
+++ b/azure_devops_rust_api/src/ims/models.rs
@@ -55,7 +55,7 @@ pub struct AccessTokenResult {
     #[serde(
         rename = "validTo",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
 }

--- a/azure_devops_rust_api/src/lib.rs
+++ b/azure_devops_rust_api/src/lib.rs
@@ -123,3 +123,5 @@ pub mod work;
 
 mod auth;
 pub use auth::Credential;
+
+pub mod date_time;

--- a/azure_devops_rust_api/src/member_entitlement_management/models.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/models.rs
@@ -262,7 +262,7 @@ pub struct ExtensionSummaryData {
     #[serde(
         rename = "trialExpiryDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub trial_expiry_date: Option<time::OffsetDateTime>,
 }
@@ -486,7 +486,7 @@ pub struct GroupEntitlement {
     #[serde(
         rename = "lastExecuted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_executed: Option<time::OffsetDateTime>,
     #[doc = "License assigned to a user"]
@@ -691,7 +691,7 @@ pub struct LicenseSummaryData {
     #[serde(
         rename = "nextBillingDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub next_billing_date: Option<time::OffsetDateTime>,
     #[doc = "Source of the License."]
@@ -1070,7 +1070,7 @@ pub struct UserEntitlement {
     #[serde(
         rename = "dateCreated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
     #[doc = "[Readonly] GroupEntitlements that this user belongs to."]
@@ -1087,7 +1087,7 @@ pub struct UserEntitlement {
     #[serde(
         rename = "lastAccessedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_accessed_date: Option<time::OffsetDateTime>,
     #[doc = "Relation between a project and the user's effective permissions in that project."]

--- a/azure_devops_rust_api/src/permissions_report/models.rs
+++ b/azure_devops_rust_api/src/permissions_report/models.rs
@@ -29,13 +29,13 @@ pub struct PermissionsReport {
     #[serde(
         rename = "reportStatusLastUpdatedTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub report_status_last_updated_time: Option<time::OffsetDateTime>,
     #[serde(
         rename = "requestedTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub requested_time: Option<time::OffsetDateTime>,
     #[doc = "User who requested the report be created"]

--- a/azure_devops_rust_api/src/pipelines/models.rs
+++ b/azure_devops_rust_api/src/pipelines/models.rs
@@ -113,7 +113,7 @@ pub struct Log {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "The ID of the log."]
@@ -123,7 +123,7 @@ pub struct Log {
     #[serde(
         rename = "lastChangedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
     #[doc = "The number of lines in the log."]
@@ -423,11 +423,11 @@ pub struct Run {
     #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links")]
     pub links: ReferenceLinks,
-    #[serde(rename = "createdDate", with = "azure_core::date::rfc3339")]
+    #[serde(rename = "createdDate", with = "crate::date_time::rfc3339")]
     pub created_date: time::OffsetDateTime,
     #[serde(rename = "finalYaml", default, skip_serializing_if = "Option::is_none")]
     pub final_yaml: Option<String>,
-    #[serde(rename = "finishedDate", with = "azure_core::date::rfc3339")]
+    #[serde(rename = "finishedDate", with = "crate::date_time::rfc3339")]
     pub finished_date: time::OffsetDateTime,
     #[doc = "A reference to a Pipeline."]
     pub pipeline: PipelineReference,
@@ -608,7 +608,7 @@ pub struct SignedUrl {
     #[serde(
         rename = "signatureExpires",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub signature_expires: Option<time::OffsetDateTime>,
     #[doc = "The URL to allow access to."]

--- a/azure_devops_rust_api/src/policy/models.rs
+++ b/azure_devops_rust_api/src/policy/models.rs
@@ -129,7 +129,7 @@ pub struct PolicyConfiguration {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Indicates whether the policy is blocking."]
@@ -209,7 +209,7 @@ pub struct PolicyEvaluationRecord {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "The full policy configuration with settings."]
@@ -229,7 +229,7 @@ pub struct PolicyEvaluationRecord {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
     #[doc = "Status of the policy (Running, Approved, Failed, etc.)"]

--- a/azure_devops_rust_api/src/profile/models.rs
+++ b/azure_devops_rust_api/src/profile/models.rs
@@ -64,7 +64,7 @@ pub struct Avatar {
     #[serde(
         rename = "timeStamp",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -237,7 +237,7 @@ pub struct Profile {
     #[serde(
         rename = "timeStamp",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,
 }
@@ -283,7 +283,7 @@ pub struct ProfileAttributeBase {
     #[serde(
         rename = "timeStamp",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,
     #[doc = "The value of the attribute."]

--- a/azure_devops_rust_api/src/release/models.rs
+++ b/azure_devops_rust_api/src/release/models.rs
@@ -792,7 +792,7 @@ pub struct AzureKeyVaultVariableGroupProviderData {
     #[serde(
         rename = "lastRefreshedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_refreshed_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets the service endpoint ID."]
@@ -827,7 +827,7 @@ pub struct AzureKeyVaultVariableValue {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     #[doc = "Gets or sets the expire time of key vault variable value."]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub expires: Option<time::OffsetDateTime>,
 }
 impl AzureKeyVaultVariableValue {
@@ -990,7 +990,7 @@ pub struct Change {
     #[serde(rename = "pushedBy", default, skip_serializing_if = "Option::is_none")]
     pub pushed_by: Option<IdentityRef>,
     #[doc = "A timestamp for the change."]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub timestamp: Option<time::OffsetDateTime>,
 }
 impl Change {
@@ -1490,7 +1490,7 @@ pub struct Deployment {
     #[serde(
         rename = "completedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_on: Option<time::OffsetDateTime>,
     #[doc = "Gets the list of condition associated with deployment."]
@@ -1524,7 +1524,7 @@ pub struct Deployment {
     #[serde(
         rename = "lastModifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
     #[doc = "Gets operation status of deployment."]
@@ -1559,7 +1559,7 @@ pub struct Deployment {
     #[serde(
         rename = "queuedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queued_on: Option<time::OffsetDateTime>,
     #[doc = "Gets reason of deployment."]
@@ -1600,14 +1600,14 @@ pub struct Deployment {
     #[serde(
         rename = "scheduledDeploymentTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_deployment_time: Option<time::OffsetDateTime>,
     #[doc = "Gets the date on which deployment is started."]
     #[serde(
         rename = "startedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_on: Option<time::OffsetDateTime>,
 }
@@ -1802,7 +1802,7 @@ pub struct DeploymentAttempt {
     #[serde(
         rename = "lastModifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
     #[doc = "Deployment operation status."]
@@ -1830,7 +1830,7 @@ pub struct DeploymentAttempt {
     #[serde(
         rename = "queuedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub queued_on: Option<time::OffsetDateTime>,
     #[doc = "Reason for the deployment."]
@@ -2537,7 +2537,7 @@ pub struct Folder {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Description of the folder."]
@@ -2554,7 +2554,7 @@ pub struct Folder {
     #[serde(
         rename = "lastChangedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_date: Option<time::OffsetDateTime>,
     #[doc = "path of the folder."]
@@ -2772,7 +2772,7 @@ pub struct IgnoredGate {
     #[serde(
         rename = "lastModifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
     #[doc = "Name of gate ignored."]
@@ -3131,7 +3131,7 @@ pub struct MailMessage {
     #[serde(
         rename = "replyBy",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub reply_by: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -3183,7 +3183,7 @@ pub struct ManualIntervention {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Gets the unique identifier for manual intervention."]
@@ -3196,7 +3196,7 @@ pub struct ManualIntervention {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets the name."]
@@ -3770,7 +3770,7 @@ pub struct Release {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Gets revision number of definition snapshot."]
@@ -3814,7 +3814,7 @@ pub struct Release {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Gets name."]
@@ -3961,7 +3961,7 @@ pub struct ReleaseApproval {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Gets history which specifies all approvals associated with this approval."]
@@ -3981,7 +3981,7 @@ pub struct ReleaseApproval {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets rank which specifies the order of the approval. e.g. Same rank denotes parallel approval."]
@@ -4068,14 +4068,14 @@ pub struct ReleaseApprovalHistory {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Time when this approval modified."]
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Approval history revision."]
@@ -4278,7 +4278,7 @@ pub struct ReleaseDefinition {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets the description."]
@@ -4308,7 +4308,7 @@ pub struct ReleaseDefinition {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "The class represents a property bag as a collection of key-value pairs. Values of all primitive types (any type with a `TypeCode != TypeCode.Object`) except for `DBNull` are accepted. Values of type Byte[], Int32, Double, DateType and String preserve their type, other primitives are retuned as a String. Byte[] expected as base64 encoded string."]
@@ -4737,7 +4737,7 @@ pub struct ReleaseDefinitionRevision {
     #[serde(
         rename = "changedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
     #[doc = "Gets type of change."]
@@ -4905,7 +4905,7 @@ pub struct ReleaseDeployPhase {
     #[serde(
         rename = "startedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_on: Option<time::OffsetDateTime>,
     #[doc = "Status of the phase."]
@@ -4966,7 +4966,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Gets definition environment id."]
@@ -5000,7 +5000,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Gets name."]
@@ -5010,7 +5010,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "nextScheduledUtcTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub next_scheduled_utc_time: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -5092,7 +5092,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "scheduledDeploymentTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_deployment_time: Option<time::OffsetDateTime>,
     #[doc = "Gets list of schedules."]
@@ -5399,7 +5399,7 @@ pub struct ReleaseEnvironmentUpdateMetadata {
     #[serde(
         rename = "scheduledDeploymentTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_deployment_time: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets status of environment."]
@@ -5476,7 +5476,7 @@ pub struct ReleaseGates {
     #[serde(
         rename = "lastModifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
     #[doc = "Run plan ID of the gates."]
@@ -5486,14 +5486,14 @@ pub struct ReleaseGates {
     #[serde(
         rename = "stabilizationCompletedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub stabilization_completed_on: Option<time::OffsetDateTime>,
     #[doc = "Gates evaluation started time."]
     #[serde(
         rename = "startedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_on: Option<time::OffsetDateTime>,
     #[doc = "Status of release gates."]
@@ -5503,7 +5503,7 @@ pub struct ReleaseGates {
     #[serde(
         rename = "succeedingSince",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub succeeding_since: Option<time::OffsetDateTime>,
 }
@@ -5547,14 +5547,14 @@ pub struct ReleaseGatesPhase {
     #[serde(
         rename = "stabilizationCompletedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub stabilization_completed_on: Option<time::OffsetDateTime>,
     #[doc = "Date and time at which all gates executed successfully."]
     #[serde(
         rename = "succeedingSince",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub succeeding_since: Option<time::OffsetDateTime>,
 }
@@ -5658,7 +5658,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Gets description."]
@@ -5720,7 +5720,7 @@ pub struct ReleaseRevision {
     #[serde(
         rename = "changedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
     #[doc = "Change details of the revision."]
@@ -5966,7 +5966,7 @@ pub struct ReleaseTask {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "ID of the release task."]
@@ -6005,7 +6005,7 @@ pub struct ReleaseTask {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
     #[doc = "Status of release task."]
@@ -6064,7 +6064,7 @@ pub struct ReleaseTaskAttachment {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -6078,7 +6078,7 @@ pub struct ReleaseTaskAttachment {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Name of the task attachment."]
@@ -6448,7 +6448,7 @@ pub struct SourcePullRequestVersion {
     #[serde(
         rename = "pullRequestMergedAt",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub pull_request_merged_at: Option<time::OffsetDateTime>,
     #[doc = "Source branch of the Pull Request."]
@@ -6731,7 +6731,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets description."]
@@ -6754,7 +6754,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets name."]

--- a/azure_devops_rust_api/src/service_endpoint/models.rs
+++ b/azure_devops_rust_api/src/service_endpoint/models.rs
@@ -1101,7 +1101,7 @@ pub struct OAuthConfiguration {
     #[serde(
         rename = "createdOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets the type of the endpoint."]
@@ -1125,7 +1125,7 @@ pub struct OAuthConfiguration {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Gets or sets the name"]
@@ -1474,7 +1474,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "finishTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
     #[doc = "Gets the Id of service endpoint execution data."]
@@ -1493,7 +1493,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
 }

--- a/azure_devops_rust_api/src/status/models.rs
+++ b/azure_devops_rust_api/src/status/models.rs
@@ -66,7 +66,7 @@ pub struct LiveSiteEvent {
     #[serde(
         rename = "endTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub end_time: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -84,7 +84,7 @@ pub struct LiveSiteEvent {
     #[serde(
         rename = "nextUpdateTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub next_update_time: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -92,7 +92,7 @@ pub struct LiveSiteEvent {
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -175,7 +175,7 @@ pub struct LiveSiteEventLog {
     #[serde(
         rename = "creationDateTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date_time: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -193,7 +193,7 @@ pub struct LiveSiteEventLog {
     #[serde(
         rename = "lastUpdatedDateTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date_time: Option<time::OffsetDateTime>,
     #[serde(rename = "scopeType", default, skip_serializing_if = "Option::is_none")]
@@ -234,7 +234,7 @@ pub struct LiveSiteEventLogAttachment {
     #[serde(
         rename = "creationDateTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date_time: Option<time::OffsetDateTime>,
     #[serde(
@@ -460,7 +460,7 @@ pub struct Status {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[doc = ""]

--- a/azure_devops_rust_api/src/symbol/models.rs
+++ b/azure_devops_rust_api/src/symbol/models.rs
@@ -211,7 +211,7 @@ pub struct Request {
     #[serde(
         rename = "expirationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub expiration_date: Option<time::OffsetDateTime>,
     #[doc = "Indicates if request should be chunk dedup"]
@@ -257,7 +257,7 @@ pub struct ResourceBase {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "An identifier for this item. Optional."]

--- a/azure_devops_rust_api/src/test/models.rs
+++ b/azure_devops_rust_api/src/test/models.rs
@@ -40,7 +40,7 @@ pub struct AfnStrip {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[doc = "File name of the attachment created"]
@@ -568,7 +568,7 @@ pub struct BuildConfiguration {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[doc = "Build flavor (eg Build/Release)."]
@@ -774,7 +774,7 @@ pub struct BuildReference2 {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[serde(rename = "projectId", default, skip_serializing_if = "Option::is_none")]
@@ -826,14 +826,14 @@ pub struct CloneOperationInformation {
     #[serde(
         rename = "completionDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completion_date: Option<time::OffsetDateTime>,
     #[doc = "DateTime when the operation was started"]
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[doc = "An abstracted reference to some other resource. This class is used to provide the build data contracts with a uniform way to reference other resources in a way that provides easy traversal through links."]
@@ -1197,13 +1197,13 @@ pub struct Coverage2 {
     #[serde(
         rename = "dateCreated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateModified",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_modified: Option<time::OffsetDateTime>,
     #[serde(rename = "lastError", default, skip_serializing_if = "Option::is_none")]
@@ -1388,7 +1388,7 @@ pub mod custom_test_field_definition {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DatedTestFieldData {
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub date: Option<time::OffsetDateTime>,
     #[doc = ""]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1486,7 +1486,7 @@ pub struct FailingSince {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<BuildReference>,
     #[doc = "Time since failing(UTC)."]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Reference to a release."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1966,7 +1966,7 @@ pub struct LastResultDetails {
     #[serde(
         rename = "dateCompleted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[doc = "Duration of the last result in milliseconds."]
@@ -2045,13 +2045,13 @@ pub struct LegacyBuildConfiguration {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -2098,7 +2098,7 @@ pub struct LegacyReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -2122,7 +2122,7 @@ pub struct LegacyReleaseReference {
     #[serde(
         rename = "releaseCreationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub release_creation_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -2260,7 +2260,7 @@ pub struct LegacyTestCaseResult {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -2272,13 +2272,13 @@ pub struct LegacyTestCaseResult {
     #[serde(
         rename = "dateCompleted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2310,7 +2310,7 @@ pub struct LegacyTestCaseResult {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(
@@ -2539,7 +2539,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "completeDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub complete_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -2553,7 +2553,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -2597,7 +2597,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "dueDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -2634,7 +2634,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(
@@ -2733,7 +2733,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "startDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2868,7 +2868,7 @@ pub struct LegacyTestSettings {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2886,7 +2886,7 @@ pub struct LegacyTestSettings {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(
@@ -3325,7 +3325,7 @@ pub struct PointLastResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[serde(rename = "pointId", default, skip_serializing_if = "Option::is_none")]
@@ -3453,7 +3453,7 @@ pub struct PointsResults2 {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(
@@ -3728,7 +3728,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[doc = "Release definition ID."]
@@ -3742,7 +3742,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
     #[doc = "Release environment definition ID."]
@@ -3793,7 +3793,7 @@ pub struct ReleaseReference2 {
     #[serde(
         rename = "environmentCreationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
     #[serde(rename = "projectId", default, skip_serializing_if = "Option::is_none")]
@@ -3801,7 +3801,7 @@ pub struct ReleaseReference2 {
     #[serde(
         rename = "releaseCreationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub release_creation_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -3868,7 +3868,7 @@ pub struct RequirementsToTestsMapping2 {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(rename = "deletedBy", default, skip_serializing_if = "Option::is_none")]
@@ -3876,7 +3876,7 @@ pub struct RequirementsToTestsMapping2 {
     #[serde(
         rename = "deletionDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deletion_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -4060,7 +4060,7 @@ pub struct ResultRetentionSettings {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Manual test result retention duration in days"]
@@ -4192,7 +4192,7 @@ pub struct ResultUpdateResponse {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(
@@ -4323,7 +4323,7 @@ pub struct ResultsFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -5320,8 +5320,8 @@ pub struct TeamProjectReference {
     #[doc = "Project identifier."]
     pub id: String,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime")]
-    pub last_update_time: String,
+    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
+    pub last_update_time: time::OffsetDateTime,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
@@ -5338,7 +5338,7 @@ pub struct TeamProjectReference {
 impl TeamProjectReference {
     pub fn new(
         id: String,
-        last_update_time: String,
+        last_update_time: time::OffsetDateTime,
         name: String,
         state: team_project_reference::State,
         visibility: team_project_reference::Visibility,
@@ -5404,19 +5404,19 @@ pub struct TestActionResult {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateCompleted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5439,7 +5439,7 @@ pub struct TestActionResult {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(
@@ -5482,19 +5482,19 @@ pub struct TestActionResult2 {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateCompleted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5514,7 +5514,7 @@ pub struct TestActionResult2 {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5604,7 +5604,7 @@ pub struct TestAttachment {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Attachment file name"]
@@ -5709,7 +5709,7 @@ pub struct TestAuthoringDetails {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(rename = "pointId", default, skip_serializing_if = "Option::is_none")]
@@ -5821,13 +5821,13 @@ pub struct TestCaseReference2 {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "lastRefTestRunDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_ref_test_run_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5944,7 +5944,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Machine name where test executed."]
@@ -5961,7 +5961,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Additional properties of test result."]
@@ -6020,7 +6020,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Test outcome of test result. Valid values = (Unspecified, None, Passed, Failed, Inconclusive, Timeout, Aborted, Blocked, NotExecuted, Warning, Error, NotApplicable, Paused, InProgress, NotImpacted)"]
@@ -6090,7 +6090,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
     #[doc = "State of test result. Type TestRunState."]
@@ -6368,7 +6368,7 @@ pub struct TestConfiguration {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Name of the configuration"]
@@ -6722,7 +6722,7 @@ pub struct TestHistoryQuery {
     #[serde(
         rename = "maxCompleteDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
     #[doc = "Get the results history only for this ReleaseEnvDefinitionId. This to get used in query GroupBy should be Environment."]
@@ -6786,7 +6786,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Duration of execution."]
@@ -6816,7 +6816,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
     #[doc = "Url to test iteration result."]
@@ -6858,7 +6858,7 @@ pub struct TestLog {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Size in Bytes for Log file"]
@@ -7089,7 +7089,7 @@ pub struct TestMessageLogDetails {
     #[serde(
         rename = "dateCreated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
     #[doc = "Id of the resource"]
@@ -7110,7 +7110,7 @@ pub struct TestMessageLogEntry {
     #[serde(
         rename = "dateCreated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
     #[serde(rename = "entryId", default, skip_serializing_if = "Option::is_none")]
@@ -7145,7 +7145,7 @@ pub struct TestMessageLogEntry2 {
     #[serde(
         rename = "dateCreated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
     #[serde(rename = "entryId", default, skip_serializing_if = "Option::is_none")]
@@ -7226,7 +7226,7 @@ pub struct TestParameter2 {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(rename = "dataType", default, skip_serializing_if = "Option::is_none")]
@@ -7234,7 +7234,7 @@ pub struct TestParameter2 {
     #[serde(
         rename = "dateModified",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_modified: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -7288,7 +7288,7 @@ pub struct TestPlan {
     #[serde(
         rename = "endDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
     #[doc = "ID of the test plan."]
@@ -7330,7 +7330,7 @@ pub struct TestPlan {
     #[serde(
         rename = "startDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
     #[doc = "State of the test plan."]
@@ -7349,7 +7349,7 @@ pub struct TestPlan {
     #[serde(
         rename = "updatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
     #[doc = "URL of the test plan resource."]
@@ -7466,7 +7466,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastResetToActive",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_reset_to_active: Option<time::OffsetDateTime>,
     #[doc = "Last resolution state id of test point."]
@@ -7522,7 +7522,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Outcome of test point."]
@@ -7692,19 +7692,19 @@ pub struct TestResult2 {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateCompleted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
     #[serde(
@@ -7722,7 +7722,7 @@ pub struct TestResult2 {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(
@@ -7817,7 +7817,7 @@ pub struct TestResultAttachment {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -8239,7 +8239,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Duration of execution."]
@@ -8263,7 +8263,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
 }
@@ -8381,7 +8381,7 @@ pub struct TestResultReset2 {
     #[serde(
         rename = "dateModified",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_modified: Option<time::OffsetDateTime>,
     #[serde(rename = "projectId", default, skip_serializing_if = "Option::is_none")]
@@ -8483,7 +8483,7 @@ pub struct TestResultTrendFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -8600,13 +8600,13 @@ pub struct TestResultsEx2 {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateTimeValue",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_time_value: Option<time::OffsetDateTime>,
     #[serde(rename = "fieldId", default, skip_serializing_if = "Option::is_none")]
@@ -8754,7 +8754,7 @@ pub struct TestResultsWithWatermark {
     #[serde(
         rename = "changedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -8793,7 +8793,7 @@ pub struct TestRun {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Test Run Controller."]
@@ -8803,7 +8803,7 @@ pub struct TestRun {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "List of Custom Fields for TestRun."]
@@ -8845,7 +8845,7 @@ pub struct TestRun {
     #[serde(
         rename = "dueDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
     #[doc = "Error message associated with the run."]
@@ -8889,7 +8889,7 @@ pub struct TestRun {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Name of the test run."]
@@ -8965,7 +8965,7 @@ pub struct TestRun {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
     #[doc = "The state of the run. Type TestRunState Valid states - Unspecified ,NotStarted, InProgress, Completed, Waiting, Aborted, NeedsInvestigation"]
@@ -9072,7 +9072,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "completeDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub complete_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9086,13 +9086,13 @@ pub struct TestRun2 {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "deletedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_on: Option<time::OffsetDateTime>,
     #[serde(
@@ -9104,7 +9104,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "dueDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -9142,7 +9142,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(
@@ -9208,7 +9208,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "startDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -9380,13 +9380,13 @@ pub struct TestRunEx2 {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateTimeValue",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_time_value: Option<time::OffsetDateTime>,
     #[serde(rename = "fieldId", default, skip_serializing_if = "Option::is_none")]
@@ -9552,7 +9552,7 @@ pub struct TestRunSummary2 {
     #[serde(
         rename = "testRunCompletedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub test_run_completed_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -9623,7 +9623,7 @@ pub struct TestSession {
     #[serde(
         rename = "endDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
     #[doc = "Id of the test session"]
@@ -9640,7 +9640,7 @@ pub struct TestSession {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -9666,7 +9666,7 @@ pub struct TestSession {
     #[serde(
         rename = "startDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
     #[doc = "State of the test session"]
@@ -9737,14 +9737,14 @@ pub struct TestSessionExploredWorkItemReference {
     #[serde(
         rename = "endTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub end_time: Option<time::OffsetDateTime>,
     #[doc = "Time when explore of workitem was started."]
     #[serde(
         rename = "startTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
 }
@@ -9839,7 +9839,7 @@ pub struct TestSettings2 {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Description of the test settings. Used in create test settings."]
@@ -9858,7 +9858,7 @@ pub struct TestSettings2 {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Xml string of machine roles. Used in create test settings."]
@@ -9922,7 +9922,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Machine where test executed."]
@@ -9970,7 +9970,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Outcome of sub result."]
@@ -10004,7 +10004,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
     #[doc = "List of sub results inside a sub result, if ResultGroupType is not None, it holds corresponding type sub results."]
@@ -10083,7 +10083,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastPopulatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_populated_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -10097,7 +10097,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Name of test suite."]
@@ -10358,7 +10358,7 @@ pub struct UpdatedProperties {
     #[serde(
         rename = "lastUpdated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
     #[serde(

--- a/azure_devops_rust_api/src/test_plan/models.rs
+++ b/azure_devops_rust_api/src/test_plan/models.rs
@@ -34,14 +34,14 @@ pub struct CloneOperationCommonResponse {
     #[serde(
         rename = "completionDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completion_date: Option<time::OffsetDateTime>,
     #[doc = "Creation data of the operation"]
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[doc = "The class to represent a collection of REST reference links."]
@@ -574,7 +574,7 @@ pub struct LastResultDetails {
     #[serde(
         rename = "dateCompleted",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[doc = "Duration of the last result in milliseconds."]
@@ -1013,8 +1013,8 @@ pub struct TeamProjectReference {
     #[doc = "Project identifier."]
     pub id: String,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime")]
-    pub last_update_time: String,
+    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
+    pub last_update_time: time::OffsetDateTime,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
@@ -1031,7 +1031,7 @@ pub struct TeamProjectReference {
 impl TeamProjectReference {
     pub fn new(
         id: String,
-        last_update_time: String,
+        last_update_time: time::OffsetDateTime,
         name: String,
         state: team_project_reference::State,
         visibility: team_project_reference::Visibility,
@@ -1123,7 +1123,7 @@ pub struct TestCaseAssociatedResult {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Test Configuration Reference"]
@@ -1442,7 +1442,7 @@ pub struct TestPlan {
     #[serde(
         rename = "updatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
 }
@@ -1474,7 +1474,7 @@ pub struct TestPlanCreateParams {
     #[serde(
         rename = "endDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
     #[doc = "Iteration path of the test plan."]
@@ -1497,7 +1497,7 @@ pub struct TestPlanCreateParams {
     #[serde(
         rename = "startDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
     #[doc = "State of the test plan."]
@@ -1528,7 +1528,7 @@ pub struct TestPlanDetailedReference {
     #[serde(
         rename = "endDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
     #[doc = "Iteration path of the test plan."]
@@ -1545,7 +1545,7 @@ pub struct TestPlanDetailedReference {
     #[serde(
         rename = "startDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
 }
@@ -1751,7 +1751,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastResetToActive",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_reset_to_active: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -1765,7 +1765,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "The class to represent a collection of REST reference links."]
@@ -2103,7 +2103,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastPopulatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_populated_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -2117,7 +2117,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "The test plan reference resource."]

--- a/azure_devops_rust_api/src/test_results/models.rs
+++ b/azure_devops_rust_api/src/test_results/models.rs
@@ -386,7 +386,7 @@ pub struct BuildConfiguration {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[doc = "Build flavor (eg Build/Release)."]
@@ -712,7 +712,7 @@ pub struct FailingSince {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<BuildReference>,
     #[doc = "Time since failing(UTC)."]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Reference to a release."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1170,7 +1170,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "creationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[doc = "Release definition ID."]
@@ -1184,7 +1184,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
     #[doc = "Release environment definition ID."]
@@ -1295,7 +1295,7 @@ pub struct ResultsFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -2037,9 +2037,8 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub id: String,
-    #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime")]
-    pub last_update_time: String,
+    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
+    pub last_update_time: time::OffsetDateTime,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
@@ -2051,7 +2050,7 @@ pub struct TeamProjectReference {
 impl TeamProjectReference {
     pub fn new(
         id: String,
-        last_update_time: String,
+        last_update_time: time::OffsetDateTime,
         name: String,
         state: team_project_reference::State,
         visibility: team_project_reference::Visibility,
@@ -2160,7 +2159,7 @@ pub struct TestAttachment {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Attachment file name"]
@@ -2306,7 +2305,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Machine name where test executed."]
@@ -2323,7 +2322,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Additional properties of test result."]
@@ -2382,7 +2381,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Test outcome of test result. Valid values = (Unspecified, None, Passed, Failed, Inconclusive, Timeout, Aborted, Blocked, NotExecuted, Warning, Error, NotApplicable, Paused, InProgress, NotImpacted)"]
@@ -2452,7 +2451,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
     #[doc = "State of test result. Type TestRunState."]
@@ -2703,7 +2702,7 @@ pub struct TestHistoryQuery {
     #[serde(
         rename = "maxCompleteDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
     #[doc = "Get the results history only for this ReleaseEnvDefinitionId. This to get used in query GroupBy should be Environment."]
@@ -2767,7 +2766,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Duration of execution."]
@@ -2797,7 +2796,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
     #[doc = "Url to test iteration result."]
@@ -2826,7 +2825,7 @@ pub struct TestLog {
     #[serde(
         rename = "modifiedOn",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
     #[doc = "Size in Bytes for Log file"]
@@ -2992,7 +2991,7 @@ pub struct TestMessageLogDetails {
     #[serde(
         rename = "dateCreated",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
     #[doc = "Id of the resource"]
@@ -3260,7 +3259,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Duration of execution."]
@@ -3284,7 +3283,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
 }
@@ -3426,7 +3425,7 @@ pub struct TestResultTrendFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
     #[serde(
@@ -3621,7 +3620,7 @@ pub struct TestRun {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Test Run Controller."]
@@ -3631,7 +3630,7 @@ pub struct TestRun {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "List of Custom Fields for TestRun."]
@@ -3673,7 +3672,7 @@ pub struct TestRun {
     #[serde(
         rename = "dueDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
     #[doc = "Error message associated with the run."]
@@ -3717,7 +3716,7 @@ pub struct TestRun {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Name of the test run."]
@@ -3793,7 +3792,7 @@ pub struct TestRun {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
     #[doc = "The state of the run. Type TestRunState Valid states - Unspecified ,NotStarted, InProgress, Completed, Waiting, Aborted, NeedsInvestigation"]
@@ -3975,7 +3974,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "completedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[doc = "Machine where test executed."]
@@ -4023,7 +4022,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
     #[doc = "Outcome of sub result."]
@@ -4057,7 +4056,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "startedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
     #[doc = "List of sub results inside a sub result, if ResultGroupType is not None, it holds corresponding type sub results."]

--- a/azure_devops_rust_api/src/tfvc/models.rs
+++ b/azure_devops_rust_api/src/tfvc/models.rs
@@ -451,8 +451,8 @@ pub struct TeamProjectReference {
     #[doc = "Project identifier."]
     pub id: String,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime")]
-    pub last_update_time: String,
+    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
+    pub last_update_time: time::OffsetDateTime,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
@@ -469,7 +469,7 @@ pub struct TeamProjectReference {
 impl TeamProjectReference {
     pub fn new(
         id: String,
-        last_update_time: String,
+        last_update_time: time::OffsetDateTime,
         name: String,
         state: team_project_reference::State,
         visibility: team_project_reference::Visibility,
@@ -595,7 +595,7 @@ pub struct TfvcBranchRef {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Branch description."]
@@ -759,7 +759,7 @@ pub struct TfvcChangesetRef {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "URL to retrieve the item."]
@@ -866,7 +866,7 @@ pub struct TfvcItem {
     #[serde(
         rename = "changeDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub change_date: Option<time::OffsetDateTime>,
     #[doc = "Greater than 0 if item is deleted."]
@@ -1064,7 +1064,7 @@ pub struct TfvcLabelRef {
     #[serde(
         rename = "modifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
     #[doc = "Label name."]
@@ -1278,7 +1278,7 @@ pub struct TfvcShelvesetRef {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Shelveset Id."]

--- a/azure_devops_rust_api/src/token_admin/models.rs
+++ b/azure_devops_rust_api/src/token_admin/models.rs
@@ -67,13 +67,13 @@ pub struct SessionToken {
     #[serde(
         rename = "validFrom",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub valid_from: Option<time::OffsetDateTime>,
     #[serde(
         rename = "validTo",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
 }
@@ -212,7 +212,7 @@ pub struct TokenAdminRevocationRule {
     #[serde(
         rename = "createdBefore",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_before: Option<time::OffsetDateTime>,
     #[doc = "A string containing a space-delimited list of OAuth scopes. A token matching any one of the scopes will be rejected. For a list of all OAuth scopes supported by Azure DevOps, see: https://docs.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops#scopes This is a mandatory parameter."]

--- a/azure_devops_rust_api/src/wiki/models.rs
+++ b/azure_devops_rust_api/src/wiki/models.rs
@@ -24,7 +24,7 @@ pub struct Comment {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "The id assigned to the comment."]
@@ -47,7 +47,7 @@ pub struct Comment {
     #[serde(
         rename = "modifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
     #[doc = "The comment id of the parent comment, if any"]
@@ -106,7 +106,7 @@ pub struct CommentAttachment {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Unique Id of the attachment."]
@@ -567,9 +567,8 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub id: String,
-    #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime")]
-    pub last_update_time: String,
+    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
+    pub last_update_time: time::OffsetDateTime,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
@@ -581,7 +580,7 @@ pub struct TeamProjectReference {
 impl TeamProjectReference {
     pub fn new(
         id: String,
-        last_update_time: String,
+        last_update_time: time::OffsetDateTime,
         name: String,
         state: team_project_reference::State,
         visibility: team_project_reference::Visibility,
@@ -943,7 +942,7 @@ pub struct WikiPageStat {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub count: Option<i32>,
     #[doc = "Day of the stat"]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub day: Option<time::OffsetDateTime>,
 }
 impl WikiPageStat {
@@ -961,7 +960,7 @@ pub struct WikiPageViewStats {
     #[serde(
         rename = "lastViewedTime",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_viewed_time: Option<time::OffsetDateTime>,
     #[doc = "Wiki page path."]

--- a/azure_devops_rust_api/src/wit/models.rs
+++ b/azure_devops_rust_api/src/wit/models.rs
@@ -84,7 +84,7 @@ pub struct AccountRecentActivityWorkItemModelBase {
     #[serde(
         rename = "activityDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub activity_date: Option<time::OffsetDateTime>,
     #[doc = "Type of the activity"]
@@ -98,7 +98,7 @@ pub struct AccountRecentActivityWorkItemModelBase {
     #[serde(
         rename = "changedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
     #[doc = "Work Item Id"]
@@ -169,7 +169,7 @@ pub struct AccountRecentMentionWorkItemModel {
     #[serde(
         rename = "mentionedDateField",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub mentioned_date_field: Option<time::OffsetDateTime>,
     #[doc = "State of the work item"]
@@ -210,7 +210,7 @@ pub struct AccountWorkWorkItemModel {
     #[serde(
         rename = "changedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -294,14 +294,14 @@ pub struct Comment {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Effective Date/time value for adding the comment. Can be optionally different from CreatedDate."]
     #[serde(
         rename = "createdOnBehalfDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on_behalf_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -331,7 +331,7 @@ pub struct Comment {
     #[serde(
         rename = "modifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
     #[doc = "The reactions of the comment."]
@@ -550,14 +550,14 @@ pub struct CommentVersion {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Effective Date/time value for adding the comment. Can be optionally different from CreatedDate."]
     #[serde(
         rename = "createdOnBehalfDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_on_behalf_date: Option<time::OffsetDateTime>,
     #[doc = ""]
@@ -584,7 +584,7 @@ pub struct CommentVersion {
     #[serde(
         rename = "modifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
     #[doc = "The rendered content of the comment at this version."]
@@ -704,7 +704,7 @@ pub struct ExternalDeployment {
     #[serde(
         rename = "statusDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub status_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1133,7 +1133,7 @@ pub struct QueryHierarchyItem {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "The link query mode."]
@@ -1180,7 +1180,7 @@ pub struct QueryHierarchyItem {
     #[serde(
         rename = "lastExecutedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_executed_date: Option<time::OffsetDateTime>,
     #[doc = "Describes a reference to an identity."]
@@ -1194,7 +1194,7 @@ pub struct QueryHierarchyItem {
     #[serde(
         rename = "lastModifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
     #[doc = "Represents a clause in a work item query. This shows the structure of a work item query."]
@@ -1633,7 +1633,7 @@ pub struct WorkItemBatchGetRequest {
     #[serde(rename = "$expand", default, skip_serializing_if = "Option::is_none")]
     pub expand: Option<work_item_batch_get_request::Expand>,
     #[doc = "AsOf UTC date time string"]
-    #[serde(rename = "asOf", default, with = "azure_core::date::rfc3339::option")]
+    #[serde(rename = "asOf", default, with = "crate::date_time::rfc3339::option")]
     pub as_of: Option<time::OffsetDateTime>,
     #[doc = "The flag to control error policy in a bulk get work items request. Possible options are {Fail, Omit}."]
     #[serde(
@@ -1768,7 +1768,7 @@ pub struct WorkItemComment {
     #[serde(
         rename = "revisedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub revised_date: Option<time::OffsetDateTime>,
     #[doc = "The work item revision number."]
@@ -2198,7 +2198,7 @@ pub struct WorkItemHistory {
     #[serde(
         rename = "revisedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub revised_date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2371,7 +2371,7 @@ pub mod work_item_query_clause {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct WorkItemQueryResult {
     #[doc = "The date the query was run in the context of."]
-    #[serde(rename = "asOf", default, with = "azure_core::date::rfc3339::option")]
+    #[serde(rename = "asOf", default, with = "crate::date_time::rfc3339::option")]
     pub as_of: Option<time::OffsetDateTime>,
     #[doc = "The columns of the query."]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -3106,7 +3106,7 @@ pub struct WorkItemUpdate {
     #[serde(
         rename = "revisedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub revised_date: Option<time::OffsetDateTime>,
     #[doc = "The work item ID."]

--- a/azure_devops_rust_api/src/work/models.rs
+++ b/azure_devops_rust_api/src/work/models.rs
@@ -745,10 +745,10 @@ pub mod create_plan {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DateRange {
     #[doc = "End of the date range."]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub end: Option<time::OffsetDateTime>,
     #[doc = "Start of the date range."]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub start: Option<time::OffsetDateTime>,
 }
 impl DateRange {
@@ -779,7 +779,7 @@ pub struct DeliveryViewData {
     #[serde(
         rename = "endDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
     #[doc = "Max number of teams that can be configured for a delivery plan"]
@@ -800,7 +800,7 @@ pub struct DeliveryViewData {
     #[serde(
         rename = "startDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
     #[doc = "All the team data"]
@@ -1166,7 +1166,7 @@ pub struct Marker {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     #[doc = "Where the marker should be displayed on the timeline."]
-    #[serde(default, with = "azure_core::date::rfc3339::option")]
+    #[serde(default, with = "crate::date_time::rfc3339::option")]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Label/title for the marker."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1256,7 +1256,7 @@ pub struct Plan {
     #[serde(
         rename = "createdDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[doc = "Description of the plan"]
@@ -1276,7 +1276,7 @@ pub struct Plan {
     #[serde(
         rename = "modifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
     #[doc = "Name of the plan"]
@@ -1362,7 +1362,7 @@ pub struct PlanMetadata {
     #[serde(
         rename = "modifiedDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
     #[doc = "Bit flag indicating set of permissions a user has to the plan."]
@@ -1830,14 +1830,14 @@ pub struct TeamIterationAttributes {
     #[serde(
         rename = "finishDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_date: Option<time::OffsetDateTime>,
     #[doc = "Start date of the iteration. Date-only, correct unadjusted at midnight in UTC."]
     #[serde(
         rename = "startDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
     #[doc = "Time frame of the iteration, such as past, current or future."]
@@ -2258,7 +2258,7 @@ pub struct TimelineTeamIteration {
     #[serde(
         rename = "finishDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub finish_date: Option<time::OffsetDateTime>,
     #[doc = "The iteration name"]
@@ -2278,7 +2278,7 @@ pub struct TimelineTeamIteration {
     #[serde(
         rename = "startDate",
         default,
-        with = "azure_core::date::rfc3339::option"
+        with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
     #[doc = ""]

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -48,15 +48,9 @@ const DOC_PATCHES: &[(&str, &str)] = &[
     ),
 ];
 
-const SPEC_DESCRIPTIONS : &[(&str, &str)] = &[
-    (
-        "git.json",
-        "Git repositories"
-    ),
-    (
-        "workItemTracking.json",
-        "Work item tracking"
-    ),
+const SPEC_DESCRIPTIONS: &[(&str, &str)] = &[
+    ("git.json", "Git repositories"),
+    ("workItemTracking.json", "Work item tracking"),
 ];
 
 struct Patcher {
@@ -139,7 +133,6 @@ impl Patcher {
         Patcher::patch_spec_descriptions,
         Patcher::patch_json_reference_links,
         Patcher::patch_teamproject_visibility_enum,
-        Patcher::patch_team_project_reference_last_update_time,
         Patcher::patch_array_array_schema,
         Patcher::patch_response_schema,
         Patcher::patch_git_reference_links,
@@ -159,11 +152,7 @@ impl Patcher {
         }
     }
 
-    fn patch_json_reference_links(
-        &mut self,
-        key: &[&str],
-        value: &JsonValue,
-    ) -> Option<JsonValue> {
+    fn patch_json_reference_links(&mut self, key: &[&str], value: &JsonValue) -> Option<JsonValue> {
         match key {
             ["definitions", schema_name, "properties", "_links"] => {
                 if *value != json::object! { "$ref": "#/definitions/ReferenceLinks" } {
@@ -172,8 +161,7 @@ impl Patcher {
                         "description": "Links",
                         "type": "object",
                     })
-                }
-                else {
+                } else {
                     println!("Skip replacing _links definition for {}", schema_name);
                     None
                 }
@@ -254,11 +242,7 @@ impl Patcher {
         }
     }
 
-    fn patch_spec_descriptions(
-        &mut self,
-        key: &[&str],
-        _value: &JsonValue,
-    ) -> Option<JsonValue> {
+    fn patch_spec_descriptions(&mut self, key: &[&str], _value: &JsonValue) -> Option<JsonValue> {
         for (filename, desc) in SPEC_DESCRIPTIONS {
             if !self.spec_path.ends_with(filename) {
                 continue;
@@ -267,9 +251,9 @@ impl Patcher {
             match key {
                 ["info", "description"] => {
                     println!("Patching spec description: {}: {}", filename, desc);
-                    return Some(JsonValue::from(*desc))
+                    return Some(JsonValue::from(*desc));
                 }
-                _ => ()
+                _ => (),
             }
         }
         None
@@ -371,30 +355,6 @@ impl Patcher {
         }
     }
 
-    // TeamProjectReference lastUpdateTime claims to be a "date-time" format,
-    // which according to the OpenApi spec should be RFC3339 compliant.
-    // However, the lastUpdateTime sometimes contains "0000-01-01T00:00:00",
-    // which is non-compliant because it does not include any timezone
-    // (e.g. a terminating "Z").
-    //
-    // We patch it here to be a string to avoid parsing errors.
-    fn patch_team_project_reference_last_update_time(
-        &mut self,
-        key: &[&str],
-        _value: &JsonValue,
-    ) -> Option<JsonValue> {
-        match key {
-            ["definitions", "TeamProjectReference", "properties", "lastUpdateTime"] => {
-                println!("Replace TeamProjectReference lastUpdateTime field");
-                Some(json::object! {
-                    "description": "Project last update time.",
-                    "type": "string"
-                })
-            }
-            _ => None,
-        }
-    }
-
     fn patch_git_reference_links(&mut self, key: &[&str], _value: &JsonValue) -> Option<JsonValue> {
         // Only applies to git specs
         if !self.spec_path.ends_with("git.json") {
@@ -440,7 +400,11 @@ impl Patcher {
         }
     }
 
-    fn patch_build_reference_links(&mut self, key: &[&str], _value: &JsonValue) -> Option<JsonValue> {
+    fn patch_build_reference_links(
+        &mut self,
+        key: &[&str],
+        _value: &JsonValue,
+    ) -> Option<JsonValue> {
         // Only applies to build specs
         if !self.spec_path.ends_with("build.json") {
             return None;
@@ -714,7 +678,7 @@ impl Patcher {
                     "uri",
                     "url",
                     "validationResults"
-                ]"#
+                ]"#,
             ),
             (
                 "build.json",
@@ -731,7 +695,7 @@ impl Patcher {
                     "type",
                     "uri",
                     "url"
-                ]"#
+                ]"#,
             ),
             (
                 "build.json",
@@ -740,7 +704,7 @@ impl Patcher {
                     "id",
                     "type",
                     "url"
-                ]"#
+                ]"#,
             ),
             (
                 "build.json",
@@ -752,7 +716,7 @@ impl Patcher {
                     "id",
                     "pool",
                     "name"
-                ]"#
+                ]"#,
             ),
             (
                 "build.json",
@@ -762,7 +726,7 @@ impl Patcher {
                 r#"[
                     "id",
                     "name"
-                ]"#
+                ]"#,
             ),
             (
                 "build.json",
@@ -771,7 +735,7 @@ impl Patcher {
                 //   orchestrationType
                 r#"[
                     "planId"
-                ]"#
+                ]"#,
             ),
             (
                 "build.json",
@@ -787,7 +751,7 @@ impl Patcher {
                 r#"[
                     "id",
                     "type"
-                ]"#
+                ]"#,
             ),
             (
                 "*",
@@ -797,7 +761,7 @@ impl Patcher {
                     "descriptor",
                     "displayName",
                     "url"
-                ]"#
+                ]"#,
             ),
             (
                 "*",
@@ -805,7 +769,7 @@ impl Patcher {
                 r#"[
                     "id",
                     "uniqueName"
-                ]"#
+                ]"#,
             ),
             (
                 "workItemTracking.json",
@@ -814,21 +778,21 @@ impl Patcher {
                     "attributes",
                     "rel",
                     "url"
-                ]"#
+                ]"#,
             ),
             (
                 "workItemTracking.json",
                 "WorkItemTrackingResourceReference",
                 r#"[
                     "url"
-                ]"#
+                ]"#,
             ),
             (
                 "workItemTracking.json",
                 "WorkItemTrackingResource",
                 r#"[
                     "_links"
-                ]"#
+                ]"#,
             ),
             (
                 "workItemTracking.json",
@@ -836,21 +800,21 @@ impl Patcher {
                 r#"[
                     "id",
                     "fields"
-                ]"#
+                ]"#,
             ),
             (
                 "status.json",
                 "ServiceHealth",
                 r#"[
                     "id"
-                ]"#
+                ]"#,
             ),
             (
                 "status.json",
                 "GeographyWithHealth",
                 r#"[
                     "health"
-                ]"#
+                ]"#,
             ),
             (
                 "status.json",
@@ -858,14 +822,14 @@ impl Patcher {
                 r#"[
                     "id",
                     "name"
-                ]"#
+                ]"#,
             ),
             (
                 "status.json",
                 "Status",
                 r#"[
                     "status"
-                ]"#
+                ]"#,
             ),
             (
                 "status.json",
@@ -873,14 +837,15 @@ impl Patcher {
                 r#"[
                     "health",
                     "message"
-                ]"#
-            )
+                ]"#,
+            ),
         ];
 
         match key {
             ["definitions", def] => {
                 for (filename, def_name, required_fields) in patches.iter() {
-                    if (*filename == "*" || self.spec_path.ends_with(filename)) && (def == def_name) {
+                    if (*filename == "*" || self.spec_path.ends_with(filename)) && (def == def_name)
+                    {
                         println!("Add required values to {} definition", def_name);
                         let mut value = value.to_owned();
                         value["required"] = json::parse(required_fields).unwrap();


### PR DESCRIPTION
Added custom date-time serde implementation to gracefully handle `0001-01-01T00:00:00`.

Fixes https://github.com/microsoft/azure-devops-rust-api/issues/22