### PR TITLE
fix: patch the header used in wiki page updates to 'if-match' instead of 'version'

### DIFF
--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -186,6 +186,10 @@ name = "client_pipeline_policy"
 required-features = ["git"]
 
 [[example]]
+name = "wiki_pages_create_or_update"
+required-features = ["wiki"]
+
+[[example]]
 name = "wit"
 required-features = ["wit"]
 

--- a/azure_devops_rust_api/examples/wiki_pages_create_or_update.rs
+++ b/azure_devops_rust_api/examples/wiki_pages_create_or_update.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// wiki_pages_create_or_update.rs
+// Wiki page creation/update example.
+use anyhow::Result;
+use azure_devops_rust_api::wiki::{self, pages};
+use azure_devops_rust_api::Credential;
+use std::env;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+
+    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
+    let credential = match env::var("ADO_TOKEN") {
+        Ok(token) => {
+            println!("Authenticate using PAT provided via $ADO_TOKEN");
+            Credential::from_pat(token)
+        }
+        Err(_) => {
+            println!("Authenticate using Azure CLI");
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
+        }
+    };
+
+    // Get ADO configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+    // Get wiki params based on arguments
+    let wiki_id = env::args()
+        .nth(1)
+        .expect("Usage: Wiki ID to create/update a page under <wiki-id>");
+    let wiki_page_path = env::args()
+        .nth(2)
+        .expect("Usage: Wiki page path to create/update <wiki-page-path>");
+    let wiki_content = env::args()
+        .nth(3)
+        .expect("Usage: Wiki content to be inserted into the page <wiki-content>");
+
+    // Create a wiki pages client
+    let wiki_pages_client = wiki::ClientBuilder::new(credential).build().pages_client();
+    // To update an existing wiki page the page version, called an eTag, must be supplied in an `If-Match` header. NB: the RequestBuilder will insert this header for you when you call it with the `eTag`.
+    // This function call returns `Some(String)` containing the eTag if the pages exists, otherwise
+    // it will return `None` indicating that the page needs to be created.
+    let op_etag: Option<String> = get_wiki_page_etag(
+        &wiki_pages_client,
+        &wiki_page_path,
+        &organization,
+        &project,
+        &wiki_id,
+    )
+    .await;
+    // The content to be displayed on the page
+    let wiki_body = wiki::models::WikiPageCreateOrUpdateParameters {
+        content: Some(wiki_content),
+    };
+
+    // Based on whether the page exists either update or create
+    match op_etag {
+        Some(etag) => {
+            println!("Updating wiki page...");
+            match wiki_pages_client
+                .create_or_update(
+                    organization,
+                    wiki_body,
+                    project,
+                    wiki_id,
+                    wiki_page_path,
+                    etag,
+                )
+                .into_future()
+                .await
+            {
+                Ok(p) => println!("Page updated: {:?}", p.remote_url),
+                Err(e) => panic!("Failed to update wiki page: {}", e),
+            }
+        }
+        None => {
+            println!("Creating wiki page...");
+            match wiki_pages_client
+                .create_or_update(
+                    organization,
+                    wiki_body,
+                    project,
+                    wiki_id,
+                    wiki_page_path,
+                    "a123", // fake version value, unused in creation operation
+                )
+                .into_future()
+                .await
+            {
+                Ok(p) => println!("Page created: {:?}", p.remote_url),
+                Err(e) => panic!("Failed to create wiki page: {}", e),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Using a [pages::Client] attempt to retrieve the version (`eTag`) of a wiki page at `page_path`.
+/// The `eTag` is required when updating an existing wiki page.
+///
+/// If the page does not exist [None] is returned and in such cases the page needs to be created
+async fn get_wiki_page_etag(
+    client: &pages::Client,
+    page_path: &String,
+    organisation: &String,
+    project: &String,
+    wiki_id: &String,
+) -> Option<String> {
+    match client
+        .get_page(organisation, project, wiki_id)
+        .path(page_path)
+        .send()
+        .await
+    {
+        Ok(r) => {
+            let etag = r.headers().e_tag().unwrap().to_owned();
+            println!("Etag for page {}, {}", page_path, etag);
+            Some(etag)
+        }
+        Err(e) => {
+            // If the response is a 404 then we need to create the page
+            if e.as_http_error()
+                .expect("Failed cast to http error")
+                .status()
+                .canonical_reason()
+                == "Not Found"
+            {
+                println!("Wiki page does not exist");
+                None
+            } else {
+                panic!("Failed to retrieve etag: {}", e)
+            }
+        }
+    }
+}

--- a/azure_devops_rust_api/run_all_examples
+++ b/azure_devops_rust_api/run_all_examples
@@ -9,10 +9,13 @@ ADO_PROJECT_NAME=$1
 ADO_USER_EMAIL=$2
 ADO_REPO_NAME=$3
 ADO_PR_ID=$4
+ADO_WIKI_ID=$5
+ADO_WIKI_PAGE_PATH=$6
+ADO_WIKI_CONTENT=$7
 
 usage () {
     echo "Usage:"
-    echo "  ./run_all_examples <project_name> <user_email_address> <repo_name> <pr_id>"
+    echo "  ./run_all_examples <project_name> <user_email_address> <repo_name> <pr_id> <wiki_id> <wiki_page_path> <wiki_content>"
 }
 
 if [ -z "$ADO_PROJECT_NAME" ];
@@ -43,6 +46,27 @@ then
     exit 1
 fi
 
+if [ -z "$ADO_WIKI_ID" ];
+then
+    echo "Error: Missing wiki_id parameter"
+    usage
+    exit 1
+fi
+
+if [ -z "$ADO_WIKI_PAGE_PATH" ];
+then
+    echo "Error: Missing wiki_page_path parameter"
+    usage
+    exit 1
+fi
+
+if [ -z "$ADO_WIKI_CONTENT" ];
+then
+    echo "Error: Missing wiki_content parameter"
+    usage
+    exit 1
+fi
+
 # Enable trace
 set -x
 
@@ -69,5 +93,6 @@ cargo run --example search_code --features="search"
 cargo run --example search_repositories --features="search" $ADO_REPO_NAME
 cargo run --example test_runs_list --features="test"
 cargo run --example client_pipeline_policy --features="git"
+cargo run --example wiki_pages_create_or_update --features="wiki" $ADO_WIKI_ID $ADO_WIKI_PAGE_PATH $ADO_WIKI_CONTENT
 
 echo "Done"

--- a/azure_devops_rust_api/src/wiki/mod.rs
+++ b/azure_devops_rust_api/src/wiki/mod.rs
@@ -1055,7 +1055,7 @@ pub mod pages {
         #[doc = "* `project`: Project ID or project name"]
         #[doc = "* `wiki_identifier`: Wiki ID or wiki name."]
         #[doc = "* `path`: Wiki page path."]
-        #[doc = "* `version`: Version of the page on which the change is to be made. Mandatory for `Edit` scenario. To be populated in the If-Match header of the request."]
+        #[doc = "* `if_match`: Version of the page on which the change is to be made. Mandatory for `Edit` scenario. To be populated in the If-Match header of the request."]
         pub fn create_or_update(
             &self,
             organization: impl Into<String>,
@@ -1063,7 +1063,7 @@ pub mod pages {
             project: impl Into<String>,
             wiki_identifier: impl Into<String>,
             path: impl Into<String>,
-            version: impl Into<String>,
+            if_match: impl Into<String>,
         ) -> create_or_update::RequestBuilder {
             create_or_update::RequestBuilder {
                 client: self.0.clone(),
@@ -1072,7 +1072,7 @@ pub mod pages {
                 project: project.into(),
                 wiki_identifier: wiki_identifier.into(),
                 path: path.into(),
-                version: version.into(),
+                if_match: if_match.into(),
                 comment: None,
                 version_descriptor_version: None,
                 version_descriptor_version_options: None,
@@ -1137,7 +1137,7 @@ pub mod pages {
         #[doc = "* `project`: Project ID or project name"]
         #[doc = "* `wiki_identifier`: Wiki ID or wiki name."]
         #[doc = "* `id`: Wiki page ID."]
-        #[doc = "* `version`: Version of the page on which the change is to be made. Mandatory for `Edit` scenario. To be populated in the If-Match header of the request."]
+        #[doc = "* `if_match`: Version of the page on which the change is to be made. Mandatory for `Edit` scenario. To be populated in the If-Match header of the request."]
         pub fn update(
             &self,
             organization: impl Into<String>,
@@ -1145,7 +1145,7 @@ pub mod pages {
             project: impl Into<String>,
             wiki_identifier: impl Into<String>,
             id: i32,
-            version: impl Into<String>,
+            if_match: impl Into<String>,
         ) -> update::RequestBuilder {
             update::RequestBuilder {
                 client: self.0.clone(),
@@ -1154,7 +1154,7 @@ pub mod pages {
                 project: project.into(),
                 wiki_identifier: wiki_identifier.into(),
                 id,
-                version: version.into(),
+                if_match: if_match.into(),
                 comment: None,
             }
         }
@@ -1408,7 +1408,7 @@ pub mod pages {
             pub(crate) project: String,
             pub(crate) wiki_identifier: String,
             pub(crate) path: String,
-            pub(crate) version: String,
+            pub(crate) if_match: String,
             pub(crate) comment: Option<String>,
             pub(crate) version_descriptor_version: Option<String>,
             pub(crate) version_descriptor_version_options: Option<String>,
@@ -1473,7 +1473,7 @@ pub mod pages {
                         let req_body = azure_core::to_json(&this.body)?;
                         let path = &this.path;
                         req.url_mut().query_pairs_mut().append_pair("path", path);
-                        req.insert_header("version", &this.version);
+                        req.insert_header("if-match", &this.if_match);
                         if let Some(comment) = &this.comment {
                             req.url_mut()
                                 .query_pairs_mut()
@@ -1840,7 +1840,7 @@ pub mod pages {
             pub(crate) project: String,
             pub(crate) wiki_identifier: String,
             pub(crate) id: i32,
-            pub(crate) version: String,
+            pub(crate) if_match: String,
             pub(crate) comment: Option<String>,
         }
         impl RequestBuilder {
@@ -1876,7 +1876,7 @@ pub mod pages {
                             .append_pair(azure_core::query_param::API_VERSION, "7.1-preview");
                         req.insert_header("content-type", "application/json");
                         let req_body = azure_core::to_json(&this.body)?;
-                        req.insert_header("version", &this.version);
+                        req.insert_header("if-match", &this.if_match);
                         if let Some(comment) = &this.comment {
                             req.url_mut()
                                 .query_pairs_mut()


### PR DESCRIPTION
When when using either the [Update](https://learn.microsoft.com/en-us/rest/api/azure/devops/wiki/pages/update?view=azure-devops-rest-7.1&tabs=HTTP) or [CreateOrUpdate](https://learn.microsoft.com/en-us/rest/api/azure/devops/wiki/pages/create-or-update?view=azure-devops-rest-7.1&tabs=HTTP) APIs to modify a page in an ADO Wiki the user needs to supply the eTag (page version) in the header of the request.

The docs refer to this [header](https://learn.microsoft.com/en-us/rest/api/azure/devops/wiki/pages/create-or-update?view=azure-devops-rest-7.1&tabs=HTTP#request-headers) with the name `Version`. The auto code generation produces a couple instances where this header is being [created](https://github.com/microsoft/azure-devops-rust-api/blob/main/azure_devops_rust_api/src/wiki/mod.rs):

```rust
req.insert_header("version", &this.version);
```

However the ADO API doesn't recognise `version` as being the acceptable header name and returns an internal server error. Instead the header name should be `If-Match`.

This PR modifies `vsts-api-patcher` to alter the parameters of these two API calls to swap `Version` out with `If-Match`.

A new example has also been included to showcase calling the `create_or_update()` method for creating or updating a wiki page.