### PR TITLE
Patch arrays as well as objects

### DIFF
--- a/azure_devops_rust_api/src/security/mod.rs
+++ b/azure_devops_rust_api/src/security/mod.rs
@@ -142,7 +142,7 @@ pub mod access_control_entries {
         #[doc = "* `organization`: The name of the Azure DevOps organization."]
         pub fn set_access_control_entries(
             &self,
-            body: impl Into<models::JObject>,
+            body: impl Into<serde_json::Value>,
             security_namespace_id: impl Into<String>,
             organization: impl Into<String>,
         ) -> set_access_control_entries::RequestBuilder {
@@ -225,7 +225,7 @@ pub mod access_control_entries {
         #[doc = r" [`Response`] value."]
         pub struct RequestBuilder {
             pub(crate) client: super::super::Client,
-            pub(crate) body: models::JObject,
+            pub(crate) body: serde_json::Value,
             pub(crate) security_namespace_id: String,
             pub(crate) organization: String,
         }

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -1918,6 +1918,14 @@ impl Patcher {
                 self.walker(&new_key, v);
             }
         }
+        if let JsonValue::Array(_) = value {
+            for (i, v) in value.members_mut().enumerate() {
+                let mut new_key = key.to_owned();
+                let i = i.to_string();
+                new_key.push(i.as_str());
+                self.walker(&new_key, v);
+            }
+        }
     }
 
     // Adds all the accumulated new definitions to the definitions section of the schema


### PR DESCRIPTION
My specific issue was that I need to pass arbitrary json values to the set access control entries method. Previous jobject patch didn't work because the relevant type was inside an array, and the patcher currently ignores those.