### PR TITLE
don't serialize unprovided datetimes

### DIFF
--- a/autorust/codegen/src/codegen_models.rs
+++ b/autorust/codegen/src/codegen_models.rs
@@ -683,7 +683,7 @@ fn create_struct(cg: &CodeGen, schema: &SchemaGen, struct_name: &str, pageable: 
         } else {
             if type_name.is_date_time() {
                 // Must specify `default` when using `with` for `Option`
-                serde_attrs.push(quote! { default, with = "crate::date_time::rfc3339::option"});
+                serde_attrs.push(quote! { default, skip_serializing_if = "Option::is_none", with = "crate::date_time::rfc3339::option"});
             } else if type_name.is_date_time_rfc1123() {
                 // Must specify `default` when using `with` for `Option`
                 serde_attrs.push(quote! { default, with = "azure_core::date::rfc1123::option"});

--- a/azure_devops_rust_api/src/accounts/models.rs
+++ b/azure_devops_rust_api/src/accounts/models.rs
@@ -53,6 +53,7 @@ pub struct Account {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -69,6 +70,7 @@ pub struct Account {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/artifacts/models.rs
+++ b/azure_devops_rust_api/src/artifacts/models.rs
@@ -74,6 +74,7 @@ pub struct Feed {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -91,6 +92,7 @@ pub struct Feed {
     #[serde(
         rename = "permanentDeletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub permanent_deleted_date: Option<time::OffsetDateTime>,
@@ -105,6 +107,7 @@ pub struct Feed {
     #[serde(
         rename = "scheduledPermanentDeleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_permanent_delete_date: Option<time::OffsetDateTime>,
@@ -112,6 +115,7 @@ pub struct Feed {
     #[serde(
         rename = "upstreamEnabledChangedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub upstream_enabled_changed_date: Option<time::OffsetDateTime>,
@@ -736,6 +740,7 @@ pub struct MinimalPackageVersion {
     #[serde(
         rename = "publishDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub publish_date: Option<time::OffsetDateTime>,
@@ -985,6 +990,7 @@ pub struct PackageMetrics {
     #[serde(
         rename = "lastDownloaded",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_downloaded: Option<time::OffsetDateTime>,
@@ -1046,6 +1052,7 @@ pub struct PackageVersion {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -1189,6 +1196,7 @@ pub struct PackageVersionMetrics {
     #[serde(
         rename = "lastDownloaded",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_downloaded: Option<time::OffsetDateTime>,
@@ -1342,6 +1350,7 @@ pub struct RecycleBinPackageVersion {
     #[serde(
         rename = "scheduledPermanentDeleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_permanent_delete_date: Option<time::OffsetDateTime>,
@@ -1449,6 +1458,7 @@ pub struct UpstreamSource {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/artifacts_package_types/models.rs
+++ b/azure_devops_rust_api/src/artifacts_package_types/models.rs
@@ -144,6 +144,7 @@ pub struct MavenPackage {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -201,6 +202,7 @@ pub struct MavenPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -690,6 +692,7 @@ pub struct NpmPackageVersionDeletionState {
     #[serde(
         rename = "unpublishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub unpublished_date: Option<time::OffsetDateTime>,
@@ -762,6 +765,7 @@ pub struct NuGetPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -838,6 +842,7 @@ pub struct Package {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -851,6 +856,7 @@ pub struct Package {
     #[serde(
         rename = "permanentlyDeletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub permanently_deleted_date: Option<time::OffsetDateTime>,
@@ -919,6 +925,7 @@ pub struct PyPiPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -1013,6 +1020,7 @@ pub struct UPackPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/audit/models.rs
+++ b/azure_devops_rust_api/src/audit/models.rs
@@ -118,7 +118,11 @@ pub struct AuditLogEntry {
     #[serde(rename = "scopeType", default, skip_serializing_if = "Option::is_none")]
     pub scope_type: Option<audit_log_entry::ScopeType>,
     #[doc = "The time when the event occurred in UTC"]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub timestamp: Option<time::OffsetDateTime>,
     #[doc = "The user agent from the request"]
     #[serde(rename = "userAgent", default, skip_serializing_if = "Option::is_none")]
@@ -194,6 +198,7 @@ pub struct AuditStream {
     #[serde(
         rename = "createdTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_time: Option<time::OffsetDateTime>,
@@ -221,6 +226,7 @@ pub struct AuditStream {
     #[serde(
         rename = "updatedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_time: Option<time::OffsetDateTime>,
@@ -369,7 +375,11 @@ pub struct DecoratedAuditLogEntry {
     #[serde(rename = "scopeType", default, skip_serializing_if = "Option::is_none")]
     pub scope_type: Option<decorated_audit_log_entry::ScopeType>,
     #[doc = "The time when the event occurred in UTC"]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub timestamp: Option<time::OffsetDateTime>,
     #[doc = "The user agent from the request"]
     #[serde(rename = "userAgent", default, skip_serializing_if = "Option::is_none")]

--- a/azure_devops_rust_api/src/build/models.rs
+++ b/azure_devops_rust_api/src/build/models.rs
@@ -497,6 +497,7 @@ pub struct Build {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -518,6 +519,7 @@ pub struct Build {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -534,6 +536,7 @@ pub struct Build {
     #[serde(
         rename = "lastChangedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_date: Option<time::OffsetDateTime>,
@@ -588,6 +591,7 @@ pub struct Build {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -638,6 +642,7 @@ pub struct Build {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -845,6 +850,7 @@ pub struct BuildAgent {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -882,6 +888,7 @@ pub struct BuildAgent {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -1065,6 +1072,7 @@ pub struct BuildController {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1081,6 +1089,7 @@ pub struct BuildController {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -1597,6 +1606,7 @@ pub struct BuildDefinitionRevision {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -1679,6 +1689,7 @@ pub struct BuildDefinitionSourceProvider {
     #[serde(
         rename = "lastModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified: Option<time::OffsetDateTime>,
@@ -1973,6 +1984,7 @@ pub struct BuildLog {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -1980,6 +1992,7 @@ pub struct BuildLog {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -2034,7 +2047,11 @@ impl BuildLogReference {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BuildMetric {
     #[doc = "The date for the scope."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "The value."]
     #[serde(rename = "intValue", default, skip_serializing_if = "Option::is_none")]
@@ -2406,6 +2423,7 @@ pub struct BuildReference {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -2416,6 +2434,7 @@ pub struct BuildReference {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -2433,6 +2452,7 @@ pub struct BuildReference {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -2652,6 +2672,7 @@ pub struct BuildRetentionSample {
     #[serde(
         rename = "sampleTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub sample_time: Option<time::OffsetDateTime>,
@@ -2696,6 +2717,7 @@ pub struct BuildServer {
     #[serde(
         rename = "statusChangedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub status_changed_date: Option<time::OffsetDateTime>,
@@ -2760,6 +2782,7 @@ pub struct BuildSummary {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -2783,6 +2806,7 @@ pub struct BuildSummary {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -3010,7 +3034,11 @@ pub struct Change {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pusher: Option<String>,
     #[doc = "The timestamp for the change."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub timestamp: Option<time::OffsetDateTime>,
     #[doc = "The type of change. \"commit\", \"changeset\", etc."]
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
@@ -3283,6 +3311,7 @@ pub struct DefinitionReference {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -3542,6 +3571,7 @@ pub struct Folder {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3559,6 +3589,7 @@ pub struct Folder {
     #[serde(
         rename = "lastChangedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_date: Option<time::OffsetDateTime>,
@@ -3757,6 +3788,7 @@ pub struct InformationNode {
     #[serde(
         rename = "lastModifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
@@ -4444,6 +4476,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -4458,6 +4491,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
@@ -4588,6 +4622,7 @@ pub struct RetentionLease {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -4618,6 +4653,7 @@ pub struct RetentionLease {
     #[serde(
         rename = "validUntil",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_until: Option<time::OffsetDateTime>,
@@ -5567,6 +5603,7 @@ pub struct Timeline {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -5637,6 +5674,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -5656,6 +5694,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "lastModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified: Option<time::OffsetDateTime>,
@@ -5702,6 +5741,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -6111,6 +6151,7 @@ pub struct WorkspaceTemplate {
     #[serde(
         rename = "lastModifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
@@ -6179,6 +6220,7 @@ pub struct XamlBuildDefinition {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/clt/models.rs
+++ b/azure_devops_rust_api/src/clt/models.rs
@@ -15,6 +15,7 @@ pub struct AgentGroup {
     #[serde(
         rename = "creationTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_time: Option<time::OffsetDateTime>,
@@ -314,6 +315,7 @@ pub struct CounterInstanceSamples {
     #[serde(
         rename = "nextRefreshTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub next_refresh_time: Option<time::OffsetDateTime>,
@@ -361,6 +363,7 @@ pub struct CounterSample {
     #[serde(
         rename = "intervalEndDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub interval_end_date: Option<time::OffsetDateTime>,
@@ -459,6 +462,7 @@ pub struct Diagnostics {
     #[serde(
         rename = "lastModifiedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_time: Option<time::OffsetDateTime>,
@@ -498,6 +502,7 @@ pub struct ErrorDetails {
     #[serde(
         rename = "lastErrorDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_error_date: Option<time::OffsetDateTime>,
@@ -1168,6 +1173,7 @@ pub struct TestDefinitionBasic {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1183,6 +1189,7 @@ pub struct TestDefinitionBasic {
     #[serde(
         rename = "lastModifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
@@ -1243,6 +1250,7 @@ pub struct TestDrop {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1424,6 +1432,7 @@ pub struct TestRun {
     #[serde(
         rename = "executionFinishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub execution_finished_date: Option<time::OffsetDateTime>,
@@ -1431,6 +1440,7 @@ pub struct TestRun {
     #[serde(
         rename = "executionStartedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub execution_started_date: Option<time::OffsetDateTime>,
@@ -1438,6 +1448,7 @@ pub struct TestRun {
     #[serde(
         rename = "queuedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queued_date: Option<time::OffsetDateTime>,
@@ -1468,6 +1479,7 @@ pub struct TestRun {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -1498,6 +1510,7 @@ pub struct TestRun {
     #[serde(
         rename = "warmUpStartedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub warm_up_started_date: Option<time::OffsetDateTime>,
@@ -1571,6 +1584,7 @@ pub struct TestRunAbortMessage {
     #[serde(
         rename = "loggedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub logged_date: Option<time::OffsetDateTime>,
@@ -1592,6 +1606,7 @@ pub struct TestRunBasic {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1602,6 +1617,7 @@ pub struct TestRunBasic {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -1609,6 +1625,7 @@ pub struct TestRunBasic {
     #[serde(
         rename = "finishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finished_date: Option<time::OffsetDateTime>,
@@ -1796,6 +1813,7 @@ pub struct TestRunMessage {
     #[serde(
         rename = "loggedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub logged_date: Option<time::OffsetDateTime>,
@@ -2130,6 +2148,7 @@ pub struct WebApiTestMachine {
     #[serde(
         rename = "lastHeartBeat",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_heart_beat: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/core/models.rs
+++ b/azure_devops_rust_api/src/core/models.rs
@@ -421,6 +421,7 @@ pub struct ProjectInfo {
     #[serde(
         rename = "lastUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
@@ -956,6 +957,7 @@ pub struct TemporaryDataCreatedDto {
     #[serde(
         rename = "expirationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub expiration_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/distributed_task/models.rs
+++ b/azure_devops_rust_api/src/distributed_task/models.rs
@@ -68,6 +68,7 @@ pub struct AgentJobRequestMessage {
     #[serde(
         rename = "lockedUntil",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub locked_until: Option<time::OffsetDateTime>,
@@ -200,6 +201,7 @@ pub struct AzureKeyVaultVariableGroupProviderData {
     #[serde(
         rename = "lastRefreshedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_refreshed_on: Option<time::OffsetDateTime>,
@@ -230,7 +232,11 @@ pub struct AzureKeyVaultVariableValue {
     pub content_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub expires: Option<time::OffsetDateTime>,
 }
 impl AzureKeyVaultVariableValue {
@@ -1202,6 +1208,7 @@ pub struct ElasticNode {
     #[serde(
         rename = "stateChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub state_changed_on: Option<time::OffsetDateTime>,
@@ -1409,6 +1416,7 @@ pub struct ElasticPool {
     #[serde(
         rename = "offlineSince",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub offline_since: Option<time::OffsetDateTime>,
@@ -1547,7 +1555,11 @@ pub struct ElasticPoolLog {
     #[serde(rename = "poolId", default, skip_serializing_if = "Option::is_none")]
     pub pool_id: Option<i32>,
     #[doc = "Datetime that the log occurred"]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub timestamp: Option<time::OffsetDateTime>,
 }
 impl ElasticPoolLog {
@@ -1756,6 +1768,7 @@ pub struct EnvironmentDeploymentExecutionRecord {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -1785,6 +1798,7 @@ pub struct EnvironmentDeploymentExecutionRecord {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -1829,6 +1843,7 @@ pub struct EnvironmentDeploymentExecutionRecord {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -1884,6 +1899,7 @@ pub struct EnvironmentInstance {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -1904,6 +1920,7 @@ pub struct EnvironmentInstance {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -1979,6 +1996,7 @@ pub struct EnvironmentResource {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -2001,6 +2019,7 @@ pub struct EnvironmentResource {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -2051,6 +2070,7 @@ pub struct EnvironmentResourceDeploymentExecutionRecord {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -2071,6 +2091,7 @@ pub struct EnvironmentResourceDeploymentExecutionRecord {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -3134,6 +3155,7 @@ pub struct PackageMetadata {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3426,6 +3448,7 @@ pub struct ResourceLockRequest {
     #[serde(
         rename = "assignTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub assign_time: Option<time::OffsetDateTime>,
@@ -3447,6 +3470,7 @@ pub struct ResourceLockRequest {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -3473,6 +3497,7 @@ pub struct ResourceLockRequest {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -3628,6 +3653,7 @@ pub struct SecureFile {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3643,6 +3669,7 @@ pub struct SecureFile {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -3874,6 +3901,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -3893,6 +3921,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -4227,6 +4256,7 @@ pub struct TaskAgent {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -4258,6 +4288,7 @@ pub struct TaskAgent {
     #[serde(
         rename = "statusChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub status_changed_on: Option<time::OffsetDateTime>,
@@ -4409,6 +4440,7 @@ pub struct TaskAgentCloudRequest {
     #[serde(
         rename = "agentConnectedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub agent_connected_time: Option<time::OffsetDateTime>,
@@ -4426,18 +4458,21 @@ pub struct TaskAgentCloudRequest {
     #[serde(
         rename = "provisionedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub provisioned_time: Option<time::OffsetDateTime>,
     #[serde(
         rename = "provisionRequestTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub provision_request_time: Option<time::OffsetDateTime>,
     #[serde(
         rename = "releaseRequestTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub release_request_time: Option<time::OffsetDateTime>,
@@ -4567,6 +4602,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "assignTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub assign_time: Option<time::OffsetDateTime>,
@@ -4587,6 +4623,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -4603,6 +4640,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "lockedUntil",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub locked_until: Option<time::OffsetDateTime>,
@@ -4648,6 +4686,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -4655,6 +4694,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "receiveTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub receive_time: Option<time::OffsetDateTime>,
@@ -4923,6 +4963,7 @@ pub struct TaskAgentPool {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -5032,6 +5073,7 @@ pub struct TaskAgentPoolMaintenanceJob {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -5059,6 +5101,7 @@ pub struct TaskAgentPoolMaintenanceJob {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -5076,6 +5119,7 @@ pub struct TaskAgentPoolMaintenanceJob {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -5586,6 +5630,7 @@ pub struct TaskAgentUpdate {
     #[serde(
         rename = "requestTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub request_time: Option<time::OffsetDateTime>,
@@ -5652,6 +5697,7 @@ pub struct TaskAttachment {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -5664,6 +5710,7 @@ pub struct TaskAttachment {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -6045,6 +6092,7 @@ pub struct TaskGroup {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -6062,6 +6110,7 @@ pub struct TaskGroup {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -6263,6 +6312,7 @@ pub struct TaskGroupRevision {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -6686,6 +6736,7 @@ pub struct TaskLog {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -6698,6 +6749,7 @@ pub struct TaskLog {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -6865,6 +6917,7 @@ pub struct TaskOrchestrationPlan {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -6901,6 +6954,7 @@ pub struct TaskOrchestrationPlan {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -7037,6 +7091,7 @@ pub struct TaskOrchestrationQueuedPlan {
     #[serde(
         rename = "assignTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub assign_time: Option<time::OffsetDateTime>,
@@ -7061,6 +7116,7 @@ pub struct TaskOrchestrationQueuedPlan {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -7266,6 +7322,7 @@ pub struct Timeline {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -7337,6 +7394,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -7353,6 +7411,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "lastModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified: Option<time::OffsetDateTime>,
@@ -7395,6 +7454,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -7521,6 +7581,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -7544,6 +7605,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/extension_management/models.rs
+++ b/azure_devops_rust_api/src/extension_management/models.rs
@@ -714,6 +714,7 @@ pub struct ExtensionAuditLogEntry {
     #[serde(
         rename = "auditDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub audit_date: Option<time::OffsetDateTime>,
@@ -1183,6 +1184,7 @@ pub struct ExtensionRequest {
     #[serde(
         rename = "requestDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub request_date: Option<time::OffsetDateTime>,
@@ -1211,6 +1213,7 @@ pub struct ExtensionRequest {
     #[serde(
         rename = "resolveDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub resolve_date: Option<time::OffsetDateTime>,
@@ -1383,6 +1386,7 @@ pub struct ExtensionState {
     #[serde(
         rename = "lastVersionCheck",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_version_check: Option<time::OffsetDateTime>,
@@ -1469,6 +1473,7 @@ pub struct ExtensionVersion {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -1658,6 +1663,7 @@ pub struct InstalledExtension {
     #[serde(
         rename = "lastPublished",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_published: Option<time::OffsetDateTime>,
@@ -1748,6 +1754,7 @@ pub struct InstalledExtensionState {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -1874,6 +1881,7 @@ pub struct PublishedExtension {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -1887,6 +1895,7 @@ pub struct PublishedExtension {
     #[serde(
         rename = "publishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub published_date: Option<time::OffsetDateTime>,
@@ -1897,6 +1906,7 @@ pub struct PublishedExtension {
     #[serde(
         rename = "releaseDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub release_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -151,6 +151,7 @@ pub struct Attachment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -315,6 +316,7 @@ pub struct ChangeList {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -337,6 +339,7 @@ pub struct ChangeList {
     #[serde(
         rename = "sortDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub sort_date: Option<time::OffsetDateTime>,
@@ -463,6 +466,7 @@ pub struct Comment {
     #[serde(
         rename = "lastContentUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_content_updated_date: Option<time::OffsetDateTime>,
@@ -470,6 +474,7 @@ pub struct Comment {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -484,6 +489,7 @@ pub struct Comment {
     #[serde(
         rename = "publishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub published_date: Option<time::OffsetDateTime>,
@@ -597,6 +603,7 @@ pub struct CommentThread {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -607,6 +614,7 @@ pub struct CommentThread {
     #[serde(
         rename = "publishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub published_date: Option<time::OffsetDateTime>,
@@ -1519,6 +1527,7 @@ pub struct GitConflict {
     #[serde(
         rename = "resolvedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub resolved_date: Option<time::OffsetDateTime>,
@@ -2083,6 +2092,7 @@ pub struct GitDeletedRepository {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -2092,6 +2102,7 @@ pub struct GitDeletedRepository {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -2741,6 +2752,7 @@ pub struct GitLastChangeTreeItems {
     #[serde(
         rename = "lastExploredTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_explored_time: Option<time::OffsetDateTime>,
@@ -3013,6 +3025,7 @@ pub struct GitPullRequest {
     #[serde(
         rename = "closedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub closed_date: Option<time::OffsetDateTime>,
@@ -3041,6 +3054,7 @@ pub struct GitPullRequest {
     #[serde(
         rename = "completionQueueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completion_queue_time: Option<time::OffsetDateTime>,
@@ -3548,6 +3562,7 @@ pub struct GitPullRequestIteration {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -3602,6 +3617,7 @@ pub struct GitPullRequestIteration {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -4007,7 +4023,11 @@ pub struct GitPushRef {
     #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
     pub links: Option<ReferenceLinks>,
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = ""]
     #[serde(rename = "pushedBy", default, skip_serializing_if = "Option::is_none")]
@@ -4028,6 +4048,7 @@ pub struct GitPushSearchCriteria {
     #[serde(
         rename = "fromDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub from_date: Option<time::OffsetDateTime>,
@@ -4048,7 +4069,12 @@ pub struct GitPushSearchCriteria {
     pub pusher_id: Option<String>,
     #[serde(rename = "refName", default, skip_serializing_if = "Option::is_none")]
     pub ref_name: Option<String>,
-    #[serde(rename = "toDate", default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        rename = "toDate",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub to_date: Option<time::OffsetDateTime>,
 }
 impl GitPushSearchCriteria {
@@ -4899,6 +4925,7 @@ pub struct GitStatus {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -4918,6 +4945,7 @@ pub struct GitStatus {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -5322,7 +5350,11 @@ impl GitTreeRef {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitUserDate {
     #[doc = "Date of the Git operation."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Email address of the user performing the Git operation."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5706,6 +5738,7 @@ pub struct IncludedGitCommit {
     #[serde(
         rename = "commitTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub commit_time: Option<time::OffsetDateTime>,
@@ -5987,6 +6020,7 @@ pub struct PolicyConfiguration {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -6610,6 +6644,7 @@ pub struct TfvcBranchRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -6764,6 +6799,7 @@ pub struct TfvcChangesetRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -6895,6 +6931,7 @@ pub struct TfvcItem {
     #[serde(
         rename = "changeDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub change_date: Option<time::OffsetDateTime>,
@@ -7103,6 +7140,7 @@ pub struct TfvcLabelRef {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -7318,6 +7356,7 @@ pub struct TfvcShelvesetRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/graph/models.rs
+++ b/azure_devops_rust_api/src/graph/models.rs
@@ -19,6 +19,7 @@ pub struct Avatar {
     #[serde(
         rename = "timeStamp",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/hooks/models.rs
+++ b/azure_devops_rust_api/src/hooks/models.rs
@@ -183,6 +183,7 @@ pub struct Event {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -762,6 +763,7 @@ pub struct Notification {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -778,6 +780,7 @@ pub struct Notification {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -841,6 +844,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -869,6 +873,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "dequeuedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub dequeued_date: Option<time::OffsetDateTime>,
@@ -896,6 +901,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "processedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub processed_date: Option<time::OffsetDateTime>,
@@ -917,6 +923,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "queuedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queued_date: Option<time::OffsetDateTime>,
@@ -1042,6 +1049,7 @@ pub struct NotificationsQuery {
     #[serde(
         rename = "maxCreatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_created_date: Option<time::OffsetDateTime>,
@@ -1063,6 +1071,7 @@ pub struct NotificationsQuery {
     #[serde(
         rename = "minCreatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub min_created_date: Option<time::OffsetDateTime>,
@@ -1327,6 +1336,7 @@ pub struct SessionToken {
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
@@ -1373,6 +1383,7 @@ pub struct Subscription {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1389,6 +1400,7 @@ pub struct Subscription {
     #[serde(
         rename = "lastProbationRetryDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_probation_retry_date: Option<time::OffsetDateTime>,
@@ -1402,6 +1414,7 @@ pub struct Subscription {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -1550,6 +1563,7 @@ pub struct SubscriptionTracing {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -1564,6 +1578,7 @@ pub struct SubscriptionTracing {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/ims/models.rs
+++ b/azure_devops_rust_api/src/ims/models.rs
@@ -55,6 +55,7 @@ pub struct AccessTokenResult {
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/member_entitlement_management/models.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/models.rs
@@ -266,6 +266,7 @@ pub struct ExtensionSummaryData {
     #[serde(
         rename = "trialExpiryDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub trial_expiry_date: Option<time::OffsetDateTime>,
@@ -467,6 +468,7 @@ pub struct GroupEntitlement {
     #[serde(
         rename = "lastExecuted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_executed: Option<time::OffsetDateTime>,
@@ -685,6 +687,7 @@ pub struct LicenseSummaryData {
     #[serde(
         rename = "nextBillingDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub next_billing_date: Option<time::OffsetDateTime>,
@@ -1082,6 +1085,7 @@ pub struct UserEntitlement {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
@@ -1100,6 +1104,7 @@ pub struct UserEntitlement {
     #[serde(
         rename = "lastAccessedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_accessed_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/permissions_report/models.rs
+++ b/azure_devops_rust_api/src/permissions_report/models.rs
@@ -29,12 +29,14 @@ pub struct PermissionsReport {
     #[serde(
         rename = "reportStatusLastUpdatedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub report_status_last_updated_time: Option<time::OffsetDateTime>,
     #[serde(
         rename = "requestedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub requested_time: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/pipelines/models.rs
+++ b/azure_devops_rust_api/src/pipelines/models.rs
@@ -113,6 +113,7 @@ pub struct Log {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -123,6 +124,7 @@ pub struct Log {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -439,6 +441,7 @@ pub struct Run {
     #[serde(
         rename = "finishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finished_date: Option<time::OffsetDateTime>,
@@ -625,6 +628,7 @@ pub struct SignedUrl {
     #[serde(
         rename = "signatureExpires",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub signature_expires: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/policy/models.rs
+++ b/azure_devops_rust_api/src/policy/models.rs
@@ -125,6 +125,7 @@ pub struct PolicyConfiguration {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -209,6 +210,7 @@ pub struct PolicyEvaluationRecord {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -229,6 +231,7 @@ pub struct PolicyEvaluationRecord {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/profile/models.rs
+++ b/azure_devops_rust_api/src/profile/models.rs
@@ -64,6 +64,7 @@ pub struct Avatar {
     #[serde(
         rename = "timeStamp",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,
@@ -241,6 +242,7 @@ pub struct Profile {
     #[serde(
         rename = "timeStamp",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,
@@ -287,6 +289,7 @@ pub struct ProfileAttributeBase {
     #[serde(
         rename = "timeStamp",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/release/models.rs
+++ b/azure_devops_rust_api/src/release/models.rs
@@ -809,6 +809,7 @@ pub struct AzureKeyVaultVariableGroupProviderData {
     #[serde(
         rename = "lastRefreshedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_refreshed_on: Option<time::OffsetDateTime>,
@@ -844,7 +845,11 @@ pub struct AzureKeyVaultVariableValue {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     #[doc = "Gets or sets the expire time of key vault variable value."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub expires: Option<time::OffsetDateTime>,
 }
 impl AzureKeyVaultVariableValue {
@@ -1007,7 +1012,11 @@ pub struct Change {
     #[serde(rename = "pushedBy", default, skip_serializing_if = "Option::is_none")]
     pub pushed_by: Option<IdentityRef>,
     #[doc = "A timestamp for the change."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub timestamp: Option<time::OffsetDateTime>,
 }
 impl Change {
@@ -1517,6 +1526,7 @@ pub struct Deployment {
     #[serde(
         rename = "completedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_on: Option<time::OffsetDateTime>,
@@ -1555,6 +1565,7 @@ pub struct Deployment {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -1592,6 +1603,7 @@ pub struct Deployment {
     #[serde(
         rename = "queuedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queued_on: Option<time::OffsetDateTime>,
@@ -1633,6 +1645,7 @@ pub struct Deployment {
     #[serde(
         rename = "scheduledDeploymentTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_deployment_time: Option<time::OffsetDateTime>,
@@ -1640,6 +1653,7 @@ pub struct Deployment {
     #[serde(
         rename = "startedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_on: Option<time::OffsetDateTime>,
@@ -1821,6 +1835,7 @@ pub struct DeploymentAttempt {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -1849,6 +1864,7 @@ pub struct DeploymentAttempt {
     #[serde(
         rename = "queuedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queued_on: Option<time::OffsetDateTime>,
@@ -2550,6 +2566,7 @@ pub struct Folder {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -2567,6 +2584,7 @@ pub struct Folder {
     #[serde(
         rename = "lastChangedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_date: Option<time::OffsetDateTime>,
@@ -2786,6 +2804,7 @@ pub struct IgnoredGate {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -3156,6 +3175,7 @@ pub struct MailMessage {
     #[serde(
         rename = "replyBy",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub reply_by: Option<time::OffsetDateTime>,
@@ -3212,6 +3232,7 @@ pub struct ManualIntervention {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3225,6 +3246,7 @@ pub struct ManualIntervention {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -3830,6 +3852,7 @@ pub struct Release {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3878,6 +3901,7 @@ pub struct Release {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -4030,6 +4054,7 @@ pub struct ReleaseApproval {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -4054,6 +4079,7 @@ pub struct ReleaseApproval {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -4141,6 +4167,7 @@ pub struct ReleaseApprovalHistory {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -4148,6 +4175,7 @@ pub struct ReleaseApprovalHistory {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -4365,6 +4393,7 @@ pub struct ReleaseDefinition {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -4399,6 +4428,7 @@ pub struct ReleaseDefinition {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -4873,6 +4903,7 @@ pub struct ReleaseDefinitionRevision {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -5055,6 +5086,7 @@ pub struct ReleaseDeployPhase {
     #[serde(
         rename = "startedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_on: Option<time::OffsetDateTime>,
@@ -5120,6 +5152,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -5160,6 +5193,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -5170,6 +5204,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "nextScheduledUtcTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub next_scheduled_utc_time: Option<time::OffsetDateTime>,
@@ -5254,6 +5289,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "scheduledDeploymentTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_deployment_time: Option<time::OffsetDateTime>,
@@ -5566,6 +5602,7 @@ pub struct ReleaseEnvironmentUpdateMetadata {
     #[serde(
         rename = "scheduledDeploymentTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_deployment_time: Option<time::OffsetDateTime>,
@@ -5645,6 +5682,7 @@ pub struct ReleaseGates {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -5655,6 +5693,7 @@ pub struct ReleaseGates {
     #[serde(
         rename = "stabilizationCompletedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub stabilization_completed_on: Option<time::OffsetDateTime>,
@@ -5662,6 +5701,7 @@ pub struct ReleaseGates {
     #[serde(
         rename = "startedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_on: Option<time::OffsetDateTime>,
@@ -5672,6 +5712,7 @@ pub struct ReleaseGates {
     #[serde(
         rename = "succeedingSince",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub succeeding_since: Option<time::OffsetDateTime>,
@@ -5717,6 +5758,7 @@ pub struct ReleaseGatesPhase {
     #[serde(
         rename = "stabilizationCompletedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub stabilization_completed_on: Option<time::OffsetDateTime>,
@@ -5724,6 +5766,7 @@ pub struct ReleaseGatesPhase {
     #[serde(
         rename = "succeedingSince",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub succeeding_since: Option<time::OffsetDateTime>,
@@ -5836,6 +5879,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -5898,6 +5942,7 @@ pub struct ReleaseRevision {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -6150,6 +6195,7 @@ pub struct ReleaseTask {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -6193,6 +6239,7 @@ pub struct ReleaseTask {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -6252,6 +6299,7 @@ pub struct ReleaseTaskAttachment {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -6266,6 +6314,7 @@ pub struct ReleaseTaskAttachment {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -6649,6 +6698,7 @@ pub struct SourcePullRequestVersion {
     #[serde(
         rename = "pullRequestMergedAt",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub pull_request_merged_at: Option<time::OffsetDateTime>,
@@ -6943,6 +6993,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -6966,6 +7017,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/service_endpoint/models.rs
+++ b/azure_devops_rust_api/src/service_endpoint/models.rs
@@ -1132,6 +1132,7 @@ pub struct OAuthConfiguration {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -1156,6 +1157,7 @@ pub struct OAuthConfiguration {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -1514,6 +1516,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -1533,6 +1536,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/status/models.rs
+++ b/azure_devops_rust_api/src/status/models.rs
@@ -70,6 +70,7 @@ pub struct LiveSiteEvent {
     #[serde(
         rename = "endTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_time: Option<time::OffsetDateTime>,
@@ -96,6 +97,7 @@ pub struct LiveSiteEvent {
     #[serde(
         rename = "nextUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub next_update_time: Option<time::OffsetDateTime>,
@@ -104,6 +106,7 @@ pub struct LiveSiteEvent {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -187,6 +190,7 @@ pub struct LiveSiteEventLog {
     #[serde(
         rename = "creationDateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date_time: Option<time::OffsetDateTime>,
@@ -205,6 +209,7 @@ pub struct LiveSiteEventLog {
     #[serde(
         rename = "lastUpdatedDateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date_time: Option<time::OffsetDateTime>,
@@ -246,6 +251,7 @@ pub struct LiveSiteEventLogAttachment {
     #[serde(
         rename = "creationDateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date_time: Option<time::OffsetDateTime>,
@@ -497,6 +503,7 @@ pub struct Status {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/symbol/models.rs
+++ b/azure_devops_rust_api/src/symbol/models.rs
@@ -233,6 +233,7 @@ pub struct Request {
     #[serde(
         rename = "expirationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub expiration_date: Option<time::OffsetDateTime>,
@@ -279,6 +280,7 @@ pub struct ResourceBase {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/test/models.rs
+++ b/azure_devops_rust_api/src/test/models.rs
@@ -40,6 +40,7 @@ pub struct AfnStrip {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -572,6 +573,7 @@ pub struct BuildConfiguration {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -786,6 +788,7 @@ pub struct BuildReference2 {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -842,6 +845,7 @@ pub struct CloneOperationInformation {
     #[serde(
         rename = "completionDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completion_date: Option<time::OffsetDateTime>,
@@ -849,6 +853,7 @@ pub struct CloneOperationInformation {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -1215,12 +1220,14 @@ pub struct Coverage2 {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_modified: Option<time::OffsetDateTime>,
@@ -1415,7 +1422,11 @@ pub mod custom_test_field_definition {
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DatedTestFieldData {
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = ""]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1526,7 +1537,11 @@ pub struct FailingSince {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<BuildReference>,
     #[doc = "Time since failing(UTC)."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Reference to a release."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2036,6 +2051,7 @@ pub struct LastResultDetails {
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
@@ -2115,12 +2131,14 @@ pub struct LegacyBuildConfiguration {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -2168,6 +2186,7 @@ pub struct LegacyReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
@@ -2192,6 +2211,7 @@ pub struct LegacyReleaseReference {
     #[serde(
         rename = "releaseCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub release_creation_date: Option<time::OffsetDateTime>,
@@ -2330,6 +2350,7 @@ pub struct LegacyTestCaseResult {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -2343,12 +2364,14 @@ pub struct LegacyTestCaseResult {
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
@@ -2381,6 +2404,7 @@ pub struct LegacyTestCaseResult {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -2610,6 +2634,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "completeDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub complete_date: Option<time::OffsetDateTime>,
@@ -2625,6 +2650,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -2670,6 +2696,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "dueDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
@@ -2707,6 +2734,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -2811,6 +2839,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -2948,6 +2977,7 @@ pub struct LegacyTestSettings {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -2966,6 +2996,7 @@ pub struct LegacyTestSettings {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -3443,6 +3474,7 @@ pub struct PointLastResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -3581,6 +3613,7 @@ pub struct PointsResults2 {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -3859,6 +3892,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -3873,6 +3907,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
@@ -3924,6 +3959,7 @@ pub struct ReleaseReference2 {
     #[serde(
         rename = "environmentCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
@@ -3932,6 +3968,7 @@ pub struct ReleaseReference2 {
     #[serde(
         rename = "releaseCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub release_creation_date: Option<time::OffsetDateTime>,
@@ -3999,6 +4036,7 @@ pub struct RequirementsToTestsMapping2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -4007,6 +4045,7 @@ pub struct RequirementsToTestsMapping2 {
     #[serde(
         rename = "deletionDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deletion_date: Option<time::OffsetDateTime>,
@@ -4195,6 +4234,7 @@ pub struct ResultRetentionSettings {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -4347,6 +4387,7 @@ pub struct ResultUpdateResponse {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -4488,6 +4529,7 @@ pub struct ResultsFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -5617,18 +5659,21 @@ pub struct TestActionResult {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
@@ -5652,6 +5697,7 @@ pub struct TestActionResult {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -5695,18 +5741,21 @@ pub struct TestActionResult2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
@@ -5727,6 +5776,7 @@ pub struct TestActionResult2 {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -5817,6 +5867,7 @@ pub struct TestAttachment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -5926,6 +5977,7 @@ pub struct TestAuthoringDetails {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -6040,12 +6092,14 @@ pub struct TestCaseReference2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "lastRefTestRunDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_ref_test_run_date: Option<time::OffsetDateTime>,
@@ -6164,6 +6218,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -6181,6 +6236,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -6242,6 +6298,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -6312,6 +6369,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -6601,6 +6659,7 @@ pub struct TestConfiguration {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -6969,6 +7028,7 @@ pub struct TestHistoryQuery {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -7039,6 +7099,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -7073,6 +7134,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -7119,6 +7181,7 @@ pub struct TestLog {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -7350,6 +7413,7 @@ pub struct TestMessageLogDetails {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
@@ -7371,6 +7435,7 @@ pub struct TestMessageLogEntry {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
@@ -7406,6 +7471,7 @@ pub struct TestMessageLogEntry2 {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
@@ -7491,6 +7557,7 @@ pub struct TestParameter2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -7499,6 +7566,7 @@ pub struct TestParameter2 {
     #[serde(
         rename = "dateModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_modified: Option<time::OffsetDateTime>,
@@ -7557,6 +7625,7 @@ pub struct TestPlan {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -7599,6 +7668,7 @@ pub struct TestPlan {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -7618,6 +7688,7 @@ pub struct TestPlan {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -7754,6 +7825,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastResetToActive",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_reset_to_active: Option<time::OffsetDateTime>,
@@ -7810,6 +7882,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -7999,18 +8072,21 @@ pub struct TestResult2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
@@ -8029,6 +8105,7 @@ pub struct TestResult2 {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -8124,6 +8201,7 @@ pub struct TestResultAttachment {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -8555,6 +8633,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -8579,6 +8658,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -8705,6 +8785,7 @@ pub struct TestResultReset2 {
     #[serde(
         rename = "dateModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_modified: Option<time::OffsetDateTime>,
@@ -8815,6 +8896,7 @@ pub struct TestResultTrendFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -8942,12 +9024,14 @@ pub struct TestResultsEx2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateTimeValue",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_time_value: Option<time::OffsetDateTime>,
@@ -9112,6 +9196,7 @@ pub struct TestResultsWithWatermark {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -9152,6 +9237,7 @@ pub struct TestRun {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -9162,6 +9248,7 @@ pub struct TestRun {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -9205,6 +9292,7 @@ pub struct TestRun {
     #[serde(
         rename = "dueDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
@@ -9249,6 +9337,7 @@ pub struct TestRun {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -9326,6 +9415,7 @@ pub struct TestRun {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -9437,6 +9527,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "completeDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub complete_date: Option<time::OffsetDateTime>,
@@ -9451,12 +9542,14 @@ pub struct TestRun2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "deletedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_on: Option<time::OffsetDateTime>,
@@ -9469,6 +9562,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "dueDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
@@ -9507,6 +9601,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -9573,6 +9668,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -9753,12 +9849,14 @@ pub struct TestRunEx2 {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateTimeValue",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_time_value: Option<time::OffsetDateTime>,
@@ -9930,6 +10028,7 @@ pub struct TestRunSummary2 {
     #[serde(
         rename = "testRunCompletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub test_run_completed_date: Option<time::OffsetDateTime>,
@@ -10002,6 +10101,7 @@ pub struct TestSession {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -10019,6 +10119,7 @@ pub struct TestSession {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -10045,6 +10146,7 @@ pub struct TestSession {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -10117,6 +10219,7 @@ pub struct TestSessionExploredWorkItemReference {
     #[serde(
         rename = "endTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_time: Option<time::OffsetDateTime>,
@@ -10124,6 +10227,7 @@ pub struct TestSessionExploredWorkItemReference {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -10223,6 +10327,7 @@ pub struct TestSettings2 {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -10242,6 +10347,7 @@ pub struct TestSettings2 {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -10306,6 +10412,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -10355,6 +10462,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -10389,6 +10497,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -10479,6 +10588,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastPopulatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_populated_date: Option<time::OffsetDateTime>,
@@ -10493,6 +10603,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -10774,6 +10885,7 @@ pub struct UpdatedProperties {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/test_plan/models.rs
+++ b/azure_devops_rust_api/src/test_plan/models.rs
@@ -34,6 +34,7 @@ pub struct CloneOperationCommonResponse {
     #[serde(
         rename = "completionDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completion_date: Option<time::OffsetDateTime>,
@@ -41,6 +42,7 @@ pub struct CloneOperationCommonResponse {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -575,6 +577,7 @@ pub struct LastResultDetails {
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
@@ -1163,6 +1166,7 @@ pub struct TestCaseAssociatedResult {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -1498,6 +1502,7 @@ pub struct TestPlan {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -1530,6 +1535,7 @@ pub struct TestPlanCreateParams {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -1553,6 +1559,7 @@ pub struct TestPlanCreateParams {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -1584,6 +1591,7 @@ pub struct TestPlanDetailedReference {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -1601,6 +1609,7 @@ pub struct TestPlanDetailedReference {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -1833,6 +1842,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastResetToActive",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_reset_to_active: Option<time::OffsetDateTime>,
@@ -1847,6 +1857,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -2193,6 +2204,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastPopulatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_populated_date: Option<time::OffsetDateTime>,
@@ -2207,6 +2219,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/test_results/models.rs
+++ b/azure_devops_rust_api/src/test_results/models.rs
@@ -386,6 +386,7 @@ pub struct BuildConfiguration {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -718,7 +719,11 @@ pub struct FailingSince {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<BuildReference>,
     #[doc = "Time since failing(UTC)."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Reference to a release."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1184,6 +1189,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -1198,6 +1204,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
@@ -1309,6 +1316,7 @@ pub struct ResultsFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -2209,6 +2217,7 @@ pub struct TestAttachment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -2356,6 +2365,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -2373,6 +2383,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -2434,6 +2445,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -2504,6 +2516,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -2765,6 +2778,7 @@ pub struct TestHistoryQuery {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -2835,6 +2849,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -2869,6 +2884,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -2898,6 +2914,7 @@ pub struct TestLog {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -3068,6 +3085,7 @@ pub struct TestMessageLogDetails {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
@@ -3347,6 +3365,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -3371,6 +3390,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -3520,6 +3540,7 @@ pub struct TestResultTrendFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -3733,6 +3754,7 @@ pub struct TestRun {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -3743,6 +3765,7 @@ pub struct TestRun {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -3786,6 +3809,7 @@ pub struct TestRun {
     #[serde(
         rename = "dueDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
@@ -3830,6 +3854,7 @@ pub struct TestRun {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -3907,6 +3932,7 @@ pub struct TestRun {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -4098,6 +4124,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -4147,6 +4174,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -4181,6 +4209,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/tfvc/models.rs
+++ b/azure_devops_rust_api/src/tfvc/models.rs
@@ -609,6 +609,7 @@ pub struct TfvcBranchRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -793,6 +794,7 @@ pub struct TfvcChangesetRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -909,6 +911,7 @@ pub struct TfvcItem {
     #[serde(
         rename = "changeDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub change_date: Option<time::OffsetDateTime>,
@@ -1116,6 +1119,7 @@ pub struct TfvcLabelRef {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -1348,6 +1352,7 @@ pub struct TfvcShelvesetRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/token_admin/models.rs
+++ b/azure_devops_rust_api/src/token_admin/models.rs
@@ -68,12 +68,14 @@ pub struct SessionToken {
     #[serde(
         rename = "validFrom",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_from: Option<time::OffsetDateTime>,
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
@@ -217,6 +219,7 @@ pub struct TokenAdminRevocationRule {
     #[serde(
         rename = "createdBefore",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_before: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/wiki/models.rs
+++ b/azure_devops_rust_api/src/wiki/models.rs
@@ -24,6 +24,7 @@ pub struct Comment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -51,6 +52,7 @@ pub struct Comment {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -114,6 +116,7 @@ pub struct CommentAttachment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -980,7 +983,11 @@ pub struct WikiPageStat {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub count: Option<i32>,
     #[doc = "Day of the stat"]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub day: Option<time::OffsetDateTime>,
 }
 impl WikiPageStat {
@@ -998,6 +1005,7 @@ pub struct WikiPageViewStats {
     #[serde(
         rename = "lastViewedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_viewed_time: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/wit/models.rs
+++ b/azure_devops_rust_api/src/wit/models.rs
@@ -89,6 +89,7 @@ pub struct AccountRecentActivityWorkItemModelBase {
     #[serde(
         rename = "activityDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub activity_date: Option<time::OffsetDateTime>,
@@ -103,6 +104,7 @@ pub struct AccountRecentActivityWorkItemModelBase {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -174,6 +176,7 @@ pub struct AccountRecentMentionWorkItemModel {
     #[serde(
         rename = "mentionedDateField",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub mentioned_date_field: Option<time::OffsetDateTime>,
@@ -215,6 +218,7 @@ pub struct AccountWorkWorkItemModel {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -300,6 +304,7 @@ pub struct Comment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -307,6 +312,7 @@ pub struct Comment {
     #[serde(
         rename = "createdOnBehalfDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on_behalf_date: Option<time::OffsetDateTime>,
@@ -341,6 +347,7 @@ pub struct Comment {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -572,6 +579,7 @@ pub struct CommentVersion {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -579,6 +587,7 @@ pub struct CommentVersion {
     #[serde(
         rename = "createdOnBehalfDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on_behalf_date: Option<time::OffsetDateTime>,
@@ -606,6 +615,7 @@ pub struct CommentVersion {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -738,6 +748,7 @@ pub struct ExternalDeployment {
     #[serde(
         rename = "statusDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub status_date: Option<time::OffsetDateTime>,
@@ -1222,6 +1233,7 @@ pub struct QueryHierarchyItem {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1269,6 +1281,7 @@ pub struct QueryHierarchyItem {
     #[serde(
         rename = "lastExecutedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_executed_date: Option<time::OffsetDateTime>,
@@ -1283,6 +1296,7 @@ pub struct QueryHierarchyItem {
     #[serde(
         rename = "lastModifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
@@ -1768,7 +1782,12 @@ pub struct WorkItemBatchGetRequest {
     #[serde(rename = "$expand", default, skip_serializing_if = "Option::is_none")]
     pub expand: Option<work_item_batch_get_request::Expand>,
     #[doc = "AsOf UTC date time string"]
-    #[serde(rename = "asOf", default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        rename = "asOf",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub as_of: Option<time::OffsetDateTime>,
     #[doc = "The flag to control error policy in a bulk get work items request. Possible options are {Fail, Omit}."]
     #[serde(
@@ -1919,6 +1938,7 @@ pub struct WorkItemComment {
     #[serde(
         rename = "revisedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub revised_date: Option<time::OffsetDateTime>,
@@ -2366,6 +2386,7 @@ pub struct WorkItemHistory {
     #[serde(
         rename = "revisedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub revised_date: Option<time::OffsetDateTime>,
@@ -2555,7 +2576,12 @@ pub mod work_item_query_clause {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct WorkItemQueryResult {
     #[doc = "The date the query was run in the context of."]
-    #[serde(rename = "asOf", default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        rename = "asOf",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub as_of: Option<time::OffsetDateTime>,
     #[doc = "The columns of the query."]
     #[serde(
@@ -3364,6 +3390,7 @@ pub struct WorkItemUpdate {
     #[serde(
         rename = "revisedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub revised_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/work/models.rs
+++ b/azure_devops_rust_api/src/work/models.rs
@@ -815,10 +815,18 @@ pub mod create_plan {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DateRange {
     #[doc = "End of the date range."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub end: Option<time::OffsetDateTime>,
     #[doc = "Start of the date range."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub start: Option<time::OffsetDateTime>,
 }
 impl DateRange {
@@ -849,6 +857,7 @@ pub struct DeliveryViewData {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -871,6 +880,7 @@ pub struct DeliveryViewData {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -1255,7 +1265,11 @@ pub struct Marker {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     #[doc = "Where the marker should be displayed on the timeline."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Label/title for the marker."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1350,6 +1364,7 @@ pub struct Plan {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1370,6 +1385,7 @@ pub struct Plan {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -1460,6 +1476,7 @@ pub struct PlanMetadata {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -1970,6 +1987,7 @@ pub struct TeamIterationAttributes {
     #[serde(
         rename = "finishDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_date: Option<time::OffsetDateTime>,
@@ -1977,6 +1995,7 @@ pub struct TeamIterationAttributes {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -2441,6 +2460,7 @@ pub struct TimelineTeamIteration {
     #[serde(
         rename = "finishDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_date: Option<time::OffsetDateTime>,
@@ -2462,6 +2482,7 @@ pub struct TimelineTeamIteration {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,


### PR DESCRIPTION
I was trying to create a policy configuration but hitting errors like 

```
Error converting value {null} to type 'System.DateTime'. Path 'createdDate', line 1, position 250.
```
as I wasn't specifying some optional date times, and ADO returned 400 bad request on null datetimes.