### PR TITLE
patch the setaccesscontrollists body parameter

### DIFF
--- a/azure_devops_rust_api/src/security/mod.rs
+++ b/azure_devops_rust_api/src/security/mod.rs
@@ -435,7 +435,7 @@ pub mod access_control_lists {
         #[doc = "* `organization`: The name of the Azure DevOps organization."]
         pub fn set_access_control_lists(
             &self,
-            body: impl Into<models::VssJsonCollectionWrapper>,
+            body: impl Into<models::AccessControlListBody>,
             security_namespace_id: impl Into<String>,
             organization: impl Into<String>,
         ) -> set_access_control_lists::RequestBuilder {
@@ -634,7 +634,7 @@ pub mod access_control_lists {
         #[doc = r" [`Response`] value."]
         pub struct RequestBuilder {
             pub(crate) client: super::super::Client,
-            pub(crate) body: models::VssJsonCollectionWrapper,
+            pub(crate) body: models::AccessControlListBody,
             pub(crate) security_namespace_id: String,
             pub(crate) organization: String,
         }

--- a/azure_devops_rust_api/src/security/models.rs
+++ b/azure_devops_rust_api/src/security/models.rs
@@ -80,6 +80,15 @@ impl AccessControlList {
         Self::default()
     }
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AccessControlListBody {
+    pub value: Vec<AccessControlList>,
+}
+impl AccessControlListBody {
+    pub fn new(value: Vec<AccessControlList>) -> Self {
+        Self { value }
+    }
+}
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AccessControlListList {


### PR DESCRIPTION
I think any parameter using `VssJsonCollectionWrapper`  won't work. This is a specific fix for https://learn.microsoft.com/en-us/rest/api/azure/devops/security/access-control-lists/set-access-control-lists?view=azure-devops-rest-7.0&tabs=HTTP.