### PR TITLE
Fixed response types for git::commits::get_changes()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
 - Implement custom date-time serde module to gracefully handle `0001-01-01T00:00:00`
+- Fixed response types for git::commits::get_changes()
 
 ## [0.5.1]
 

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -85,6 +85,10 @@ name = "git_repo_list"
 required-features = ["git"]
 
 [[example]]
+name = "git_commit_changes"
+required-features = ["git"]
+
+[[example]]
 name = "pipelines"
 required-features = ["pipelines"]
 

--- a/azure_devops_rust_api/examples/git_commit_changes.rs
+++ b/azure_devops_rust_api/examples/git_commit_changes.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// get_commits.rs
+// Getting all the commits from a PR example.
+use anyhow::Result;
+use azure_devops_rust_api::git;
+use azure_devops_rust_api::Credential;
+use std::env;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+
+    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
+    let credential = match env::var("ADO_TOKEN") {
+        Ok(token) => {
+            println!("INFO:Authenticate using PAT provided via $ADO_TOKEN");
+            Credential::from_pat(token)
+        }
+        Err(_) => {
+            println!("INFO:Authenticate using Azure CLI");
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+        }
+    };
+
+    // Get ADO server configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    let repository_name = env::args()
+        .nth(1)
+        .expect("Usage: git_pr_commits <repository-name> <commit_id>");
+    let commit_id = env::args()
+        .nth(2)
+        .expect("Usage: git_pr_commits <repository-name> <commit_id>");
+    let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+
+    // Create a git client
+    let git_client = git::ClientBuilder::new(credential).build();
+
+    let commit_changes = git_client
+        .commits_client()
+        .get_changes(&organization, &commit_id, &repository_name, &project)
+        .into_future()
+        .await?;
+    println!("commit_changes:\n{:#?}", commit_changes);
+
+    Ok(())
+}

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -222,39 +222,16 @@ impl BranchUpdatedEvent {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Change {
     #[doc = "The type of change that was made to the item."]
-    #[serde(
-        rename = "changeType",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub change_type: Option<change::ChangeType>,
-    #[doc = "Current version."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub item: Option<String>,
-    #[doc = ""]
-    #[serde(
-        rename = "newContent",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub new_content: Option<ItemContent>,
-    #[doc = "Path of the item on the server."]
-    #[serde(
-        rename = "sourceServerItem",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub source_server_item: Option<String>,
-    #[doc = "URL to retrieve the item."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    #[serde(rename = "changeType")]
+    pub change_type: change::ChangeType,
+    pub item: serde_json::Value,
 }
 impl Change {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(change_type: change::ChangeType, item: serde_json::Value) -> Self {
+        Self { change_type, item }
     }
 }
 pub mod change {
@@ -1179,31 +1156,14 @@ impl GitBranchStatsList {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GitChange {
     #[serde(flatten)]
     pub change: Change,
-    #[doc = "ID of the change within the group of changes."]
-    #[serde(rename = "changeId", default, skip_serializing_if = "Option::is_none")]
-    pub change_id: Option<i32>,
-    #[doc = ""]
-    #[serde(
-        rename = "newContentTemplate",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub new_content_template: Option<GitTemplate>,
-    #[doc = "Original path of item if different from current path."]
-    #[serde(
-        rename = "originalPath",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub original_path: Option<String>,
 }
 impl GitChange {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(change: Change) -> Self {
+        Self { change }
     }
 }
 #[doc = "This object is returned from Cherry Pick operations and provides the id and status of the operation"]
@@ -1242,13 +1202,12 @@ impl GitCommit {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitCommitChanges {
-    #[doc = ""]
     #[serde(
         rename = "changeCounts",
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub change_counts: Option<ChangeCountDictionary>,
+    pub change_counts: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub changes: Vec<GitChange>,
 }
@@ -3178,7 +3137,7 @@ pub mod git_pull_request {
     }
 }
 #[doc = "Change made in a pull request."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GitPullRequestChange {
     #[serde(flatten)]
     pub git_change: GitChange,
@@ -3191,8 +3150,11 @@ pub struct GitPullRequestChange {
     pub change_tracking_id: Option<i32>,
 }
 impl GitPullRequestChange {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(git_change: GitChange) -> Self {
+        Self {
+            git_change,
+            change_tracking_id: None,
+        }
     }
 }
 #[doc = "Represents a comment thread of a pull request. A thread contains meta data about the file it was left on (if any) along with one or more comments (an initial comment and the subsequent replies)."]
@@ -6256,7 +6218,7 @@ impl TfvcBranchRef {
     }
 }
 #[doc = "A change."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TfvcChange {
     #[serde(flatten)]
     pub change: Change,
@@ -6276,8 +6238,12 @@ pub struct TfvcChange {
     pub pending_version: Option<i32>,
 }
 impl TfvcChange {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(change: Change) -> Self {
+        Self {
+            change,
+            merge_sources: Vec::new(),
+            pending_version: None,
+        }
     }
 }
 #[doc = "A collection of changes."]


### PR DESCRIPTION
Use vsts-api-patcher to fix spec to match actual responses.

New response structure looks like this:
```json
GitCommitChanges {
    change_counts: Some(
        Object({
            "Add": Number(
                30,
            ),
            "Delete": Number(
                1,
            ),
            "Edit": Number(
                3,
            ),
        }),
    ),
    changes: [
        GitChange {
            change: Change {
                change_type: Edit,
                item: Object({
                    "commitId": String(
                        "61c7cac38ecd26919ec32ccfb98a581db8a9e6a7",
                    ),
                    "gitObjectType": String(
                        "blob",
                    ),
                    "objectId": String(
                        "d3c8fd29a453bdc93e10a99215b71c0303396bb3",
                    ),
                    "originalObjectId": String(
                        "e5fb30ed8b763e1c8fd24b29497ebf1add43df23",
                    ),
                    "path": String(
                        "/.gitignore",
                    ),
                    "url": String(
                        "https://dev.azure.com/<redacted>",
                    ),
                }),
            },
        },
...
    ]
}
```

At some point it would be nice to replace the `change_count` and `item` JSON Value types with structs, but I'm not going to do this now as I currently have no definitive list of all the fields.

Fixes https://github.com/microsoft/azure-devops-rust-api/issues/31