### PR TITLE
Update base64 usage to new API

### DIFF
--- a/azure_devops_rust_api/src/auth.rs
+++ b/azure_devops_rust_api/src/auth.rs
@@ -8,6 +8,7 @@
 use azure_core::auth::TokenCredential;
 use azure_core::error::{Result, ResultExt};
 use std::sync::Arc;
+use base64::{Engine, prelude::BASE64_STANDARD};
 
 /// A credential for authenticating with Azure DevOps.
 ///
@@ -55,7 +56,7 @@ impl Credential {
             // PAT tokens are passed using Basic authentication.
             Credential::Pat(pat) => Ok(Some(format!(
                 "Basic {}",
-                base64::encode(format!(":{}", &pat))
+                BASE64_STANDARD.encode(format!(":{}", &pat))
             ))),
             // OAuth tokens are passed using Bearer authentication.
             Credential::TokenCredential(token_credential) => {

--- a/azure_devops_rust_api/src/auth.rs
+++ b/azure_devops_rust_api/src/auth.rs
@@ -7,8 +7,8 @@
 
 use azure_core::auth::TokenCredential;
 use azure_core::error::{Result, ResultExt};
+use base64::{prelude::BASE64_STANDARD, Engine};
 use std::sync::Arc;
-use base64::{Engine, prelude::BASE64_STANDARD};
 
 /// A credential for authenticating with Azure DevOps.
 ///


### PR DESCRIPTION
`base64` API has changed.  This update moves to the new API, removing deprecation warnings.