### PR TITLE
Fix pipeline Run required fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed definition of git `PolicyConfiguration`
+- Fixed pipeline `Run` required fields
+  - Changed `finishedDate` and `result` to optional, as they are not present if run is in progress
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed definition of git `PolicyConfiguration`
 - Fixed pipeline `Run` required fields
   - Changed `finishedDate` and `result` to optional, as they are not present if run is in progress
+- Change pipeline `Repository` fields to be optional: `id`, `type`
 
 ### Added
 

--- a/azure_devops_rust_api/examples/pipelines.rs
+++ b/azure_devops_rust_api/examples/pipelines.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
         for run in runs.iter() {
             let result = match &run.result {
                 Some(result) => format!("{:?}", result),
-                None => "-".to_string()
+                None => "-".to_string(),
             };
             println!(
                 "{:8} {:16} {:16} {:14}",

--- a/azure_devops_rust_api/examples/pipelines.rs
+++ b/azure_devops_rust_api/examples/pipelines.rs
@@ -69,11 +69,15 @@ async fn main() -> Result<()> {
         println!("\nPipeline runs: {}", runs.len());
         // Display [result, state] for each pipeline run
         for run in runs.iter() {
+            let result = match &run.result {
+                Some(result) => format!("{:?}", result),
+                None => "-".to_string()
+            };
             println!(
-                "{:8} {:16} {:14} {:14}",
+                "{:8} {:16} {:16} {:14}",
                 run.run_reference.id,
                 run.run_reference.name,
-                format!("{:?}", run.result),
+                result,
                 format!("{:?}", run.state)
             );
         }

--- a/azure_devops_rust_api/src/pipelines/models.rs
+++ b/azure_devops_rust_api/src/pipelines/models.rs
@@ -435,14 +435,19 @@ pub struct Run {
     pub created_date: time::OffsetDateTime,
     #[serde(rename = "finalYaml", default, skip_serializing_if = "Option::is_none")]
     pub final_yaml: Option<String>,
-    #[serde(rename = "finishedDate", with = "crate::date_time::rfc3339")]
-    pub finished_date: time::OffsetDateTime,
+    #[serde(
+        rename = "finishedDate",
+        default,
+        with = "crate::date_time::rfc3339::option"
+    )]
+    pub finished_date: Option<time::OffsetDateTime>,
     #[doc = "A reference to a Pipeline."]
     pub pipeline: PipelineReference,
     #[doc = ""]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resources: Option<RunResources>,
-    pub result: run::Result,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<run::Result>,
     pub state: run::State,
     pub url: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -453,9 +458,7 @@ impl Run {
         run_reference: RunReference,
         links: ReferenceLinks,
         created_date: time::OffsetDateTime,
-        finished_date: time::OffsetDateTime,
         pipeline: PipelineReference,
-        result: run::Result,
         state: run::State,
         url: String,
     ) -> Self {
@@ -464,10 +467,10 @@ impl Run {
             links,
             created_date,
             final_yaml: None,
-            finished_date,
+            finished_date: None,
             pipeline,
             resources: None,
-            result,
+            result: None,
             state,
             url,
             variables: None,

--- a/azure_devops_rust_api/src/pipelines/models.rs
+++ b/azure_devops_rust_api/src/pipelines/models.rs
@@ -279,15 +279,16 @@ pub mod pipeline_configuration {
         #[serde(rename = "designerHyphenJson")]
         DesignerHyphenJson,
     }
-    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
     pub struct Repository {
-        pub id: String,
-        #[serde(rename = "type")]
-        pub type_: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub id: Option<String>,
+        #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+        pub type_: Option<String>,
     }
     impl Repository {
-        pub fn new(id: String, type_: String) -> Self {
-            Self { id, type_ }
+        pub fn new() -> Self {
+            Self::default()
         }
     }
 }

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -365,7 +365,6 @@ impl Patcher {
                                 "type": "string"
                             }
                         },
-                        "required": ["id", "type"]
                     }
                 })
             }

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -1154,12 +1154,13 @@ impl Patcher {
             (
                 "pipelines.json",
                 "Run",
+                // Excluded
+                // - finishedDate
+                // - result
                 r#"[
                     "_links",
                     "createdDate",
-                    "finishedDate",
                     "pipeline",
-                    "result",
                     "state",
                     "url"
                 ]"#,


### PR DESCRIPTION
Fixes "Case 2" of https://github.com/microsoft/azure-devops-rust-api/issues/148

In the pipeline `Run` struct the `finishedDate` and `result` fields need to be optional as they are not present when the run is in state `InProgress`.

I had previously set them to required via the spec patcher.