### PR TITLE
added example to get manual interventions on a release

### DIFF
--- a/azure_devops_rust_api/examples/release_get_release.rs
+++ b/azure_devops_rust_api/examples/release_get_release.rs
@@ -46,5 +46,15 @@ async fn main() -> Result<()> {
         .await?;
     println!("{:#?}", release);
 
+    // Get manual interventions on a release
+    println!("\nManual interventions:");
+    let manual_interventions = release_client
+        .manual_interventions_client()
+        .list(&organization, &project, release_id)
+        .into_future()
+        .await?
+        .value;
+    println!("{:#?}", manual_interventions);
+
     Ok(())
 }


### PR DESCRIPTION
Command:
`cargo run --example release_get_release --features="release" $RELEASE_ID`

![image](https://user-images.githubusercontent.com/110555003/197347509-7ec2c623-d965-4797-98f8-f61f87a46d8d.png)
