### PR TITLE
fix: creating and updating work items

### DIFF
--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -233,6 +233,10 @@ name = "wiki_pages_create_or_update"
 required-features = ["wiki"]
 
 [[example]]
+name = "wit_create_work_item"
+required-features = ["wit"]
+
+[[example]]
 name = "wit"
 required-features = ["wit"]
 

--- a/azure_devops_rust_api/examples/wit_create_work_item.rs
+++ b/azure_devops_rust_api/examples/wit_create_work_item.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// wit_create_work_item.rs
+// Creating a Work Item example.
+use anyhow::Result;
+use azure_devops_rust_api::wit;
+use azure_devops_rust_api::wit::models::{json_patch_operation::Op, JsonPatchOperation};
+use std::env;
+
+mod utils;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+
+    // Get authentication credential
+    let credential = utils::get_credential();
+
+    // Get ADO configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+
+    // Create a wit client
+    let wit_client = wit::ClientBuilder::new(credential).build();
+    // Assign the type of work item to create
+    let work_item_type = "User Story";
+    // Define the title of the work item to be created
+    let title = JsonPatchOperation {
+        from: None,
+        op: Some(Op::Add),
+        path: Some("/fields/System.Title".to_owned()),
+        value: Some(json!("User Story title")),
+    };
+    // Each operation lives in a vector, additional elements can be added to fill in other fields
+    // of a work item, see the comments at the end of this file for some examples
+    let body = vec![title];
+    // Create a work item
+    let work_item = wit_client
+        .work_items_client()
+        .create(organization, body, project, work_item_type)
+        .await?;
+
+    println!("{:#?}", work_item);
+
+    Ok(())
+}
+
+// When creating a work item you can also assign an iteration
+
+// let iteration = JsonPatchOperation {
+// 	from: None,
+// 	op: Some(Op::Add),
+// 	path: Some("/fields/System.IterationPath".to_owned()),
+// 	value: Some(json!("my-iteration".to_owned()))
+// };
+//
+// e.g create a work item with a title and in an iteration
+//
+// let body = vec![title, iteration];
+
+// When creating a work item you can also assign a parent
+
+// let parent = JsonPatchOperation {
+// 	from: None,
+// 	op: Some(Op::Add),
+// 	path: Some("/relations/-".to_owned()),
+// 	value: Some(json!({
+// 		"rel": "System.LinkTypes.Hierarchy-Reverse",
+// 		"url": format!("https://dev.azure.com/{}/{}/_apis/wit/workItems/{}", organisation, project, parent_id)
+// 	}))
+// }
+//
+// e.g create a work item with a title, in an iteration and assign a parent item
+//
+// let body = vec![title, iteration, parent];

--- a/azure_devops_rust_api/examples/wit_create_work_item.rs
+++ b/azure_devops_rust_api/examples/wit_create_work_item.rs
@@ -6,6 +6,7 @@
 use anyhow::Result;
 use azure_devops_rust_api::wit;
 use azure_devops_rust_api::wit::models::{json_patch_operation::Op, JsonPatchOperation};
+use serde_json::json;
 use std::env;
 
 mod utils;
@@ -31,7 +32,7 @@ async fn main() -> Result<()> {
         from: None,
         op: Some(Op::Add),
         path: Some("/fields/System.Title".to_owned()),
-        value: Some(json!("User Story title")),
+        value: Some(json!("Example User Story title")),
     };
     // Each operation lives in a vector, additional elements can be added to fill in other fields
     // of a work item, see the comments at the end of this file for some examples

--- a/azure_devops_rust_api/run_all_examples
+++ b/azure_devops_rust_api/run_all_examples
@@ -108,5 +108,6 @@ cargo run --example search_work_item --features="search" $WORK_ITEM_SEARCH_TEXT
 cargo run --example test_runs_list --features="test"
 cargo run --example client_pipeline_policy --features="git"
 cargo run --example wiki_pages_create_or_update --features="wiki" $ADO_WIKI_ID $ADO_WIKI_PAGE_PATH $ADO_WIKI_CONTENT
+cargo run --example wit_create_work_item --features="wit"
 
 echo "Done"

--- a/azure_devops_rust_api/src/wit/mod.rs
+++ b/azure_devops_rust_api/src/wit/mod.rs
@@ -7033,7 +7033,7 @@ pub mod work_items {
         #[doc = ""]
         #[doc = "Arguments:"]
         #[doc = "* `organization`: The name of the Azure DevOps organization."]
-        #[doc = "* `body`: The JSON Patch document representing the work item"]
+        #[doc = "* `body`: A list of operations to perform when creating a Work Item"]
         #[doc = "* `project`: Project ID or project name"]
         #[doc = "* `type_`: The work item type of the work item to create"]
         pub fn create(
@@ -7081,20 +7081,20 @@ pub mod work_items {
         #[doc = ""]
         #[doc = "Arguments:"]
         #[doc = "* `organization`: The name of the Azure DevOps organization."]
-        #[doc = "* `body`: The JSON Patch document representing the update"]
+        #[doc = "* `body`: A list of operations to perform when updating a Work Item"]
         #[doc = "* `id`: The id of the work item to update"]
         #[doc = "* `project`: Project ID or project name"]
         pub fn update(
             &self,
             organization: impl Into<String>,
-            body: impl Into<models::JsonPatchDocument>,
+            body: Vec<models::JsonPatchOperation>,
             id: i32,
             project: impl Into<String>,
         ) -> update::RequestBuilder {
             update::RequestBuilder {
                 client: self.0.clone(),
                 organization: organization.into(),
-                body: body.into(),
+                body,
                 id,
                 project: project.into(),
                 validate_only: None,
@@ -7776,7 +7776,7 @@ pub mod work_items {
         pub struct RequestBuilder {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
-            pub(crate) body: models::JsonPatchDocument,
+            pub(crate) body: Vec<models::JsonPatchOperation>,
             pub(crate) id: i32,
             pub(crate) project: String,
             pub(crate) validate_only: Option<bool>,

--- a/azure_devops_rust_api/src/wit/mod.rs
+++ b/azure_devops_rust_api/src/wit/mod.rs
@@ -7039,14 +7039,14 @@ pub mod work_items {
         pub fn create(
             &self,
             organization: impl Into<String>,
-            body: impl Into<models::JsonPatchDocument>,
+            body: Vec<models::JsonPatchOperation>,
             project: impl Into<String>,
             type_: impl Into<String>,
         ) -> create::RequestBuilder {
             create::RequestBuilder {
                 client: self.0.clone(),
                 organization: organization.into(),
-                body: body.into(),
+                body,
                 project: project.into(),
                 type_: type_.into(),
                 validate_only: None,
@@ -7485,7 +7485,7 @@ pub mod work_items {
         pub struct RequestBuilder {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
-            pub(crate) body: models::JsonPatchDocument,
+            pub(crate) body: Vec<models::JsonPatchOperation>,
             pub(crate) project: String,
             pub(crate) type_: String,
             pub(crate) validate_only: Option<bool>,

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -165,7 +165,7 @@ impl Patcher {
         Patcher::patch_probation_retries_type,
         Patcher::patch_operation_status_in_releases,
         Patcher::patch_extension_flags,
-		Patcher::wit_definition_json_schema,
+        Patcher::patch_wit_create_update_item,
         Patcher::patch_wiki_pages_update,
         // This must be done after the other patches
         Patcher::patch_definition_required_fields,
@@ -1653,57 +1653,79 @@ impl Patcher {
             _ => None,
         }
     }
-	/// Patch the WorkItemTracking JsonPatchDocument definition
-	fn wit_definition_json_schema(&mut self, key: &[&str], value: &JsonValue) -> Option<JsonValue> {
-		if !self.spec_path.ends_with("workItemTracking.json") {
-			return None
-		}
-		match key {
-			["paths","/{organization}/{project}/_apis/wit/workitems/${type}", "post", "parameters"] => {
-				// Parameters is an array of `JsonValue`s, each of which has a `name` field
+    /// Patch the WorkItemTracking schema for creating or updating Work Items
+    ///
+    /// Creating or updating a work item can invole multiple operations in one go, e.g creating
+    /// an item but also assigning a parent/iteration to it. This patch allows a Vector of operations
+    /// to be supplied in a single API call so that multiple fields can be assigned
+    fn patch_wit_create_update_item(
+        &mut self,
+        key: &[&str],
+        value: &JsonValue,
+    ) -> Option<JsonValue> {
+        if !self.spec_path.ends_with("workItemTracking.json") {
+            return None;
+        }
+        match key {
+            ["paths", "/{organization}/{project}/_apis/wit/workitems/${type}", "post", "parameters"] =>
+            {
+                // Parameters is an array of `JsonValue`s, each of which has a `name` field
                 let mut value = value.clone();
-				for param in value.members_mut() {
-					if let Some(s) = param["name"].as_str() {
-						// find the body so we can correct its fields
-						if s == "body" {
-							// remove the schema as we're placing it with an array of items
-							let _ = param.remove("schema");
-							// add a type field to the parameter
-							param.insert("type", "array").unwrap();
-							// add an items field referring to a definition
-							param.insert("items", json::object! {
-								"$ref": "#/definitions/JsonPatchOperation"
-							}).unwrap();
-							// Update the description to reflect the definition
-							param["description"] = JsonValue::from("A list of operations to perform when creating/updating a Work Item");
-						}
-					}
-				}
-				Some(value)
-			},
-			// ["definitions", "JsonPatchDocument", "properties"]  => {
-			// 	// let mut value = value.clone();
-			// 	// // Iterate over the fields in the JsonPatchDocument definition
-			// 	// for field in value.members_mut() {
-			// 	// 	if let Some(p) = field["properties"].as_str() {
-			// 	// 		field["properties"] = json::object! {
-			// 	// 			"operation": {
-			// 	// 				"description": "",
-			// 	// 				"$ref": "#/definitions/JsonPatchOperation"
-			// 	// 			}
-			// 	// 		}
-			// 	// 	}
-			// 	// }
-			// 	Some(json::object! {
-			// 		"operation" : {
-			// 			"description": "",
-			// 			"$ref": "#/definitions/JsonPatchOperation"
-			// 		}
-			// 	})
-			// }
-			_ => None
-		}
-	}
+                for param in value.members_mut() {
+                    if let Some(s) = param["name"].as_str() {
+                        // Find the body so we can correct its fields
+                        if s == "body" {
+                            // Remove the schema as we're placing it with an array of items
+                            let _ = param.remove("schema");
+                            // Add a type field to the parameter
+                            param.insert("type", "array").unwrap();
+                            // Add an items field referring to a definition
+                            param
+                                .insert(
+                                    "items",
+                                    json::object! {
+                                        "$ref": "#/definitions/JsonPatchOperation"
+                                    },
+                                )
+                                .unwrap();
+                            // Update the description to reflect the definition
+                            param["description"] = JsonValue::from("A list of operations to perform when creating a Work Item");
+                        }
+                    }
+                }
+                Some(value)
+            }
+            ["paths", "/{organization}/{project}/_apis/wit/workitems/{id}", "patch", "parameters"] =>
+            {
+                // Parameters is an array of `JsonValue`s, each of which has a `name` field
+                let mut value = value.clone();
+                for param in value.members_mut() {
+                    if let Some(s) = param["name"].as_str() {
+                        // Find the body so we can correct its fields
+                        if s == "body" {
+                            // Remove the schema as we're placing it with an array of items
+                            let _ = param.remove("schema");
+                            // Add a type field to the parameter
+                            param.insert("type", "array").unwrap();
+                            // Add an items field referring to a definition
+                            param
+                                .insert(
+                                    "items",
+                                    json::object! {
+                                        "$ref": "#/definitions/JsonPatchOperation"
+                                    },
+                                )
+                                .unwrap();
+                            // Update the description to reflect the definition
+                            param["description"] = JsonValue::from("A list of operations to perform when updating a Work Item");
+                        }
+                    }
+                }
+                Some(value)
+            }
+            _ => None,
+        }
+    }
     /// Patch Wiki Pages
     ///
     /// To update a Wiki Page an `If-Match` header must be supplied with an `eTag` (page version)

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -1689,7 +1689,9 @@ impl Patcher {
                                 )
                                 .unwrap();
                             // Update the description to reflect the definition
-                            param["description"] = JsonValue::from("A list of operations to perform when creating a Work Item");
+                            param["description"] = JsonValue::from(
+                                "A list of operations to perform when creating a Work Item",
+                            );
                         }
                     }
                 }
@@ -1717,7 +1719,9 @@ impl Patcher {
                                 )
                                 .unwrap();
                             // Update the description to reflect the definition
-                            param["description"] = JsonValue::from("A list of operations to perform when updating a Work Item");
+                            param["description"] = JsonValue::from(
+                                "A list of operations to perform when updating a Work Item",
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
When creating a [Work Item through the API](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/work-items/create?view=azure-devops-rest-7.0&tabs=HTTP) an array of json objects can be provided to populate the various fields of the work item.

An example of the json body for creating a new Work Item with a particular title looks like:

```json
[
  {
    "op": "add",
    "path": "/fields/System.Title",
    "from": null,
    "value": "This is my story"
  }
]
```

According to the API documentation the elements of this array are referred to as `JsonPatchDocument`. The auto-generated crate turns the `JsonPatchDocument` structure into a unit struct:

```rust
pub struct JsonPatchDocument {}
```

But the API specification also creates a separate struct which contains the necessary fields (like "op" and "path" etc):

```rust
pub struct JsonPatchOperation { //...snip }
```

This means that trying to create a Work Item currently fails as `JsonPatchDocument` has no data (it seems like a broken duplicate of the `JsonPatchOperation`):

```rust
let body = JsonPatchDocument::new();

let work_item = client.work_item_client().create(organisation, body, project, work_item_type).await?;
```

This patch changes the body of the POST operation for creating a Work Item and changes the body of the PATCH operation for updating a Work Item, to instead use a `vec`  of `JsonPatchOperation`.

This allows a single API call to set multiple fields when creating a new item. The pure json form for a body which does this may look lke:

```json
[
  {
    "op": "add",
    "path": "/fields/System.Title",
    "from": null,
    "value": "This is my story"
  },
  {
    "op": "add",
    "path": "/fields/System.IterationPath",
    "from": null,
    "value": "some-interation"
  }
]
```

This would create a new Work Item and assign it to the specified iteration.

The patch itself is changing the API spec from:

```json
{
  "in": "body",
  "name": "body",
  "description": "The JSON Patch document representing the work item",
  "required": true,
  "schema": {
      "$ref": "#/definitions/JsonPatchDocument"
  }
},
```

To:

```json
{
  "in": "body",
   "name": "body",
   "description": "A list of operations to perform when creating a Work Item",
   "required": true,
   "type": "array",
   "items": {
       "$ref": "#/definitions/JsonPatchOperation"
   }
},
```

The new usage of the `create()` method is as follows:

```rust
// Define the various different fields you want populated when creating a work item:
let title = JsonPatchOperation {
        from: None,
        op: Some(Op::Add),
        path: Some("/fields/System.Title".to_owned()),
        value: Some(json!("User Story title")),
};
let iteration = JsonPatchOperation {
 	from: None,
 	op: Some(Op::Add),
	path: Some("/fields/System.IterationPath".to_owned()),
 	value: Some(json!("my-iteration".to_owned()))
 };
let parent = JsonPatchOperation {
 	from: None,
 	op: Some(Op::Add),
 	path: Some("/relations/-".to_owned()),
 	value: Some(json!({
 		"rel": "System.LinkTypes.Hierarchy-Reverse",
 		"url": format!("https://dev.azure.com/{}/{}/_apis/wit/workItems/{}", organisation, project, parent_id)
 	}))
};
// Assemble the payload
let body: Vec<JsonPatchOperation> = vec![title, iteration, parent];
// Send the request
let work_item = wit_client
        .work_items_client()
        .create(organization, body, project, work_item_type)
        .await?;
```

In summery this fixes creating and updating work items but also makes it a bit more ergonomic as you can set multiple fields in a single API call rather than making one call to create an item and then having subsequent calls to change different bits of it

