### PR TITLE
added options to get max top commits

### DIFF
--- a/azure_devops_rust_api/examples/git_pr_commits.rs
+++ b/azure_devops_rust_api/examples/git_pr_commits.rs
@@ -35,6 +35,8 @@ async fn main() -> Result<()> {
         .nth(2)
         .expect("Usage: git_pr_commits <pull_request_id>").parse().unwrap();
     let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+    // Set the max number of top commits to get if there any , Default is 100
+    let top_commits:i32 = 500;
 
     // Create a git client
     let git_client = git::ClientBuilder::new(credential).build();
@@ -43,6 +45,7 @@ async fn main() -> Result<()> {
     let pr_commits = git_client
         .pull_request_commits_client()
         .get_pull_request_commits(&organization, &repository_name, pull_request_id, &project)
+        .top(top_commits)
         .into_future()
         .await?;
     println!("{:#?}", pr_commits);

--- a/azure_devops_rust_api/examples/git_pr_commits.rs
+++ b/azure_devops_rust_api/examples/git_pr_commits.rs
@@ -35,8 +35,8 @@ async fn main() -> Result<()> {
         .nth(2)
         .expect("Usage: git_pr_commits <pull_request_id>").parse().unwrap();
     let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
-    // Set the max number of top commits to get if there any , Default is 100
-    let top_commits:i32 = 500;
+    // Set the max number of commits to get, default is 100
+    let top_commits: i32 = 500;
 
     // Create a git client
     let git_client = git::ClientBuilder::new(credential).build();


### PR DESCRIPTION
By default, maximum of 100 commits are displayed. But there are some cases where there are more than 100 commits.
In the new vars `top_commits` has been added to get the specified number of commits.

### Example: In below scenario I have more than 200 commits

![image](https://user-images.githubusercontent.com/110555003/187077431-c40a8523-cee4-4487-a569-5731cfb2a2e8.png)

