### PR TITLE
Example diff files base and target branch

### DIFF
--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -105,6 +105,10 @@ name = "git_pr_files_changed"
 required-features = ["git"]
 
 [[example]]
+name = "git_diff_files_between_base_and_target_branch"
+required-features = ["git"]
+
+[[example]]
 name = "pipelines"
 required-features = ["pipelines"]
 

--- a/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
+++ b/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
@@ -35,15 +35,15 @@ async fn main() -> Result<()> {
     let repository_name = env::args()
         .nth(1)
         .expect("Usage: git_diff_files_between_base_and_target_branch <repository-name> <base-branch-name> <target-branch-name>");
- 
+
     let base_branch_name = env::args()
         .nth(2)
-        .expect("Usage: git_diff_files_between_base_and_target_branch <repository-name> <base-branch-name> <target-branch-name>");        
+        .expect("Usage: git_diff_files_between_base_and_target_branch <repository-name> <base-branch-name> <target-branch-name>");
 
     let target_branch_name = env::args()
         .nth(3)
         .expect("Usage: git_diff_files_between_base_and_target_branch <repository-name> <base-branch-name> <target-branch-name>");
-        
+
     // Set the max number of commits to get, default is 100
     let top_commits: i32 = 500;
 
@@ -67,10 +67,10 @@ async fn main() -> Result<()> {
     // Get files name which are present in the target branch
     for diff in diffs.iter() {
         let git_object_type = diff.change.item["gitObjectType"].as_str().unwrap();
-        if git_object_type == "blob"{
+        if git_object_type == "blob" {
             let file_name = diff.change.item["path"].as_str().unwrap();
             files_diff_between_branches.insert(file_name.to_string());
-    }
+        }
     }
 
     // Unique files changed in the PR

--- a/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
+++ b/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// git_diff_files_between_base_and_target_branch.rs
+// Getting files modified in the branch
+use anyhow::Result;
+use azure_devops_rust_api::git;
+use azure_devops_rust_api::Credential;
+use std::collections::HashSet;
+use std::env;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+
+    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
+    let credential = match env::var("ADO_TOKEN") {
+        Ok(token) => {
+            println!("Authenticate using PAT provided via $ADO_TOKEN");
+            Credential::from_pat(token)
+        }
+        Err(_) => {
+            println!("Authenticate using Azure CLI");
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+        }
+    };
+
+    // Get ADO server configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+
+    // Getting repo, base and target branch name from command line
+    let repository_name = env::args()
+        .nth(1)
+        .expect("Usage: git_diff_files_between_base_and_target_branch <repository-name> <base-branch-name> <target-branch-name>");
+ 
+    let base_branch_name = env::args()
+        .nth(2)
+        .expect("Usage: git_diff_files_between_base_and_target_branch <repository-name> <base-branch-name> <target-branch-name>");        
+
+    let target_branch_name = env::args()
+        .nth(3)
+        .expect("Usage: git_diff_files_between_base_and_target_branch <repository-name> <base-branch-name> <target-branch-name>");
+        
+    // Set the max number of commits to get, default is 100
+    let top_commits: i32 = 500;
+
+    // Create a git client
+    let git_client = git::ClientBuilder::new(credential).build();
+
+    // Get diff client between branches
+    let diffs = git_client
+        .diffs_client()
+        .get(organization, repository_name, project)
+        .top(top_commits)
+        .base_version(base_branch_name)
+        .target_version(target_branch_name)
+        .into_future()
+        .await?
+        .changes;
+
+    // Record unique filenames which are changed in the PR
+    let mut files_diff_between_branches = HashSet::<String>::new();
+
+    // Get files name which are present in the target branch
+    for diff in diffs.iter() {
+        let git_object_type = diff.change.item["gitObjectType"].as_str().unwrap();
+        if git_object_type == "blob"{
+            let file_name = diff.change.item["path"].as_str().unwrap();
+            files_diff_between_branches.insert(file_name.to_string());
+    }
+    }
+
+    // Unique files changed in the PR
+    println!("These files are modified in pr(target) branch:");
+    for file_name in files_diff_between_branches.iter() {
+        println!("{}", file_name)
+    }
+
+    Ok(())
+}

--- a/azure_devops_rust_api/run_all_examples
+++ b/azure_devops_rust_api/run_all_examples
@@ -36,6 +36,7 @@ cargo run --example git_repo_get --features="git" $ADO_PROJECT_NAME
 cargo run --example git_repo_list --features="git"
 cargo run --example git_pr_commits  --features="git" $ADO_REPO_NAME $ADO_PR_ID
 cargo run --example git_pr_files_changed  --features="git" $ADO_REPO_NAME $ADO_PR_ID
+cargo run --example git_diff_files_between_base_and_target_branch --features="git" $ADO_REPO_NAME $ADO_BASE_BRANCH $ADO_TARGET_BRANCH
 cargo run --example git_pr_work_items  --features="git" $ADO_REPO_NAME $ADO_PR_ID
 cargo run --example graph_query --features="graph" $ADO_USER_EMAIL
 cargo run --example pipeline_preview --features="pipelines" $ADO_PROJECT_NAME


### PR DESCRIPTION

This example gives you files which differ between two branches. (In your pull request if there are multiple commits and in between those commits you have merged changes from main branch, then   this will ignore files changed in main branches and will only show the changes which are done in the actual pull request by the user.)

**Command Example:**
`cargo run --example git_diff_files_between_base_and_target_branch --features="git" $ADO_REPO_NAME $ADO_BASE_BRANCH  $ADO_TARGET_BRANCH`

**Example Output:**
![image](https://user-images.githubusercontent.com/110555003/190212281-085481c8-74de-49d1-946c-0c89798123e6.png)
