### PR TITLE
fixed issue with type on probation-retries in service hooks

### DIFF
--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -146,6 +146,7 @@ impl Patcher {
         Patcher::patch_git_pull_request_create,
         Patcher::patch_ims_identity_base,
         Patcher::patch_input_validation_min_max,
+        Patcher::patch_probation_retries_type,
         // This must be done after the other patches
         Patcher::patch_definition_required_fields,
     ];
@@ -675,6 +676,26 @@ impl Patcher {
         }
         match key {
             ["definitions", "InputValidation", "properties", "minValue" | "maxValue"] => {
+                let mut value = value.clone();
+                value["type"] = JsonValue::from("number");
+                value["format"] = JsonValue::from("float");
+                Some(value)
+            }
+            _ => None,
+        }
+    }
+
+    fn patch_probation_retries_type(
+        &mut self,
+        key: &[&str],
+        value: &JsonValue,
+    ) -> Option<JsonValue> {
+        // Only applies to hooks specs
+        if !self.spec_path.ends_with("serviceHooks.json") {
+            return None;
+        }
+        match key {
+            ["definitions", "Subscription", "properties", "probationRetries"] => {
                 let mut value = value.clone();
                 value["type"] = JsonValue::from("number");
                 value["format"] = JsonValue::from("float");


### PR DESCRIPTION
In the services hooks `probationRetries` was causing issue, due to data type with below error 

![image](https://user-images.githubusercontent.com/110555003/192667244-5e876bbc-bcee-44dd-8fc7-86b638bbb7bc.png)

Added patch method `patch_probation_retries_type` to fix this problem, service hooks subscription is now able to fetch the data without error
![image](https://user-images.githubusercontent.com/110555003/192668099-e3a3cdde-afba-46b6-9218-e79e90d151ec.png)


