### PR TITLE
added example for the distributed task

### DIFF
--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -86,6 +86,10 @@ name = "core_project_teams"
 required-features = ["core"]
 
 [[example]]
+name = "distributed_task"
+required-features = ["distributed_task"]
+
+[[example]]
 name = "extension_management_list"
 required-features = ["extension_management"]
 

--- a/azure_devops_rust_api/examples/distributed_task.rs
+++ b/azure_devops_rust_api/examples/distributed_task.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
 
     // Create distributed task client
     let distributed_task_client = distributed_task::ClientBuilder::new(credential).build();
-    
+
     //  Get a list of agent pools for the org
     println!("Agents pools for the org are:");
     let distributed_task_agents_pools = distributed_task_client

--- a/azure_devops_rust_api/examples/distributed_task.rs
+++ b/azure_devops_rust_api/examples/distributed_task.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// distributed_task.rs
+// Distributed Task example
+use anyhow::Result;
+use azure_devops_rust_api::distributed_task;
+use azure_devops_rust_api::Credential;
+use std::env;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
+    let credential = match env::var("ADO_TOKEN") {
+        Ok(token) => {
+            println!("Authenticate using PAT provided via $ADO_TOKEN");
+            Credential::from_pat(token)
+        }
+        Err(_) => {
+            println!("Authenticate using Azure CLI");
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
+        }
+    };
+    // Get ADO server configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+
+    // Create distributed task client
+    let distributed_task_client = distributed_task::ClientBuilder::new(credential).build();
+    
+    //  Get a list of agent pools for the org
+    println!("Agents pools for the org are:");
+    let distributed_task_agents_pools = distributed_task_client
+        .pools_client()
+        .get_agent_pools(&organization)
+        .into_future()
+        .await?
+        .value;
+    println!("{:#?}", distributed_task_agents_pools);
+
+    //  Get a list of agent queues for the project
+    println!("Agents queues for the project are:");
+    let distributed_task_agent_queues = distributed_task_client
+        .queues_client()
+        .get_agent_queues(&organization, &project)
+        .into_future()
+        .await?
+        .value;
+    println!("{:#?}", distributed_task_agent_queues);
+
+    // Get all variable groups for the project
+    println!("Variable groups for the project are:");
+    let distributed_task_variable_groups = distributed_task_client
+        .variablegroups_client()
+        .get_variable_groups(&organization, &project)
+        .into_future()
+        .await?
+        .value;
+    println!("{:#?}", distributed_task_variable_groups);
+
+    Ok(())
+}

--- a/azure_devops_rust_api/run_all_examples
+++ b/azure_devops_rust_api/run_all_examples
@@ -49,6 +49,7 @@ set -x
 cargo run --example build_list --features="build"
 cargo run --example core_org_projects --features="core"
 cargo run --example core_project_teams --features="core"
+cargo run --example distributed_task --features="distributed_task"
 cargo run --example extension_management_list --features="extension_management"
 cargo run --example git_repo_get --features="git" $ADO_PROJECT_NAME
 cargo run --example git_repo_list --features="git"


### PR DESCRIPTION
Added example for the distributed task to get agent pools, queues and variable groups.

**Command:**
`cargo run --example distributed_task --features="distributed_task"`

**Example Output:**
![image](https://user-images.githubusercontent.com/110555003/193281702-50c21a36-bacc-4e2f-a6e1-3b2ba886c332.png)
