### PR TITLE
Added example for service hooks

### DIFF
--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -117,6 +117,10 @@ name = "git_diff_files_between_base_and_target_branch"
 required-features = ["git"]
 
 [[example]]
+name = "hooks_list"
+required-features = ["hooks"]
+
+[[example]]
 name = "ims_query"
 required-features = ["ims"]
 

--- a/azure_devops_rust_api/examples/hooks_list.rs
+++ b/azure_devops_rust_api/examples/hooks_list.rs
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // hooks_list.rs
-// Service hooks Example
+// Service hooks example
 use anyhow::Result;
 use azure_devops_rust_api::hooks;
 use azure_devops_rust_api::Credential;
 use std::env;
 use std::sync::Arc;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
@@ -19,7 +20,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
     // Get ADO server configuration via environment variables
@@ -47,7 +48,7 @@ async fn main() -> Result<()> {
         .value;
     println!("{:#?}", service_hook_publishers);
 
-    // Get all publishers
+    // Get all subscriptions
     println!("The service hook subscriptions are:");
     let service_hook_subscriptions = hook_client
         .subscriptions_client()

--- a/azure_devops_rust_api/examples/hooks_list.rs
+++ b/azure_devops_rust_api/examples/hooks_list.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// hooks_list.rs
+// Service hooks Example
+use anyhow::Result;
+use azure_devops_rust_api::hooks;
+use azure_devops_rust_api::Credential;
+use std::env;
+use std::sync::Arc;
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
+    let credential = match env::var("ADO_TOKEN") {
+        Ok(token) => {
+            println!("Authenticate using PAT provided via $ADO_TOKEN");
+            Credential::from_pat(token)
+        }
+        Err(_) => {
+            println!("Authenticate using Azure CLI");
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+        }
+    };
+    // Get ADO server configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    // Create service hook client
+    let hook_client = hooks::ClientBuilder::new(credential).build();
+
+    // Get all consumers
+    println!("The service hook consumers are:");
+    let service_hook_consumers = hook_client
+        .consumers_client()
+        .list(&organization)
+        .into_future()
+        .await?
+        .value;
+    println!("{:#?}", service_hook_consumers);
+
+    // Get all publishers
+    println!("The service hook publishers are:");
+    let service_hook_publishers = hook_client
+        .publishers_client()
+        .list(&organization)
+        .into_future()
+        .await?
+        .value;
+    println!("{:#?}", service_hook_publishers);
+
+    // Get all publishers
+    println!("The service hook subscriptions are:");
+    let service_hook_subscriptions = hook_client
+        .subscriptions_client()
+        .list(&organization)
+        .into_future()
+        .await?
+        .value;
+    println!("{:#?}", service_hook_subscriptions);
+
+    Ok(())
+}

--- a/azure_devops_rust_api/run_all_examples
+++ b/azure_devops_rust_api/run_all_examples
@@ -55,6 +55,7 @@ cargo run --example git_pr_commits  --features="git" $ADO_REPO_NAME $ADO_PR_ID
 cargo run --example git_pr_files_changed  --features="git" $ADO_REPO_NAME $ADO_PR_ID
 cargo run --example git_pr_work_items  --features="git" $ADO_REPO_NAME $ADO_PR_ID
 cargo run --example graph_query --features="graph" $ADO_USER_EMAIL
+cargo run --example hooks_list --features="hooks"
 cargo run --example pipeline_preview --features="pipelines" $ADO_PROJECT_NAME
 cargo run --example pipelines --features="pipelines" $ADO_PROJECT_NAME
 cargo run --example service_endpoint --features="service_endpoint"


### PR DESCRIPTION
Added example to get all the service hooks (publishers/consumers/subscriptions)

**Command:**
`cargo run --example hooks_list --features="hooks"
`