### PR TITLE
New examples. Improved GitPullRequest.  Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1]
+
+## Added
+
 - New examples:
   - `git_repo_get_raw_rsp`
   - `artifacts_list`
   - `build_list_continuation_token`
   - `release_logs`
+  - `wiki_pages_create_or_update`
+  - `search_repositories`
+  - `permissions_report`
 - Added new fields to `GitPullRequestCreateOptions`
   - `merge_options`
   - `completion_options`
+
+## Fixed
+
 - Fix `distributedTask` `variableGroupProjectReferences` deserialization of `null` value
 - Fix `extensionManagement` parsing of `flags` fields
   - Change type from an `enum` to a `String`, as field value is a comma-separated list
@@ -164,7 +174,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.6.0...HEAD
+[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.6.1...HEAD
+[0.6.1]: https://github.com/microsoft/azure-devops-rust-api/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.5.3...0.6.0
 [0.5.3]: https://github.com/microsoft/azure-devops-rust-api/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/microsoft/azure-devops-rust-api/compare/0.5.1...0.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New examples:
   - `git_repo_get_raw_rsp`
   - `artifacts_list`
+  - `build_list_continuation_token`
+  - `release_logs`
+- Added new fields to `GitPullRequestCreateOptions`
+  - `merge_options`
+  - `completion_options`
 - Fix `distributedTask` `variableGroupProjectReferences` deserialization of `null` value
 - Fix `extensionManagement` parsing of `flags` fields
   - Change type from an `enum` to a `String`, as field value is a comma-separated list
@@ -32,11 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `InputValidation` fields `minValue` and `maxValue` need to be `number`/`float`
   - `Subscription` field `probationRetries` needs to be `integer`/`int32`
 - New examples:
-  - code_search
-  - hooks_list
-  - ims_query
-  - extension_management_list
-  - test_rust_list
+  - `code_search`
+  - `hooks_list`
+  - `ims_query`
+  - `extension_management_list`
+  - `test_rust_list`
 
 ## [0.5.3]
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ git commit -m "Updated vsts-rest-api-specs to latest revision"
   - `autorust` is MIT licensed
   - `autorust` includes an `openapi` module, which is also MIT licensed
 - Generates crate for API version 7.1 (latest API version).
+- The [azure-devops-python-api](https://github.com/Microsoft/azure-devops-python-api) can be a useful reference when investigating API issues.
 
 ## Contributing
 

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -178,6 +178,10 @@ name = "build_list"
 required-features = ["build"]
 
 [[example]]
+name = "build_list_continuation_token"
+required-features = ["build"]
+
+[[example]]
 name = "status"
 required-features = ["status"]
 
@@ -196,3 +200,7 @@ required-features = ["wit"]
 [[example]]
 name = "policy"
 required-features = ["policy"]
+
+[[example]]
+name = "release_logs"
+required-features = ["release"]

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_devops_rust_api"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["John Batty <johnbatty@microsoft.com>"]
 description = "Rust API library for Azure DevOps"

--- a/azure_devops_rust_api/examples/build_list_continuation_token.rs
+++ b/azure_devops_rust_api/examples/build_list_continuation_token.rs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// build_list_continuation_token.rs
+// Example demonstrating how to make large queries using continuation tokens.
+use anyhow::{anyhow, Context, Result};
+use azure_core::StatusCode;
+use azure_devops_rust_api::build;
+use azure_devops_rust_api::build::models::{Build, BuildList};
+use azure_devops_rust_api::Credential;
+use serde_json;
+use std::env;
+use std::sync::Arc;
+use time::format_description::well_known::Rfc3339;
+
+const NUM_BUILD_BATCHES: usize = 5;
+
+async fn get_builds(
+    build_client: &build::Client,
+    organization: &str,
+    project: &str,
+    continuation_token: &Option<String>,
+) -> Result<(Vec<Build>, Option<String>)> {
+    let mut list_builder = build_client.builds_client().list(organization, project);
+
+    if let Some(continuation_token) = continuation_token {
+        println!(
+            "Query builds with continuation_token: {}",
+            continuation_token
+        );
+        list_builder = list_builder.continuation_token(continuation_token)
+    } else {
+        println!("Query builds with no continuation_token");
+    }
+
+    let (status, headers, body) = list_builder.send().await?.into_raw_response().deconstruct();
+
+    if status != StatusCode::Ok {
+        println!("Request failed");
+        return Err(anyhow!("Request failed"));
+    }
+
+    let new_continuation_token = headers.get_optional_string(
+        &azure_core::headers::HeaderName::from_static("x-ms-continuationtoken"),
+    );
+
+    let body_data = body.collect_string().await?;
+    let build_list: BuildList = serde_json::from_str(&body_data)
+        .with_context(|| format!("Failed to parse BuildList: {}", &body_data))?;
+
+    println!("Received {} builds", build_list.count.unwrap_or(0));
+
+    Ok((build_list.value, new_continuation_token))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+
+    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
+    let credential = match env::var("ADO_TOKEN") {
+        Ok(token) => {
+            println!("Authenticate using PAT provided via $ADO_TOKEN");
+            Credential::from_pat(token)
+        }
+        Err(_) => {
+            println!("Authenticate using Azure CLI");
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
+        }
+    };
+
+    // Get ADO server configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+
+    // Create a build client
+    let build_client = build::ClientBuilder::new(credential).build();
+
+    let mut continuation_token = None;
+
+    // Query several batches of builds. Each batch has 1000 builds (by default)
+    println!("Num build batches: {}", NUM_BUILD_BATCHES);
+    for batch in 0..NUM_BUILD_BATCHES {
+        let (builds, new_continuation_token) =
+            get_builds(&build_client, &organization, &project, &continuation_token).await?;
+
+        if let Some(build) = builds.iter().next() {
+            println!(
+                "First build of batch {} start time: {}\n",
+                batch,
+                build.start_time.unwrap().format(&Rfc3339)?
+            );
+        }
+        continuation_token = new_continuation_token;
+
+        if continuation_token == None {
+            println!("continuation_token is None - exiting");
+        }
+    }
+
+    Ok(())
+}

--- a/azure_devops_rust_api/examples/git_pr_create.rs
+++ b/azure_devops_rust_api/examples/git_pr_create.rs
@@ -6,7 +6,7 @@
 use anyhow::Result;
 use azure_devops_rust_api::git;
 use azure_devops_rust_api::Credential;
-use git::models::GitPullRequestCreateOptions;
+use git::models::{GitPullRequestCreateOptions, WebApiCreateTagRequestData};
 use std::env;
 use std::sync::Arc;
 
@@ -44,14 +44,21 @@ async fn main() -> Result<()> {
     let git_client = git::ClientBuilder::new(credential).build();
 
     // Create GitPullRequestCreateOptions with all the mandatory parameters
+    println!("Create PR to merge {} => {}", src_branch, target_branch);
     let mut pr_create_options = GitPullRequestCreateOptions::new(
         // Need to specify full git refs path
         format!("refs/heads/{src_branch}"),
         format!("refs/heads/{target_branch}"),
         title,
     );
+
     // Set any additional optional parameters
     pr_create_options.description = Some(description);
+    // Label creation is unfortunately currently not very ergonomic...
+    pr_create_options.labels = vec![
+        WebApiCreateTagRequestData::new("example_label1".to_string()),
+        WebApiCreateTagRequestData::new("example_label2".to_string()),
+    ];
 
     // Define the new PR
     let pr = git_client

--- a/azure_devops_rust_api/examples/release_logs.rs
+++ b/azure_devops_rust_api/examples/release_logs.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// release_logs.rs
+// Release logs example.
+// The log data is saved as a zip file - use `unzip` to extract
+use anyhow::{anyhow, Result};
+use azure_devops_rust_api::release;
+use azure_devops_rust_api::Credential;
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
+    let credential = match env::var("ADO_TOKEN") {
+        Ok(token) => {
+            println!("Authenticate using PAT provided via $ADO_TOKEN");
+            Credential::from_pat(token)
+        }
+        Err(_) => {
+            println!("Authenticate using Azure CLI");
+            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
+        }
+    };
+    // Get ADO server configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+    let release_id: i32 = env::args()
+        .nth(1)
+        .expect("Usage: release-logs <release-id> <output-file>")
+        .parse::<i32>()
+        .ok()
+        .expect("Must Provide release ID");
+    let output_file: String = env::args()
+        .nth(2)
+        .expect("Usage: release-logs <release-id> <output-file>");
+
+    // Create release client
+    let release_client = release::ClientBuilder::new(credential).build();
+
+    // Get release logs
+    println!("\nDownloading release logs for release {}", release_id);
+    let (status, _headers, body) = release_client
+        .releases_client()
+        .get_logs(organization, project, release_id)
+        .send()
+        .await?
+        .into_raw_response()
+        .deconstruct();
+
+    if status != azure_core::StatusCode::Ok {
+        println!("Request failed. status:{}", status);
+        return Err(anyhow!("Request failed"));
+    }
+
+    // Write the data as a zipfile
+    println!("Writing data to zipfile: {}", output_file);
+    let data = body.collect().await?;
+    let mut file = File::create(&output_file)?;
+    file.write_all(&data)?;
+    println!("Logs saved");
+
+    println!("Use 'unzip {}' to extract the logs", output_file);
+
+    Ok(())
+}

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -3458,7 +3458,7 @@ pub struct GitPullRequestCreateOptions {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "crate::serde::deserialize_null_default"
     )]
-    pub labels: Vec<WebApiTagDefinition>,
+    pub labels: Vec<WebApiCreateTagRequestData>,
     #[doc = "The name of the source branch of the pull request."]
     #[serde(rename = "sourceRefName")]
     pub source_ref_name: String,
@@ -3467,6 +3467,20 @@ pub struct GitPullRequestCreateOptions {
     pub target_ref_name: String,
     #[doc = "The title of the pull request."]
     pub title: String,
+    #[doc = "The options which are used when a pull request merge is created."]
+    #[serde(
+        rename = "mergeOptions",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub merge_options: Option<GitPullRequestMergeOptions>,
+    #[doc = "Preferences about how the pull request should be completed."]
+    #[serde(
+        rename = "completionOptions",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub completion_options: Option<GitPullRequestCompletionOptions>,
     #[doc = "Any work item references associated with this pull request."]
     #[serde(
         rename = "workItemRefs",
@@ -3492,6 +3506,8 @@ impl GitPullRequestCreateOptions {
             source_ref_name,
             target_ref_name,
             title,
+            merge_options: None,
+            completion_options: None,
             work_item_refs: Vec::new(),
             reviewers: Vec::new(),
         }
@@ -7529,15 +7545,14 @@ impl VssJsonCollectionWrapperBase {
     }
 }
 #[doc = "The representation of data needed to create a tag definition which is sent across the wire."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct WebApiCreateTagRequestData {
     #[doc = "Name of the tag definition that will be created."]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: String,
 }
 impl WebApiCreateTagRequestData {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(name: String) -> Self {
+        Self { name }
     }
 }
 #[doc = "The representation of a tag definition which is sent across the wire."]

--- a/azure_devops_rust_api/src/serde.rs
+++ b/azure_devops_rust_api/src/serde.rs
@@ -1,6 +1,7 @@
 use serde::de::{Deserialize, Deserializer};
 use std::result::Result;
 
+#[allow(dead_code)]
 pub(crate) fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     T: Default + Deserialize<'de>,

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -651,7 +651,7 @@ impl Patcher {
                                 "description": "The labels associated with the pull request.",
                                 "type": "array",
                                 "items": {
-                                  "$ref": "#/definitions/WebApiTagDefinition"
+                                  "$ref": "#/definitions/WebApiCreateTagRequestData"
                                 }
                               },
                               "sourceRefName": {
@@ -665,6 +665,14 @@ impl Patcher {
                               "title": {
                                 "description": "The title of the pull request.",
                                 "type": "string"
+                              },
+                              "mergeOptions": {
+                                "description": "Options used when the pull request merge runs. These are separate from completion options since completion happens only once and a new merge will run every time the source branch of the pull request changes.",
+                                "$ref": "#/definitions/GitPullRequestMergeOptions"
+                              },
+                              "completionOptions": {
+                                "description": "Options which affect how the pull request will be merged when it is completed.",
+                                "$ref": "#/definitions/GitPullRequestCompletionOptions"
                               },
                               "workItemRefs": {
                                 "description": "Any work item references associated with this pull request.",
@@ -1038,6 +1046,13 @@ impl Patcher {
                 "GitCommitRef",
                 r#"[
                     "commitId"
+                ]"#,
+            ),
+            (
+                "git.json",
+                "WebApiCreateTagRequestData",
+                r#"[
+                    "name"
                 ]"#,
             ),
             (


### PR DESCRIPTION
New examples:
  - `build_list_continuation_token`
    - Demonstrates how requests can be made in batches with continuation tokens
  - `release_logs`
    - Demonstrates how compressed binary data can be downloaded and saved as a file
 
GitPullRequest:
  - Added more parameters to `GitPullRequestCreateOptions`
    -  `merge_options`
    - `completion_options`
  - Added new type for creating labels (tags): `WebApiCreateTagRequestData`
 
Release 0.6.1