### PR TITLE
added example for permissions report

### DIFF
--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -134,6 +134,10 @@ name = "ims_query"
 required-features = ["ims"]
 
 [[example]]
+name = "permissions_report"
+required-features = ["permissions_report"]
+
+[[example]]
 name = "pipelines"
 required-features = ["pipelines"]
 

--- a/azure_devops_rust_api/examples/permissions_report.rs
+++ b/azure_devops_rust_api/examples/permissions_report.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// permissions_report.rs
+// Permissions report example
+use anyhow::Result;
+use azure_devops_rust_api::permissions_report;
+use azure_devops_rust_api::Credential;
+use std::env;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
+    let credential = match env::var("ADO_TOKEN") {
+        Ok(token) => {
+            println!("Authenticate using PAT provided via $ADO_TOKEN");
+            Credential::from_pat(token)
+        }
+        Err(_) => {
+            println!("Authenticate using Azure CLI");
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
+        }
+    };
+    // Get ADO server configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+
+    // Create permissions_report client
+    let permissions_report_client = permissions_report::ClientBuilder::new(credential).build();
+
+    // Get Permissions reports
+    println!("Permissions reports:");
+    let permissions_reports = permissions_report_client
+        .permissions_report_client()
+        .list(&organization)
+        .into_future()
+        .await?
+        .value;
+    println!("{:#?}", permissions_reports);
+
+    Ok(())
+}

--- a/azure_devops_rust_api/run_all_examples
+++ b/azure_devops_rust_api/run_all_examples
@@ -59,6 +59,7 @@ cargo run --example git_pr_files_changed  --features="git" $ADO_REPO_NAME $ADO_P
 cargo run --example git_pr_work_items  --features="git" $ADO_REPO_NAME $ADO_PR_ID
 cargo run --example graph_query --features="graph" $ADO_USER_EMAIL
 cargo run --example hooks_list --features="hooks"
+cargo run --example permissions_report --features="permissions_report"
 cargo run --example pipeline_preview --features="pipelines" $ADO_PROJECT_NAME
 cargo run --example pipelines --features="pipelines" $ADO_PROJECT_NAME
 cargo run --example release --features="release"


### PR DESCRIPTION
Added example for get permissions report

**Command:**
`cargo run --example permissions_report --features="permissions_report"`

Example Output:
![image](https://user-images.githubusercontent.com/110555003/193649014-ac88c8c6-8c27-4cce-a66e-98d0abbc4e89.png)
