### PR TITLE
Patch identitydescriptors to just be strings

### DIFF
--- a/azure_devops_rust_api/src/artifacts/models.rs
+++ b/azure_devops_rust_api/src/artifacts/models.rs
@@ -338,13 +338,13 @@ pub struct FeedPermission {
         skip_serializing_if = "Option::is_none"
     )]
     pub display_name: Option<String>,
-    #[doc = "An Identity descriptor is a wrapper for the identity type (Windows SID, Passport) along with a unique identifier such as the SID or PUID."]
+    #[doc = "Identity associated with this role."]
     #[serde(
         rename = "identityDescriptor",
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub identity_descriptor: Option<IdentityDescriptor>,
+    pub identity_descriptor: Option<String>,
     #[doc = "Id of the identity associated with this role."]
     #[serde(
         rename = "identityId",
@@ -567,13 +567,13 @@ impl FeedViewList {
 #[doc = "Permissions for feed service-wide operations such as the creation of new feeds."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GlobalPermission {
-    #[doc = "An Identity descriptor is a wrapper for the identity type (Windows SID, Passport) along with a unique identifier such as the SID or PUID."]
+    #[doc = "Identity of the user with the provided Role."]
     #[serde(
         rename = "identityDescriptor",
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub identity_descriptor: Option<IdentityDescriptor>,
+    pub identity_descriptor: Option<String>,
     #[doc = "IdentityId corresponding to the IdentityDescriptor"]
     #[serde(
         rename = "identityId",

--- a/azure_devops_rust_api/src/core/models.rs
+++ b/azure_devops_rust_api/src/core/models.rs
@@ -51,9 +51,8 @@ pub struct IdentityBase {
         skip_serializing_if = "Option::is_none"
     )]
     pub custom_display_name: Option<String>,
-    #[doc = "An Identity descriptor is a wrapper for the identity type (Windows SID, Passport) along with a unique identifier such as the SID or PUID."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<IdentityDescriptor>,
+    pub descriptor: Option<String>,
     #[doc = "Identity Identifier. Also called Storage Key, or VSID"]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -83,13 +82,13 @@ pub struct IdentityBase {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "crate::serde::deserialize_null_default"
     )]
-    pub member_of: Vec<IdentityDescriptor>,
+    pub member_of: Vec<String>,
     #[serde(
         default,
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "crate::serde::deserialize_null_default"
     )]
-    pub members: Vec<IdentityDescriptor>,
+    pub members: Vec<String>,
     #[serde(
         rename = "metaTypeId",
         default,
@@ -653,9 +652,9 @@ pub struct ProxyAuthorization {
     #[doc = "Gets or sets the client identifier for this proxy."]
     #[serde(rename = "clientId", default, skip_serializing_if = "Option::is_none")]
     pub client_id: Option<String>,
-    #[doc = "An Identity descriptor is a wrapper for the identity type (Windows SID, Passport) along with a unique identifier such as the SID or PUID."]
+    #[doc = "Gets or sets the user identity to authorize for on-prem."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub identity: Option<IdentityDescriptor>,
+    pub identity: Option<String>,
     #[doc = "Represents the public key portion of an RSA asymmetric key."]
     #[serde(rename = "publicKey", default, skip_serializing_if = "Option::is_none")]
     pub public_key: Option<PublicKey>,

--- a/azure_devops_rust_api/src/ims/models.rs
+++ b/azure_devops_rust_api/src/ims/models.rs
@@ -315,9 +315,8 @@ pub mod framework_identity_info {
 pub struct GroupMembership {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active: Option<bool>,
-    #[doc = "An Identity descriptor is a wrapper for the identity type (Windows SID, Passport) along with a unique identifier such as the SID or PUID."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<IdentityDescriptor>,
+    pub descriptor: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(rename = "queriedId", default, skip_serializing_if = "Option::is_none")]
@@ -381,13 +380,13 @@ pub struct IdentityBase {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "crate::serde::deserialize_null_default"
     )]
-    pub member_of: Vec<IdentityDescriptor>,
+    pub member_of: Vec<String>,
     #[serde(
         default,
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "crate::serde::deserialize_null_default"
     )]
-    pub members: Vec<IdentityDescriptor>,
+    pub members: Vec<String>,
     #[serde(
         rename = "metaTypeId",
         default,
@@ -443,7 +442,7 @@ pub struct IdentityBatchInfo {
         skip_serializing_if = "Vec::is_empty",
         deserialize_with = "crate::serde::deserialize_null_default"
     )]
-    pub descriptors: Vec<IdentityDescriptor>,
+    pub descriptors: Vec<String>,
     #[serde(
         rename = "identityIds",
         default,
@@ -560,9 +559,8 @@ impl IdentityRightsTransferData {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct IdentityScope {
-    #[doc = "An Identity descriptor is a wrapper for the identity type (Windows SID, Passport) along with a unique identifier such as the SID or PUID."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub administrators: Option<IdentityDescriptor>,
+    pub administrators: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(rename = "isActive", default, skip_serializing_if = "Option::is_none")]

--- a/azure_devops_rust_api/src/security/mod.rs
+++ b/azure_devops_rust_api/src/security/mod.rs
@@ -142,7 +142,7 @@ pub mod access_control_entries {
         #[doc = "* `organization`: The name of the Azure DevOps organization."]
         pub fn set_access_control_entries(
             &self,
-            body: impl Into<models::JObject>,
+            body: impl Into<serde_json::Value>,
             security_namespace_id: impl Into<String>,
             organization: impl Into<String>,
         ) -> set_access_control_entries::RequestBuilder {
@@ -225,7 +225,7 @@ pub mod access_control_entries {
         #[doc = r" [`Response`] value."]
         pub struct RequestBuilder {
             pub(crate) client: super::super::Client,
-            pub(crate) body: models::JObject,
+            pub(crate) body: serde_json::Value,
             pub(crate) security_namespace_id: String,
             pub(crate) organization: String,
         }

--- a/azure_devops_rust_api/src/security/models.rs
+++ b/azure_devops_rust_api/src/security/models.rs
@@ -14,9 +14,9 @@ pub struct AccessControlEntry {
     #[doc = "The set of permission bits that represent the actions that the associated descriptor is not allowed to perform."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deny: Option<i32>,
-    #[doc = "An Identity descriptor is a wrapper for the identity type (Windows SID, Passport) along with a unique identifier such as the SID or PUID."]
+    #[doc = "The descriptor for the user this AccessControlEntry applies to."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub descriptor: Option<IdentityDescriptor>,
+    pub descriptor: Option<String>,
     #[doc = "Holds the inherited and effective permission information for a given AccessControlEntry."]
     #[serde(
         rename = "extendedInfo",

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -170,6 +170,7 @@ impl Patcher {
         Patcher::patch_wit_identity_reference,
         Patcher::patch_wiki_pages_update,
         Patcher::patch_jobjects,
+        Patcher::patch_identity_descriptors,
         // This must be done after the other patches
         Patcher::patch_definition_required_fields,
     ];
@@ -1887,6 +1888,32 @@ impl Patcher {
                 value.remove("$ref");
                 if value
                     .insert("type", JsonValue::String("object".to_string()))
+                    .is_ok()
+                {
+                    return Some(value);
+                }
+            }
+        }
+        None
+    }
+
+    /// Patch IdentityDescriptor
+    ///
+    /// These are spec'd as { "identifier": "string", "identityType": "string" }
+    /// but seem to always be strings in practice/examples.
+    fn patch_identity_descriptors(
+        &mut self,
+        _key: &[&str],
+        value: &JsonValue,
+    ) -> Option<JsonValue> {
+        if let JsonValue::Object(obj) = value {
+            if let Some("#/definitions/IdentityDescriptor") =
+                obj.get("$ref").and_then(|s| s.as_str())
+            {
+                let mut value = value.clone();
+                value.remove("$ref");
+                if value
+                    .insert("type", JsonValue::String("string".to_string()))
                     .is_ok()
                 {
                     return Some(value);

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -1918,6 +1918,14 @@ impl Patcher {
                 self.walker(&new_key, v);
             }
         }
+        if let JsonValue::Array(_) = value {
+            for (i, v) in value.members_mut().enumerate() {
+                let mut new_key = key.to_owned();
+                let i = i.to_string();
+                new_key.push(i.as_str());
+                self.walker(&new_key, v);
+            }
+        }
     }
 
     // Adds all the accumulated new definitions to the definitions section of the schema


### PR DESCRIPTION
without this the API fails to deserialize the responses of setting ACEs. The examples also show the identity being a string for this case.