### PR TITLE
examples: Add new utils module for common authentication code

### DIFF
--- a/azure_devops_rust_api/.gitignore
+++ b/azure_devops_rust_api/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 target/
+.env

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -15,25 +15,28 @@ categories = ["api-bindings"]
 license = "MIT"
 readme = "README.md"
 publish = ["crates-io"]
+# Require 1.64.0 for IntoFuture support
+# https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#enhancing-await-with-intofuture
+rust-version = "1.64.0"
 
 [lib]
 doctest = false
 
 [dependencies]
-azure_core = { version = "0.5", default-features = true }
+azure_core = { version = "0.8", default-features = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
 futures = "0.3"
-base64 = "0.13"
+base64 = "0.20"
 time = "0.3"
 
 [dev-dependencies]
-azure_identity = "0.6"
+azure_identity = "0.9"
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1"
 log = "0.4"
-env_logger = "0.9"
+env_logger = "0.10"
 async-trait = "0.1"
 
 [features]

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -15,9 +15,6 @@ categories = ["api-bindings"]
 license = "MIT"
 readme = "README.md"
 publish = ["crates-io"]
-# Require 1.64.0 for IntoFuture support
-# https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#enhancing-await-with-intofuture
-rust-version = "1.64.0"
 
 [lib]
 doctest = false

--- a/azure_devops_rust_api/README.md
+++ b/azure_devops_rust_api/README.md
@@ -23,18 +23,7 @@ Example usage (from [examples/git_repo_list.rs](examples/git_repo_list.rs)):
 ```rust
     // Get authentication credential either from a PAT ("ADO_TOKEN")
     // or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(
-                Arc::new(azure_identity::AzureCliCredential::new())
-            )
-        }
-    };
+    let credential = utils::get_credential()
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION")

--- a/azure_devops_rust_api/examples/artifact_provenance.rs
+++ b/azure_devops_rust_api/examples/artifact_provenance.rs
@@ -9,6 +9,8 @@ use anyhow::Result;
 use azure_devops_rust_api::artifacts;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/artifact_provenance.rs
+++ b/azure_devops_rust_api/examples/artifact_provenance.rs
@@ -7,26 +7,15 @@
 // and, if available, package code repository information.
 use anyhow::Result;
 use azure_devops_rust_api::artifacts;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/artifacts_list.rs
+++ b/azure_devops_rust_api/examples/artifacts_list.rs
@@ -5,26 +5,17 @@
 // Artifacts list example.
 use anyhow::Result;
 use azure_devops_rust_api::artifacts;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
+
+mod utils;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/build_list.rs
+++ b/azure_devops_rust_api/examples/build_list.rs
@@ -8,6 +8,8 @@ use azure_devops_rust_api::build;
 use std::env;
 use time::{ext::NumericalDuration, OffsetDateTime};
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/build_list.rs
+++ b/azure_devops_rust_api/examples/build_list.rs
@@ -5,9 +5,7 @@
 // Repository list example.
 use anyhow::Result;
 use azure_devops_rust_api::build;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 use time::{ext::NumericalDuration, OffsetDateTime};
 
 #[tokio::main]
@@ -15,17 +13,8 @@ async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/build_list_continuation_token.rs
+++ b/azure_devops_rust_api/examples/build_list_continuation_token.rs
@@ -7,10 +7,8 @@ use anyhow::{anyhow, Context, Result};
 use azure_core::StatusCode;
 use azure_devops_rust_api::build;
 use azure_devops_rust_api::build::models::{Build, BuildList};
-use azure_devops_rust_api::Credential;
 use serde_json;
 use std::env;
-use std::sync::Arc;
 use time::format_description::well_known::Rfc3339;
 
 const NUM_BUILD_BATCHES: usize = 5;
@@ -58,17 +56,8 @@ async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/build_list_continuation_token.rs
+++ b/azure_devops_rust_api/examples/build_list_continuation_token.rs
@@ -11,6 +11,8 @@ use serde_json;
 use std::env;
 use time::format_description::well_known::Rfc3339;
 
+mod utils;
+
 const NUM_BUILD_BATCHES: usize = 5;
 
 async fn get_builds(

--- a/azure_devops_rust_api/examples/build_list_sync.rs
+++ b/azure_devops_rust_api/examples/build_list_sync.rs
@@ -9,6 +9,8 @@ use azure_devops_rust_api::build;
 use std::env;
 use time::{ext::NumericalDuration, OffsetDateTime};
 
+mod utils;
+
 fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();

--- a/azure_devops_rust_api/examples/build_list_sync.rs
+++ b/azure_devops_rust_api/examples/build_list_sync.rs
@@ -6,26 +6,15 @@
 // For more info see: https://tokio.rs/tokio/topics/bridging
 use anyhow::Result;
 use azure_devops_rust_api::build;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 use time::{ext::NumericalDuration, OffsetDateTime};
 
 fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/client_pipeline_policy.rs
+++ b/azure_devops_rust_api/examples/client_pipeline_policy.rs
@@ -9,9 +9,7 @@
 
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use azure_core::{Context, Policy, PolicyResult, Request};
@@ -52,17 +50,8 @@ async fn main() -> Result<()> {
     // Initialize logging - set default log level to info
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/client_pipeline_policy.rs
+++ b/azure_devops_rust_api/examples/client_pipeline_policy.rs
@@ -10,6 +10,7 @@
 use anyhow::Result;
 use azure_devops_rust_api::git;
 use std::env;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use azure_core::{Context, Policy, PolicyResult, Request};

--- a/azure_devops_rust_api/examples/client_pipeline_policy.rs
+++ b/azure_devops_rust_api/examples/client_pipeline_policy.rs
@@ -17,6 +17,8 @@ use azure_core::{Context, Policy, PolicyResult, Request};
 use env_logger::Env;
 use log::info;
 
+mod utils;
+
 /// Basic request logger policy
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct RequestLogger {}

--- a/azure_devops_rust_api/examples/core_org_projects.rs
+++ b/azure_devops_rust_api/examples/core_org_projects.rs
@@ -5,26 +5,15 @@
 // Projects from Orgs example.
 use anyhow::Result;
 use azure_devops_rust_api::core;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/core_org_projects.rs
+++ b/azure_devops_rust_api/examples/core_org_projects.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::core;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/core_project_teams.rs
+++ b/azure_devops_rust_api/examples/core_project_teams.rs
@@ -5,26 +5,15 @@
 // Project Teams from organization example.
 use anyhow::Result;
 use azure_devops_rust_api::core;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/core_project_teams.rs
+++ b/azure_devops_rust_api/examples/core_project_teams.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::core;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/distributed_task.rs
+++ b/azure_devops_rust_api/examples/distributed_task.rs
@@ -6,6 +6,8 @@ use anyhow::Result;
 use azure_devops_rust_api::distributed_task;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/distributed_task.rs
+++ b/azure_devops_rust_api/examples/distributed_task.rs
@@ -4,25 +4,16 @@
 // Distributed Task example
 use anyhow::Result;
 use azure_devops_rust_api::distributed_task;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+
+    // Get authentication credential
+    let credential = utils::get_credential();
+
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
     let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");

--- a/azure_devops_rust_api/examples/extension_management_list.rs
+++ b/azure_devops_rust_api/examples/extension_management_list.rs
@@ -6,26 +6,15 @@
 use anyhow::Result;
 use azure_devops_rust_api::extension_management;
 use azure_devops_rust_api::extension_management::models::InstalledExtension;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/extension_management_list.rs
+++ b/azure_devops_rust_api/examples/extension_management_list.rs
@@ -8,6 +8,8 @@ use azure_devops_rust_api::extension_management;
 use azure_devops_rust_api::extension_management::models::InstalledExtension;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_commit_changes.rs
+++ b/azure_devops_rust_api/examples/git_commit_changes.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::git;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_commit_changes.rs
+++ b/azure_devops_rust_api/examples/git_commit_changes.rs
@@ -5,26 +5,15 @@
 // Getting all the commits from a PR example.
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("INFO:Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("INFO:Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
+++ b/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
@@ -5,27 +5,16 @@
 // Getting files modified in the branch
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::collections::HashSet;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
+++ b/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
@@ -8,6 +8,8 @@ use azure_devops_rust_api::git;
 use std::collections::HashSet;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_items_get.rs
+++ b/azure_devops_rust_api/examples/git_items_get.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::git;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_items_get.rs
+++ b/azure_devops_rust_api/examples/git_items_get.rs
@@ -5,26 +5,15 @@
 // Git items (files and folders) get example.
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/git_items_list.rs
+++ b/azure_devops_rust_api/examples/git_items_list.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::git;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_items_list.rs
+++ b/azure_devops_rust_api/examples/git_items_list.rs
@@ -5,26 +5,15 @@
 // Git items (files and folders) list example.
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/git_pr_commits.rs
+++ b/azure_devops_rust_api/examples/git_pr_commits.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::git;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_pr_commits.rs
+++ b/azure_devops_rust_api/examples/git_pr_commits.rs
@@ -5,26 +5,15 @@
 // Getting all the commits from a PR example.
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("INFO:Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("INFO:Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/git_pr_create.rs
+++ b/azure_devops_rust_api/examples/git_pr_create.rs
@@ -5,27 +5,16 @@
 // Create Pull Request example.
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use git::models::{GitPullRequestCreateOptions, WebApiCreateTagRequestData};
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("INFO:Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("INFO:Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     const USAGE: &str =
         "Usage: git_pr_create <repository-name> <src_branch> <target_branch> <title> <description>";

--- a/azure_devops_rust_api/examples/git_pr_create.rs
+++ b/azure_devops_rust_api/examples/git_pr_create.rs
@@ -8,6 +8,8 @@ use azure_devops_rust_api::git;
 use git::models::{GitPullRequestCreateOptions, WebApiCreateTagRequestData};
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_pr_files_changed.rs
+++ b/azure_devops_rust_api/examples/git_pr_files_changed.rs
@@ -5,27 +5,16 @@
 // Getting all the files changed in a PR example.
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::collections::HashSet;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("INFO:Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("INFO:Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/git_pr_files_changed.rs
+++ b/azure_devops_rust_api/examples/git_pr_files_changed.rs
@@ -8,6 +8,8 @@ use azure_devops_rust_api::git;
 use std::collections::HashSet;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_pr_work_items.rs
+++ b/azure_devops_rust_api/examples/git_pr_work_items.rs
@@ -5,7 +5,6 @@
 // Example: Getting work items(s) associated with a PR
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::env;
 use std::sync::Arc;
 
@@ -14,17 +13,8 @@ async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("INFO:Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("INFO:Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/git_pr_work_items.rs
+++ b/azure_devops_rust_api/examples/git_pr_work_items.rs
@@ -6,7 +6,6 @@
 use anyhow::Result;
 use azure_devops_rust_api::git;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -37,6 +36,7 @@ async fn main() -> Result<()> {
         .list(&organization, &repository_name, pull_request_id, &project)
         .into_future()
         .await?;
+
     println!("PR work items:");
     println!("{:#?}", pr_work_items);
 

--- a/azure_devops_rust_api/examples/git_pr_work_items.rs
+++ b/azure_devops_rust_api/examples/git_pr_work_items.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::git;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_repo_get.rs
+++ b/azure_devops_rust_api/examples/git_repo_get.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::git;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_repo_get.rs
+++ b/azure_devops_rust_api/examples/git_repo_get.rs
@@ -5,26 +5,15 @@
 // Repository get example.
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/git_repo_get_raw_rsp.rs
+++ b/azure_devops_rust_api/examples/git_repo_get_raw_rsp.rs
@@ -6,26 +6,15 @@
 // which enables inspection of the response status, headers and body.
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/git_repo_get_raw_rsp.rs
+++ b/azure_devops_rust_api/examples/git_repo_get_raw_rsp.rs
@@ -8,6 +8,8 @@ use anyhow::Result;
 use azure_devops_rust_api::git;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/git_repo_list.rs
+++ b/azure_devops_rust_api/examples/git_repo_list.rs
@@ -5,26 +5,15 @@
 // Repository list example.
 use anyhow::Result;
 use azure_devops_rust_api::git;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/git_repo_list.rs
+++ b/azure_devops_rust_api/examples/git_repo_list.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::git;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/graph_query.rs
+++ b/azure_devops_rust_api/examples/graph_query.rs
@@ -6,26 +6,15 @@
 use anyhow::Result;
 use azure_devops_rust_api::graph;
 use azure_devops_rust_api::graph::models::GraphSubjectQuery;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/graph_query.rs
+++ b/azure_devops_rust_api/examples/graph_query.rs
@@ -8,6 +8,8 @@ use azure_devops_rust_api::graph;
 use azure_devops_rust_api::graph::models::GraphSubjectQuery;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/hooks_list.rs
+++ b/azure_devops_rust_api/examples/hooks_list.rs
@@ -6,6 +6,8 @@ use anyhow::Result;
 use azure_devops_rust_api::hooks;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/hooks_list.rs
+++ b/azure_devops_rust_api/examples/hooks_list.rs
@@ -4,25 +4,16 @@
 // Service hooks example
 use anyhow::Result;
 use azure_devops_rust_api::hooks;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+
+    // Get authentication credential
+    let credential = utils::get_credential();
+
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
     // Create service hook client

--- a/azure_devops_rust_api/examples/ims_query.rs
+++ b/azure_devops_rust_api/examples/ims_query.rs
@@ -5,26 +5,15 @@
 // Identity query example.
 use anyhow::Result;
 use azure_devops_rust_api::ims;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/ims_query.rs
+++ b/azure_devops_rust_api/examples/ims_query.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::ims;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/permissions_report.rs
+++ b/azure_devops_rust_api/examples/permissions_report.rs
@@ -6,6 +6,8 @@ use anyhow::Result;
 use azure_devops_rust_api::permissions_report;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/permissions_report.rs
+++ b/azure_devops_rust_api/examples/permissions_report.rs
@@ -4,25 +4,16 @@
 // Permissions report example
 use anyhow::Result;
 use azure_devops_rust_api::permissions_report;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+
+    // Get authentication credential
+    let credential = utils::get_credential();
+
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
 

--- a/azure_devops_rust_api/examples/pipeline_preview.rs
+++ b/azure_devops_rust_api/examples/pipeline_preview.rs
@@ -8,6 +8,8 @@ use azure_devops_rust_api::pipelines;
 use azure_devops_rust_api::pipelines::models::{Pipeline, RunPipelineParameters};
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/pipeline_preview.rs
+++ b/azure_devops_rust_api/examples/pipeline_preview.rs
@@ -6,26 +6,15 @@
 use anyhow::Result;
 use azure_devops_rust_api::pipelines;
 use azure_devops_rust_api::pipelines::models::{Pipeline, RunPipelineParameters};
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/pipelines.rs
+++ b/azure_devops_rust_api/examples/pipelines.rs
@@ -6,26 +6,15 @@
 use anyhow::Result;
 use azure_devops_rust_api::pipelines;
 use azure_devops_rust_api::pipelines::models::Pipeline;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/pipelines.rs
+++ b/azure_devops_rust_api/examples/pipelines.rs
@@ -8,6 +8,8 @@ use azure_devops_rust_api::pipelines;
 use azure_devops_rust_api::pipelines::models::Pipeline;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/policy.rs
+++ b/azure_devops_rust_api/examples/policy.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::policy;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/policy.rs
+++ b/azure_devops_rust_api/examples/policy.rs
@@ -5,26 +5,15 @@
 // Policy example.
 use anyhow::Result;
 use azure_devops_rust_api::policy;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/release.rs
+++ b/azure_devops_rust_api/examples/release.rs
@@ -4,25 +4,16 @@
 // Release example
 use anyhow::Result;
 use azure_devops_rust_api::release;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+
+    // Get authentication credential
+    let credential = utils::get_credential();
+
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
     let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");

--- a/azure_devops_rust_api/examples/release.rs
+++ b/azure_devops_rust_api/examples/release.rs
@@ -6,6 +6,8 @@ use anyhow::Result;
 use azure_devops_rust_api::release;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/release_get_release.rs
+++ b/azure_devops_rust_api/examples/release_get_release.rs
@@ -6,6 +6,8 @@ use anyhow::Result;
 use azure_devops_rust_api::release;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/release_get_release.rs
+++ b/azure_devops_rust_api/examples/release_get_release.rs
@@ -4,25 +4,16 @@
 // Get a specific release example
 use anyhow::Result;
 use azure_devops_rust_api::release;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+
+    // Get authentication credential
+    let credential = utils::get_credential();
+
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
     let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");

--- a/azure_devops_rust_api/examples/release_logs.rs
+++ b/azure_devops_rust_api/examples/release_logs.rs
@@ -9,6 +9,8 @@ use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/release_logs.rs
+++ b/azure_devops_rust_api/examples/release_logs.rs
@@ -5,27 +5,18 @@
 // The log data is saved as a zip file - use `unzip` to extract
 use anyhow::{anyhow, Result};
 use azure_devops_rust_api::release;
-use azure_devops_rust_api::Credential;
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+
+    // Get authentication credential
+    let credential = utils::get_credential();
+
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
     let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");

--- a/azure_devops_rust_api/examples/search_code.rs
+++ b/azure_devops_rust_api/examples/search_code.rs
@@ -10,6 +10,8 @@ use azure_devops_rust_api::search::models::{
 };
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/search_code.rs
+++ b/azure_devops_rust_api/examples/search_code.rs
@@ -8,26 +8,15 @@ use azure_devops_rust_api::search;
 use azure_devops_rust_api::search::models::{
     CodeSearchRequest, EntitySearchRequest, EntitySearchRequestBase,
 };
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/search_package.rs
+++ b/azure_devops_rust_api/examples/search_package.rs
@@ -8,26 +8,15 @@ use azure_devops_rust_api::search;
 use azure_devops_rust_api::search::models::{
     EntitySearchRequest, EntitySearchRequestBase, PackageSearchRequest,
 };
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/search_package.rs
+++ b/azure_devops_rust_api/examples/search_package.rs
@@ -10,6 +10,8 @@ use azure_devops_rust_api::search::models::{
 };
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/search_repositories.rs
+++ b/azure_devops_rust_api/examples/search_repositories.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::search;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/search_repositories.rs
+++ b/azure_devops_rust_api/examples/search_repositories.rs
@@ -5,26 +5,15 @@
 // Search code example.
 use anyhow::Result;
 use azure_devops_rust_api::search;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/search_work_item.rs
+++ b/azure_devops_rust_api/examples/search_work_item.rs
@@ -8,26 +8,15 @@ use azure_devops_rust_api::search;
 use azure_devops_rust_api::search::models::{
     EntitySearchRequest, EntitySearchRequestBase, WorkItemSearchRequest,
 };
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/search_work_item.rs
+++ b/azure_devops_rust_api/examples/search_work_item.rs
@@ -10,6 +10,8 @@ use azure_devops_rust_api::search::models::{
 };
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/service_endpoint.rs
+++ b/azure_devops_rust_api/examples/service_endpoint.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::service_endpoint;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/service_endpoint.rs
+++ b/azure_devops_rust_api/examples/service_endpoint.rs
@@ -5,26 +5,15 @@
 // Service Endpoint (aka "Service Connection") example.
 use anyhow::Result;
 use azure_devops_rust_api::service_endpoint;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/status.rs
+++ b/azure_devops_rust_api/examples/status.rs
@@ -8,6 +8,8 @@ use azure_devops_rust_api::status;
 use azure_devops_rust_api::status::models::geography_with_health::Health;
 use azure_devops_rust_api::Credential;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/test_runs_list.rs
+++ b/azure_devops_rust_api/examples/test_runs_list.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::test;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging

--- a/azure_devops_rust_api/examples/test_runs_list.rs
+++ b/azure_devops_rust_api/examples/test_runs_list.rs
@@ -1,28 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 // test_runs_list.rs
 // Getting test runs example
 use anyhow::Result;
 use azure_devops_rust_api::test;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+
+    // Get authentication credential
+    let credential = utils::get_credential();
+
     // Get ADO server configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
     let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");

--- a/azure_devops_rust_api/examples/utils/mod.rs
+++ b/azure_devops_rust_api/examples/utils/mod.rs
@@ -14,11 +14,21 @@ pub fn get_credential() -> Credential {
         }
         Err(_) => {
             println!("Authenticate using auto-refereshing DefaultAzureCredential");
-            // Authenticate using one of:
+            // `DefaultAzureCredential` can authenticate using one of:
             // - `EnvironmentCredential`
             // - `ManagedIdentityCredential`
             // - `AzureCliCredential`
-            let default_azure_credential = Arc::new(DefaultAzureCredential::default());
+            // For examples we just want to use AzureCliCredential, so exclude the
+            // other mechanisms.
+            // It would be simpler to directly create `AzureCliCredential` here, but I wanted to
+            // demonstrate use of `DefaultAzureCredentialBuilder`.
+            let default_azure_credential = Arc::new(
+                DefaultAzureCredentialBuilder::new()
+                    .exclude_environment_credential()
+                    .exclude_managed_identity_credential()
+                    .build(),
+            );
+
             // Use the `AutoRefreshingTokenCredential` wrapper to cache the credentials,
             // refreshing when required.
             let auto_refreshing_credential =

--- a/azure_devops_rust_api/examples/utils/mod.rs
+++ b/azure_devops_rust_api/examples/utils/mod.rs
@@ -5,6 +5,7 @@ use azure_devops_rust_api::Credential;
 use azure_identity::{AutoRefreshingTokenCredential, DefaultAzureCredentialBuilder};
 use std::sync::Arc;
 
+#[allow(dead_code)]
 pub fn get_credential() -> Credential {
     // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
     match std::env::var("ADO_TOKEN") {

--- a/azure_devops_rust_api/examples/utils/mod.rs
+++ b/azure_devops_rust_api/examples/utils/mod.rs
@@ -1,0 +1,29 @@
+use azure_devops_rust_api::Credential;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use azure_identity::{AutoRefreshingTokenCredential, DefaultAzureCredential};
+use std::sync::Arc;
+
+pub fn get_credential() -> Credential {
+    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli
+    match std::env::var("ADO_TOKEN") {
+        Ok(token) => {
+            println!("Authenticate using PAT provided via $ADO_TOKEN");
+            Credential::from_pat(token)
+        }
+        Err(_) => {
+            println!("Authenticate using auto-refereshing DefaultAzureCredential");
+            // Authenticate using one of:
+            // - `EnvironmentCredential`
+            // - `ManagedIdentityCredential`
+            // - `AzureCliCredential`
+            let default_azure_credential = Arc::new(DefaultAzureCredential::default());
+            // Use the `AutoRefreshingTokenCredential` wrapper to cache the credentials,
+            // refreshing when required.
+            let auto_refreshing_credential =
+                Arc::new(AutoRefreshingTokenCredential::new(default_azure_credential));
+            Credential::from_token_credential(auto_refreshing_credential)
+        }
+    }
+}

--- a/azure_devops_rust_api/examples/utils/mod.rs
+++ b/azure_devops_rust_api/examples/utils/mod.rs
@@ -2,7 +2,7 @@ use azure_devops_rust_api::Credential;
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use azure_identity::{AutoRefreshingTokenCredential, DefaultAzureCredential};
+use azure_identity::{AutoRefreshingTokenCredential, DefaultAzureCredentialBuilder};
 use std::sync::Arc;
 
 pub fn get_credential() -> Credential {
@@ -20,7 +20,7 @@ pub fn get_credential() -> Credential {
             // - `AzureCliCredential`
             // For examples we just want to use AzureCliCredential, so exclude the
             // other mechanisms.
-            // It would be simpler to directly create `AzureCliCredential` here, but I wanted to
+            // It would be simpler to directly create `AzureCliCredential` here, but I want to
             // demonstrate use of `DefaultAzureCredentialBuilder`.
             let default_azure_credential = Arc::new(
                 DefaultAzureCredentialBuilder::new()

--- a/azure_devops_rust_api/examples/wiki_pages_create_or_update.rs
+++ b/azure_devops_rust_api/examples/wiki_pages_create_or_update.rs
@@ -5,26 +5,15 @@
 // Wiki page creation/update example.
 use anyhow::Result;
 use azure_devops_rust_api::wiki::{self, pages};
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/wiki_pages_create_or_update.rs
+++ b/azure_devops_rust_api/examples/wiki_pages_create_or_update.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use azure_devops_rust_api::wiki::{self, pages};
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
@@ -31,6 +33,7 @@ async fn main() -> Result<()> {
 
     // Create a wiki pages client
     let wiki_pages_client = wiki::ClientBuilder::new(credential).build().pages_client();
+
     // To update an existing wiki page the page version, called an eTag, must be supplied in an `If-Match` header. NB: the RequestBuilder will insert this header for you when you call it with the `eTag`.
     // This function call returns `Some(String)` containing the eTag if the pages exists, otherwise
     // it will return `None` indicating that the page needs to be created.
@@ -42,6 +45,7 @@ async fn main() -> Result<()> {
         &wiki_id,
     )
     .await;
+
     // The content to be displayed on the page
     let wiki_body = wiki::models::WikiPageCreateOrUpdateParameters {
         content: Some(wiki_content),

--- a/azure_devops_rust_api/examples/wit.rs
+++ b/azure_devops_rust_api/examples/wit.rs
@@ -6,26 +6,15 @@
 use anyhow::Result;
 use azure_devops_rust_api::wit;
 use azure_devops_rust_api::wit::models::WorkItemRelation;
-use azure_devops_rust_api::Credential;
 use std::env;
-use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
     env_logger::init();
 
-    // Get authentication credential either from a PAT ("ADO_TOKEN") or via the az cli.
-    let credential = match env::var("ADO_TOKEN") {
-        Ok(token) => {
-            println!("Authenticate using PAT provided via $ADO_TOKEN");
-            Credential::from_pat(token)
-        }
-        Err(_) => {
-            println!("Authenticate using Azure CLI");
-            Credential::from_token_credential(Arc::new(azure_identity::AzureCliCredential::new()))
-        }
-    };
+    // Get authentication credential
+    let credential = utils::get_credential();
 
     // Get ADO configuration via environment variables
     let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");

--- a/azure_devops_rust_api/examples/wit.rs
+++ b/azure_devops_rust_api/examples/wit.rs
@@ -8,6 +8,8 @@ use azure_devops_rust_api::wit;
 use azure_devops_rust_api::wit::models::WorkItemRelation;
 use std::env;
 
+mod utils;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging


### PR DESCRIPTION
This PR has several changes:
- Upgraded dependency versions
- A new `utils` module for common example code
- Updated example authentication code

Almost all the examples use common authentication code.  This change adds a `utils` module to the examples directory, and moves the common authentication code to a new authentication function `get_credential()` in this module.

This change also includes an update to the authentication code to:
- demonstrate use of `DefaultAzureCredentialBuilder`
- wrap the `Credential` in `AutoRefreshingTokenCredential`, so that the auth token is cached and only updated when it is about to expire