### PR TITLE
Fix definition of wit IdentityReference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed definition of wit `IdentityReference`
+
+### Added
+
+- New example: `wit_work_item_queries`
+
 ## [0.7.3]
 
 ### Breaking change

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -241,6 +241,10 @@ name = "wit_work_item_get"
 required-features = ["wit"]
 
 [[example]]
+name = "wit_work_item_queries"
+required-features = ["wit"]
+
+[[example]]
 name = "policy"
 required-features = ["policy"]
 

--- a/azure_devops_rust_api/examples/wit_work_item_queries.rs
+++ b/azure_devops_rust_api/examples/wit_work_item_queries.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// wit_work_item_queries.rs
+// Work Item query list example.
+use anyhow::{anyhow, Context, Result};
+use azure_devops_rust_api::wit;
+use std::env;
+
+mod utils;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+
+    // Get authentication credential
+    let credential = utils::get_credential();
+
+    // Get ADO configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+
+    // Create a wit client
+    let wit_client = wit::ClientBuilder::new(credential).build();
+
+    // Get all work item queries
+    let work_item_queries = wit_client
+        .queries_client()
+        .list(&organization, &project)
+        .await?;
+
+    println!("All work item queries:\n{:#?}", work_item_queries);
+
+    Ok(())
+}

--- a/azure_devops_rust_api/examples/wit_work_item_queries.rs
+++ b/azure_devops_rust_api/examples/wit_work_item_queries.rs
@@ -3,7 +3,7 @@
 
 // wit_work_item_queries.rs
 // Work Item query list example.
-use anyhow::{anyhow, Context, Result};
+use anyhow::Result;
 use azure_devops_rust_api::wit;
 use std::env;
 

--- a/azure_devops_rust_api/run_all_examples
+++ b/azure_devops_rust_api/run_all_examples
@@ -109,5 +109,6 @@ cargo run --example test_runs_list --features="test"
 cargo run --example client_pipeline_policy --features="git"
 cargo run --example wiki_pages_create_or_update --features="wiki" $ADO_WIKI_ID $ADO_WIKI_PAGE_PATH $ADO_WIKI_CONTENT
 cargo run --example wit_work_item_create --features="wit"
+cargo run --example wit_work_item_queries --features="wit"
 
 echo "Done"

--- a/azure_devops_rust_api/src/wit/models.rs
+++ b/azure_devops_rust_api/src/wit/models.rs
@@ -917,24 +917,64 @@ impl IdentityRefList {
         Self::default()
     }
 }
-#[doc = "Describes a reference to an identity."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[doc = ""]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct IdentityReference {
     #[serde(flatten)]
-    pub identity_ref: IdentityRef,
+    pub graph_subject_base: GraphSubjectBase,
+    #[doc = "Deprecated - Can be retrieved by querying the Graph user referenced in the \"self\" entry of the IdentityRef \"_links\" dictionary"]
+    #[serde(
+        rename = "directoryAlias",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub directory_alias: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    #[doc = "Legacy back-compat property. This has been the WIT specific value from Constants. Will be hidden (but exists) on the client unless they are targeting the newest version"]
+    #[doc = "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary"]
+    #[serde(rename = "imageUrl", default, skip_serializing_if = "Option::is_none")]
+    pub image_url: Option<String>,
+    #[doc = "Deprecated - Can be retrieved by querying the Graph membership state referenced in the \"membershipState\" entry of the GraphUser \"_links\" dictionary"]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub inactive: Option<bool>,
+    #[doc = "Deprecated - Can be inferred from the subject type of the descriptor (Descriptor.IsAadUserType/Descriptor.IsAadGroupType)"]
+    #[serde(
+        rename = "isAadIdentity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub is_aad_identity: Option<bool>,
+    #[doc = "Deprecated - Can be inferred from the subject type of the descriptor (Descriptor.IsGroupType)"]
+    #[serde(
+        rename = "isContainer",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub is_container: Option<bool>,
+    #[serde(
+        rename = "isDeletedInOrigin",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub is_deleted_in_origin: Option<bool>,
+    #[doc = "Deprecated - not in use in most preexisting implementations of ToIdentityRef"]
+    #[serde(
+        rename = "profileUrl",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub profile_url: Option<String>,
+    #[doc = "Deprecated - use Domain+PrincipalName instead"]
+    #[serde(
+        rename = "uniqueName",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub unique_name: Option<String>,
 }
 impl IdentityReference {
-    pub fn new(identity_ref: IdentityRef) -> Self {
-        Self {
-            identity_ref,
-            id: None,
-            name: None,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 #[doc = "The JSON model for JSON Patch Operations"]
@@ -1175,7 +1215,7 @@ pub struct QueryHierarchyItem {
         deserialize_with = "crate::serde::deserialize_null_default"
     )]
     pub columns: Vec<WorkItemFieldReference>,
-    #[doc = "Describes a reference to an identity."]
+    #[doc = ""]
     #[serde(rename = "createdBy", default, skip_serializing_if = "Option::is_none")]
     pub created_by: Option<IdentityReference>,
     #[doc = "When the query item was created."]
@@ -1218,7 +1258,7 @@ pub struct QueryHierarchyItem {
     #[doc = "Indicates if this query item is public or private."]
     #[serde(rename = "isPublic", default, skip_serializing_if = "Option::is_none")]
     pub is_public: Option<bool>,
-    #[doc = "Describes a reference to an identity."]
+    #[doc = ""]
     #[serde(
         rename = "lastExecutedBy",
         default,
@@ -1232,7 +1272,7 @@ pub struct QueryHierarchyItem {
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_executed_date: Option<time::OffsetDateTime>,
-    #[doc = "Describes a reference to an identity."]
+    #[doc = ""]
     #[serde(
         rename = "lastModifiedBy",
         default,
@@ -1872,7 +1912,7 @@ impl WorkItemClassificationNodeList {
 pub struct WorkItemComment {
     #[serde(flatten)]
     pub work_item_tracking_resource: WorkItemTrackingResource,
-    #[doc = "Describes a reference to an identity."]
+    #[doc = ""]
     #[serde(rename = "revisedBy", default, skip_serializing_if = "Option::is_none")]
     pub revised_by: Option<IdentityReference>,
     #[doc = "The date of comment."]
@@ -2320,7 +2360,7 @@ pub struct WorkItemHistory {
     pub work_item_tracking_resource: WorkItemTrackingResource,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rev: Option<i32>,
-    #[doc = "Describes a reference to an identity."]
+    #[doc = ""]
     #[serde(rename = "revisedBy", default, skip_serializing_if = "Option::is_none")]
     pub revised_by: Option<IdentityReference>,
     #[serde(
@@ -3317,7 +3357,7 @@ pub struct WorkItemUpdate {
     #[doc = "The revision number of work item update."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rev: Option<i32>,
-    #[doc = "Describes a reference to an identity."]
+    #[doc = ""]
     #[serde(rename = "revisedBy", default, skip_serializing_if = "Option::is_none")]
     pub revised_by: Option<IdentityReference>,
     #[doc = "The work item updates revision date."]

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -1733,7 +1733,7 @@ impl Patcher {
     }
 
     // The definition of IdentityReference has issues because it defines a property called `id` which is also in `IdentityRef` which is included via `allOf`.
-    // This causes the deserilization to fail as it doesn't know which `id` to use.
+    // This causes the deserialization to fail as it doesn't know which `id` to use.
     // Fix is to replace the definition of `IdentityReference` with the definition of `IdentityRef`.
     fn patch_wit_identity_reference(
         &mut self,

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -166,6 +166,7 @@ impl Patcher {
         Patcher::patch_operation_status_in_releases,
         Patcher::patch_extension_flags,
         Patcher::patch_wit_create_update_item,
+        Patcher::patch_wit_identity_reference,
         Patcher::patch_wiki_pages_update,
         // This must be done after the other patches
         Patcher::patch_definition_required_fields,
@@ -1730,6 +1731,72 @@ impl Patcher {
             _ => None,
         }
     }
+
+    // The definition of IdentityReference has issues because it defines a property called `id` which is also in `IdentityRef` which is included via `allOf`.
+    // This causes the deserilization to fail as it doesn't know which `id` to use.
+    // Fix is to replace the definition of `IdentityReference` with the definition of `IdentityRef`.
+    fn patch_wit_identity_reference(
+        &mut self,
+        key: &[&str],
+        _value: &JsonValue,
+    ) -> Option<JsonValue> {
+        if !self.spec_path.ends_with("workItemTracking.json") {
+            return None;
+        }
+
+        match key {
+            ["definitions", "IdentityReference"] => {
+                // Replace with the definition of `IdentifyRef`
+                Some(json::object!(
+                    "description": "",
+                    "type": "object",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/GraphSubjectBase"
+                        }
+                    ],
+                    "properties": {
+                        "directoryAlias": {
+                            "description": "Deprecated - Can be retrieved by querying the Graph user referenced in the \"self\" entry of the IdentityRef \"_links\" dictionary",
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "imageUrl": {
+                            "description": "Deprecated - Available in the \"avatar\" entry of the IdentityRef \"_links\" dictionary",
+                            "type": "string"
+                        },
+                        "inactive": {
+                            "description": "Deprecated - Can be retrieved by querying the Graph membership state referenced in the \"membershipState\" entry of the GraphUser \"_links\" dictionary",
+                            "type": "boolean"
+                        },
+                        "isAadIdentity": {
+                            "description": "Deprecated - Can be inferred from the subject type of the descriptor (Descriptor.IsAadUserType/Descriptor.IsAadGroupType)",
+                            "type": "boolean"
+                        },
+                        "isContainer": {
+                            "description": "Deprecated - Can be inferred from the subject type of the descriptor (Descriptor.IsGroupType)",
+                            "type": "boolean"
+                        },
+                        "isDeletedInOrigin": {
+                            "type": "boolean"
+                        },
+                        "profileUrl": {
+                            "description": "Deprecated - not in use in most preexisting implementations of ToIdentityRef",
+                            "type": "string"
+                        },
+                        "uniqueName": {
+                            "description": "Deprecated - use Domain+PrincipalName instead",
+                            "type": "string"
+                        }
+                    }
+                ))
+            }
+            _ => None,
+        }
+    }
+
     /// Patch Wiki Pages
     ///
     /// To update a Wiki Page an `If-Match` header must be supplied with an `eTag` (page version)


### PR DESCRIPTION
- Patched definition of wit `IdentityReference` - replaced with `IdentityRef` definition.
- Added new example: `wit_work_item_queries`

Fixes https://github.com/microsoft/azure-devops-rust-api/issues/127
