### PR TITLE
Azure SDK upgrade

### DIFF
--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -19,7 +19,7 @@ publish = ["crates-io"]
 doctest = false
 
 [dependencies]
-azure_core = { version = "0.4", default-features = true }
+azure_core = { version = "0.5", default-features = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -28,7 +28,7 @@ base64 = "0.13"
 time = "0.3"
 
 [dev-dependencies]
-azure_identity = "0.5"
+azure_identity = "0.6"
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1"
 log = "0.4"

--- a/azure_devops_rust_api/README.md
+++ b/azure_devops_rust_api/README.md
@@ -31,7 +31,7 @@ Example usage (from [examples/git_repo_list.rs](examples/git_repo_list.rs)):
         Err(_) => {
             println!("Authenticate using Azure CLI");
             Credential::from_token_credential(
-                Arc::new(azure_identity::AzureCliCredential {})
+                Arc::new(azure_identity::AzureCliCredential::new())
             )
         }
     };

--- a/azure_devops_rust_api/examples/build_list.rs
+++ b/azure_devops_rust_api/examples/build_list.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/client_pipeline_policy.rs
+++ b/azure_devops_rust_api/examples/client_pipeline_policy.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/core_org_projects.rs
+++ b/azure_devops_rust_api/examples/core_org_projects.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/extension_management_list.rs
+++ b/azure_devops_rust_api/examples/extension_management_list.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/git_commit_changes.rs
+++ b/azure_devops_rust_api/examples/git_commit_changes.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("INFO:Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
+++ b/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/git_pr_commits.rs
+++ b/azure_devops_rust_api/examples/git_pr_commits.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("INFO:Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/git_pr_create.rs
+++ b/azure_devops_rust_api/examples/git_pr_create.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("INFO:Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/git_pr_files_changed.rs
+++ b/azure_devops_rust_api/examples/git_pr_files_changed.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("INFO:Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/git_pr_work_items.rs
+++ b/azure_devops_rust_api/examples/git_pr_work_items.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("INFO:Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/git_repo_get.rs
+++ b/azure_devops_rust_api/examples/git_repo_get.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/git_repo_list.rs
+++ b/azure_devops_rust_api/examples/git_repo_list.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/graph_query.rs
+++ b/azure_devops_rust_api/examples/graph_query.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/ims_query.rs
+++ b/azure_devops_rust_api/examples/ims_query.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/pipeline_preview.rs
+++ b/azure_devops_rust_api/examples/pipeline_preview.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/pipelines.rs
+++ b/azure_devops_rust_api/examples/pipelines.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/policy.rs
+++ b/azure_devops_rust_api/examples/policy.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/service_endpoint.rs
+++ b/azure_devops_rust_api/examples/service_endpoint.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 

--- a/azure_devops_rust_api/examples/wit.rs
+++ b/azure_devops_rust_api/examples/wit.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
         }
         Err(_) => {
             println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential {}))
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
         }
     };
 


### PR DESCRIPTION
Upgrade Azure SDK crates:
- azure_core 0.4 to 0.5
- azure_identity 0.5. to 0.6

`azure_identity` upgrade requires changes to creation of AzureCliCredential.  Now need to use:
- `azure_identity::AzureCliCredential::new()`