### PR TITLE
added example to search repo in a project

### DIFF
--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -162,6 +162,10 @@ name = "search_code"
 required-features = ["search"]
 
 [[example]]
+name = "search_repositories"
+required-features = ["search"]
+
+[[example]]
 name = "test_runs_list"
 required-features = ["test"]
 

--- a/azure_devops_rust_api/examples/search_repositories.rs
+++ b/azure_devops_rust_api/examples/search_repositories.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// search_code.rs
+// Search code example.
+use anyhow::Result;
+use azure_devops_rust_api::search;
+use azure_devops_rust_api::Credential;
+use std::env;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+
+    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
+    let credential = match env::var("ADO_TOKEN") {
+        Ok(token) => {
+            println!("Authenticate using PAT provided via $ADO_TOKEN");
+            Credential::from_pat(token)
+        }
+        Err(_) => {
+            println!("Authenticate using Azure CLI");
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
+        }
+    };
+
+    // Get ADO configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+
+    let repository_name = env::args()
+        .nth(1)
+        .expect("Usage: Repo name to be searched <repository-name>");
+
+    // Create a search client
+    println!("Create search client");
+    let search_client = search::ClientBuilder::new(credential).build();
+
+    // Do the search
+    println!("Search...");
+    let search_results = search_client
+        .repositories_client()
+        .get(organization, project, repository_name)
+        .into_future()
+        .await?;
+
+    println!("{:#?}", search_results);
+    Ok(())
+}

--- a/azure_devops_rust_api/run_all_examples
+++ b/azure_devops_rust_api/run_all_examples
@@ -66,6 +66,7 @@ cargo run --example pipelines --features="pipelines" $ADO_PROJECT_NAME
 cargo run --example release --features="release"
 cargo run --example service_endpoint --features="service_endpoint"
 cargo run --example search_code --features="search"
+cargo run --example search_repositories --features="search" $ADO_REPO_NAME
 cargo run --example test_runs_list --features="test"
 cargo run --example client_pipeline_policy --features="git"
 


### PR DESCRIPTION
Added example to search a repo in a project

**Example Command:**
`cargo run --example search_repositories --features="search" $ADO_REPO_NAME`

**Example Output:**
![image](https://user-images.githubusercontent.com/110555003/193707285-56c13d3b-b21a-4ae4-ad6e-b91f85cbbc7a.png)
