### PR TITLE
Specify the correct token scope for ADO by default

### DIFF
--- a/autorust/codegen/src/codegen_operations.rs
+++ b/autorust/codegen/src/codegen_operations.rs
@@ -137,7 +137,7 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
             #[must_use]
             pub fn build(self) -> Client {
                 let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-                let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+                let scopes = self.scopes.unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
                 Client::new(endpoint, self.credential, scopes, self.options)
             }
         }

--- a/azure_devops_rust_api/src/accounts/mod.rs
+++ b/azure_devops_rust_api/src/accounts/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/artifacts/mod.rs
+++ b/azure_devops_rust_api/src/artifacts/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/artifacts_package_types/mod.rs
+++ b/azure_devops_rust_api/src/artifacts_package_types/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/audit/mod.rs
+++ b/azure_devops_rust_api/src/audit/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/build/mod.rs
+++ b/azure_devops_rust_api/src/build/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/clt/mod.rs
+++ b/azure_devops_rust_api/src/clt/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/core/mod.rs
+++ b/azure_devops_rust_api/src/core/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/dashboard/mod.rs
+++ b/azure_devops_rust_api/src/dashboard/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/distributed_task/mod.rs
+++ b/azure_devops_rust_api/src/distributed_task/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/extension_management/mod.rs
+++ b/azure_devops_rust_api/src/extension_management/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/git/mod.rs
+++ b/azure_devops_rust_api/src/git/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/graph/mod.rs
+++ b/azure_devops_rust_api/src/graph/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/hooks/mod.rs
+++ b/azure_devops_rust_api/src/hooks/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/ims/mod.rs
+++ b/azure_devops_rust_api/src/ims/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/lib.rs
+++ b/azure_devops_rust_api/src/lib.rs
@@ -128,3 +128,7 @@ pub use auth::Credential;
 pub mod date_time;
 
 pub(crate) mod serde;
+
+/// The token scope for Azure Devops
+/// https://learn.microsoft.com/en-us/rest/api/azure/devops/tokens/?view=azure-devops-rest-7.0&tabs=powershell
+pub const ADO_SCOPE: &str = "499b84ac-1321-427f-aa17-267ca6975798";

--- a/azure_devops_rust_api/src/member_entitlement_management/mod.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/operations/mod.rs
+++ b/azure_devops_rust_api/src/operations/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/permissions_report/mod.rs
+++ b/azure_devops_rust_api/src/permissions_report/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/pipelines/mod.rs
+++ b/azure_devops_rust_api/src/pipelines/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/policy/mod.rs
+++ b/azure_devops_rust_api/src/policy/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
@@ -155,6 +157,25 @@ pub mod configurations {
                 policy_type: None,
             }
         }
+        #[doc = "Create a policy configuration of a given policy type."]
+        #[doc = ""]
+        #[doc = "Arguments:"]
+        #[doc = "* `organization`: The name of the Azure DevOps organization."]
+        #[doc = "* `body`: The policy configuration to create."]
+        #[doc = "* `project`: Project ID or project name"]
+        pub fn create(
+            &self,
+            organization: impl Into<String>,
+            body: impl Into<models::PolicyConfiguration>,
+            project: impl Into<String>,
+        ) -> create::RequestBuilder {
+            create::RequestBuilder {
+                client: self.0.clone(),
+                organization: organization.into(),
+                body: body.into(),
+                project: project.into(),
+            }
+        }
         #[doc = "Get a policy configuration by its ID."]
         #[doc = ""]
         #[doc = "Arguments:"]
@@ -170,27 +191,6 @@ pub mod configurations {
             get::RequestBuilder {
                 client: self.0.clone(),
                 organization: organization.into(),
-                project: project.into(),
-                configuration_id,
-            }
-        }
-        #[doc = "Create a policy configuration of a given policy type."]
-        #[doc = ""]
-        #[doc = "Arguments:"]
-        #[doc = "* `organization`: The name of the Azure DevOps organization."]
-        #[doc = "* `body`: The policy configuration to create."]
-        #[doc = "* `project`: Project ID or project name"]
-        pub fn create(
-            &self,
-            organization: impl Into<String>,
-            body: impl Into<models::PolicyConfiguration>,
-            project: impl Into<String>,
-            configuration_id: i32,
-        ) -> create::RequestBuilder {
-            create::RequestBuilder {
-                client: self.0.clone(),
-                organization: organization.into(),
-                body: body.into(),
                 project: project.into(),
                 configuration_id,
             }
@@ -385,6 +385,114 @@ pub mod configurations {
             }
         }
     }
+    pub mod create {
+        use super::models;
+        pub struct Response(azure_core::Response);
+        impl Response {
+            pub async fn into_body(self) -> azure_core::Result<models::PolicyConfiguration> {
+                let bytes = self.0.into_body().collect().await?;
+                let body: models::PolicyConfiguration =
+                    serde_json::from_slice(&bytes).map_err(|e| {
+                        azure_core::error::Error::full(
+                            azure_core::error::ErrorKind::DataConversion,
+                            e,
+                            format!(
+                                "Failed to deserialize response:\n{}",
+                                String::from_utf8_lossy(&bytes)
+                            ),
+                        )
+                    })?;
+                Ok(body)
+            }
+            pub fn into_raw_response(self) -> azure_core::Response {
+                self.0
+            }
+            pub fn as_raw_response(&self) -> &azure_core::Response {
+                &self.0
+            }
+        }
+        impl From<Response> for azure_core::Response {
+            fn from(rsp: Response) -> Self {
+                rsp.into_raw_response()
+            }
+        }
+        impl AsRef<azure_core::Response> for Response {
+            fn as_ref(&self) -> &azure_core::Response {
+                self.as_raw_response()
+            }
+        }
+        #[derive(Clone)]
+        #[doc = r" `RequestBuilder` provides a mechanism for setting optional parameters on a request."]
+        #[doc = r""]
+        #[doc = r" Each `RequestBuilder` parameter method call returns `Self`, so setting of multiple"]
+        #[doc = r" parameters can be chained."]
+        #[doc = r""]
+        #[doc = r" The building of a request is typically finalized by invoking `.await` on"]
+        #[doc = r" `RequestBuilder`. This implicitly invokes the [`IntoFuture::into_future()`](#method.into_future)"]
+        #[doc = r" method, which converts `RequestBuilder` into a future that executes the request"]
+        #[doc = r" operation and returns a `Result` with the parsed response."]
+        #[doc = r""]
+        #[doc = r" If you need lower-level access to the raw response details (e.g. to inspect"]
+        #[doc = r" response headers or raw body data) then you can finalize the request using the"]
+        #[doc = r" [`RequestBuilder::send()`] method which returns a future that resolves to a lower-level"]
+        #[doc = r" [`Response`] value."]
+        pub struct RequestBuilder {
+            pub(crate) client: super::super::Client,
+            pub(crate) organization: String,
+            pub(crate) body: models::PolicyConfiguration,
+            pub(crate) project: String,
+        }
+        impl RequestBuilder {
+            #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
+            #[doc = ""]
+            #[doc = "You should typically use `.await` (which implicitly calls `IntoFuture::into_future()`) to finalize and send requests rather than `send()`."]
+            #[doc = "However, this function can provide more flexibility when required."]
+            pub fn send(self) -> futures::future::BoxFuture<'static, azure_core::Result<Response>> {
+                Box::pin({
+                    let this = self.clone();
+                    async move {
+                        let url = azure_core::Url::parse(&format!(
+                            "{}/{}/{}/_apis/policy/configurations",
+                            this.client.endpoint(),
+                            &this.organization,
+                            &this.project
+                        ))?;
+                        let mut req = azure_core::Request::new(url, azure_core::Method::Post);
+                        if let Some(auth_header) = this
+                            .client
+                            .token_credential()
+                            .http_authorization_header(&this.client.scopes)
+                            .await?
+                        {
+                            req.insert_header(azure_core::headers::AUTHORIZATION, auth_header);
+                        }
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair(azure_core::query_param::API_VERSION, "7.1-preview");
+                        req.insert_header("content-type", "application/json");
+                        let req_body = azure_core::to_json(&this.body)?;
+                        req.set_body(req_body);
+                        Ok(Response(this.client.send(&mut req).await?))
+                    }
+                })
+            }
+        }
+        impl std::future::IntoFuture for RequestBuilder {
+            type Output = azure_core::Result<models::PolicyConfiguration>;
+            type IntoFuture = futures::future::BoxFuture<
+                'static,
+                azure_core::Result<models::PolicyConfiguration>,
+            >;
+            #[doc = "Returns a future that sends the request and returns the parsed response body."]
+            #[doc = ""]
+            #[doc = "You should not normally call this method directly, simply invoke `.await` which implicitly calls `IntoFuture::into_future`."]
+            #[doc = ""]
+            #[doc = "See [IntoFuture documentation](https://doc.rust-lang.org/std/future/trait.IntoFuture.html) for more details."]
+            fn into_future(self) -> Self::IntoFuture {
+                Box::pin(async move { self.send().await?.into_body().await })
+            }
+        }
+    }
     pub mod get {
         use super::models;
         pub struct Response(azure_core::Response);
@@ -471,116 +579,6 @@ pub mod configurations {
                             .query_pairs_mut()
                             .append_pair(azure_core::query_param::API_VERSION, "7.1-preview");
                         let req_body = azure_core::EMPTY_BODY;
-                        req.set_body(req_body);
-                        Ok(Response(this.client.send(&mut req).await?))
-                    }
-                })
-            }
-        }
-        impl std::future::IntoFuture for RequestBuilder {
-            type Output = azure_core::Result<models::PolicyConfiguration>;
-            type IntoFuture = futures::future::BoxFuture<
-                'static,
-                azure_core::Result<models::PolicyConfiguration>,
-            >;
-            #[doc = "Returns a future that sends the request and returns the parsed response body."]
-            #[doc = ""]
-            #[doc = "You should not normally call this method directly, simply invoke `.await` which implicitly calls `IntoFuture::into_future`."]
-            #[doc = ""]
-            #[doc = "See [IntoFuture documentation](https://doc.rust-lang.org/std/future/trait.IntoFuture.html) for more details."]
-            fn into_future(self) -> Self::IntoFuture {
-                Box::pin(async move { self.send().await?.into_body().await })
-            }
-        }
-    }
-    pub mod create {
-        use super::models;
-        pub struct Response(azure_core::Response);
-        impl Response {
-            pub async fn into_body(self) -> azure_core::Result<models::PolicyConfiguration> {
-                let bytes = self.0.into_body().collect().await?;
-                let body: models::PolicyConfiguration =
-                    serde_json::from_slice(&bytes).map_err(|e| {
-                        azure_core::error::Error::full(
-                            azure_core::error::ErrorKind::DataConversion,
-                            e,
-                            format!(
-                                "Failed to deserialize response:\n{}",
-                                String::from_utf8_lossy(&bytes)
-                            ),
-                        )
-                    })?;
-                Ok(body)
-            }
-            pub fn into_raw_response(self) -> azure_core::Response {
-                self.0
-            }
-            pub fn as_raw_response(&self) -> &azure_core::Response {
-                &self.0
-            }
-        }
-        impl From<Response> for azure_core::Response {
-            fn from(rsp: Response) -> Self {
-                rsp.into_raw_response()
-            }
-        }
-        impl AsRef<azure_core::Response> for Response {
-            fn as_ref(&self) -> &azure_core::Response {
-                self.as_raw_response()
-            }
-        }
-        #[derive(Clone)]
-        #[doc = r" `RequestBuilder` provides a mechanism for setting optional parameters on a request."]
-        #[doc = r""]
-        #[doc = r" Each `RequestBuilder` parameter method call returns `Self`, so setting of multiple"]
-        #[doc = r" parameters can be chained."]
-        #[doc = r""]
-        #[doc = r" The building of a request is typically finalized by invoking `.await` on"]
-        #[doc = r" `RequestBuilder`. This implicitly invokes the [`IntoFuture::into_future()`](#method.into_future)"]
-        #[doc = r" method, which converts `RequestBuilder` into a future that executes the request"]
-        #[doc = r" operation and returns a `Result` with the parsed response."]
-        #[doc = r""]
-        #[doc = r" If you need lower-level access to the raw response details (e.g. to inspect"]
-        #[doc = r" response headers or raw body data) then you can finalize the request using the"]
-        #[doc = r" [`RequestBuilder::send()`] method which returns a future that resolves to a lower-level"]
-        #[doc = r" [`Response`] value."]
-        pub struct RequestBuilder {
-            pub(crate) client: super::super::Client,
-            pub(crate) organization: String,
-            pub(crate) body: models::PolicyConfiguration,
-            pub(crate) project: String,
-            pub(crate) configuration_id: i32,
-        }
-        impl RequestBuilder {
-            #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
-            #[doc = ""]
-            #[doc = "You should typically use `.await` (which implicitly calls `IntoFuture::into_future()`) to finalize and send requests rather than `send()`."]
-            #[doc = "However, this function can provide more flexibility when required."]
-            pub fn send(self) -> futures::future::BoxFuture<'static, azure_core::Result<Response>> {
-                Box::pin({
-                    let this = self.clone();
-                    async move {
-                        let url = azure_core::Url::parse(&format!(
-                            "{}/{}/{}/_apis/policy/configurations/{}",
-                            this.client.endpoint(),
-                            &this.organization,
-                            &this.project,
-                            &this.configuration_id
-                        ))?;
-                        let mut req = azure_core::Request::new(url, azure_core::Method::Post);
-                        if let Some(auth_header) = this
-                            .client
-                            .token_credential()
-                            .http_authorization_header(&this.client.scopes)
-                            .await?
-                        {
-                            req.insert_header(azure_core::headers::AUTHORIZATION, auth_header);
-                        }
-                        req.url_mut()
-                            .query_pairs_mut()
-                            .append_pair(azure_core::query_param::API_VERSION, "7.1-preview");
-                        req.insert_header("content-type", "application/json");
-                        let req_body = azure_core::to_json(&this.body)?;
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?))
                     }

--- a/azure_devops_rust_api/src/policy/mod.rs
+++ b/azure_devops_rust_api/src/policy/mod.rs
@@ -157,25 +157,6 @@ pub mod configurations {
                 policy_type: None,
             }
         }
-        #[doc = "Create a policy configuration of a given policy type."]
-        #[doc = ""]
-        #[doc = "Arguments:"]
-        #[doc = "* `organization`: The name of the Azure DevOps organization."]
-        #[doc = "* `body`: The policy configuration to create."]
-        #[doc = "* `project`: Project ID or project name"]
-        pub fn create(
-            &self,
-            organization: impl Into<String>,
-            body: impl Into<models::PolicyConfiguration>,
-            project: impl Into<String>,
-        ) -> create::RequestBuilder {
-            create::RequestBuilder {
-                client: self.0.clone(),
-                organization: organization.into(),
-                body: body.into(),
-                project: project.into(),
-            }
-        }
         #[doc = "Get a policy configuration by its ID."]
         #[doc = ""]
         #[doc = "Arguments:"]
@@ -191,6 +172,27 @@ pub mod configurations {
             get::RequestBuilder {
                 client: self.0.clone(),
                 organization: organization.into(),
+                project: project.into(),
+                configuration_id,
+            }
+        }
+        #[doc = "Create a policy configuration of a given policy type."]
+        #[doc = ""]
+        #[doc = "Arguments:"]
+        #[doc = "* `organization`: The name of the Azure DevOps organization."]
+        #[doc = "* `body`: The policy configuration to create."]
+        #[doc = "* `project`: Project ID or project name"]
+        pub fn create(
+            &self,
+            organization: impl Into<String>,
+            body: impl Into<models::PolicyConfiguration>,
+            project: impl Into<String>,
+            configuration_id: i32,
+        ) -> create::RequestBuilder {
+            create::RequestBuilder {
+                client: self.0.clone(),
+                organization: organization.into(),
+                body: body.into(),
                 project: project.into(),
                 configuration_id,
             }
@@ -385,114 +387,6 @@ pub mod configurations {
             }
         }
     }
-    pub mod create {
-        use super::models;
-        pub struct Response(azure_core::Response);
-        impl Response {
-            pub async fn into_body(self) -> azure_core::Result<models::PolicyConfiguration> {
-                let bytes = self.0.into_body().collect().await?;
-                let body: models::PolicyConfiguration =
-                    serde_json::from_slice(&bytes).map_err(|e| {
-                        azure_core::error::Error::full(
-                            azure_core::error::ErrorKind::DataConversion,
-                            e,
-                            format!(
-                                "Failed to deserialize response:\n{}",
-                                String::from_utf8_lossy(&bytes)
-                            ),
-                        )
-                    })?;
-                Ok(body)
-            }
-            pub fn into_raw_response(self) -> azure_core::Response {
-                self.0
-            }
-            pub fn as_raw_response(&self) -> &azure_core::Response {
-                &self.0
-            }
-        }
-        impl From<Response> for azure_core::Response {
-            fn from(rsp: Response) -> Self {
-                rsp.into_raw_response()
-            }
-        }
-        impl AsRef<azure_core::Response> for Response {
-            fn as_ref(&self) -> &azure_core::Response {
-                self.as_raw_response()
-            }
-        }
-        #[derive(Clone)]
-        #[doc = r" `RequestBuilder` provides a mechanism for setting optional parameters on a request."]
-        #[doc = r""]
-        #[doc = r" Each `RequestBuilder` parameter method call returns `Self`, so setting of multiple"]
-        #[doc = r" parameters can be chained."]
-        #[doc = r""]
-        #[doc = r" The building of a request is typically finalized by invoking `.await` on"]
-        #[doc = r" `RequestBuilder`. This implicitly invokes the [`IntoFuture::into_future()`](#method.into_future)"]
-        #[doc = r" method, which converts `RequestBuilder` into a future that executes the request"]
-        #[doc = r" operation and returns a `Result` with the parsed response."]
-        #[doc = r""]
-        #[doc = r" If you need lower-level access to the raw response details (e.g. to inspect"]
-        #[doc = r" response headers or raw body data) then you can finalize the request using the"]
-        #[doc = r" [`RequestBuilder::send()`] method which returns a future that resolves to a lower-level"]
-        #[doc = r" [`Response`] value."]
-        pub struct RequestBuilder {
-            pub(crate) client: super::super::Client,
-            pub(crate) organization: String,
-            pub(crate) body: models::PolicyConfiguration,
-            pub(crate) project: String,
-        }
-        impl RequestBuilder {
-            #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
-            #[doc = ""]
-            #[doc = "You should typically use `.await` (which implicitly calls `IntoFuture::into_future()`) to finalize and send requests rather than `send()`."]
-            #[doc = "However, this function can provide more flexibility when required."]
-            pub fn send(self) -> futures::future::BoxFuture<'static, azure_core::Result<Response>> {
-                Box::pin({
-                    let this = self.clone();
-                    async move {
-                        let url = azure_core::Url::parse(&format!(
-                            "{}/{}/{}/_apis/policy/configurations",
-                            this.client.endpoint(),
-                            &this.organization,
-                            &this.project
-                        ))?;
-                        let mut req = azure_core::Request::new(url, azure_core::Method::Post);
-                        if let Some(auth_header) = this
-                            .client
-                            .token_credential()
-                            .http_authorization_header(&this.client.scopes)
-                            .await?
-                        {
-                            req.insert_header(azure_core::headers::AUTHORIZATION, auth_header);
-                        }
-                        req.url_mut()
-                            .query_pairs_mut()
-                            .append_pair(azure_core::query_param::API_VERSION, "7.1-preview");
-                        req.insert_header("content-type", "application/json");
-                        let req_body = azure_core::to_json(&this.body)?;
-                        req.set_body(req_body);
-                        Ok(Response(this.client.send(&mut req).await?))
-                    }
-                })
-            }
-        }
-        impl std::future::IntoFuture for RequestBuilder {
-            type Output = azure_core::Result<models::PolicyConfiguration>;
-            type IntoFuture = futures::future::BoxFuture<
-                'static,
-                azure_core::Result<models::PolicyConfiguration>,
-            >;
-            #[doc = "Returns a future that sends the request and returns the parsed response body."]
-            #[doc = ""]
-            #[doc = "You should not normally call this method directly, simply invoke `.await` which implicitly calls `IntoFuture::into_future`."]
-            #[doc = ""]
-            #[doc = "See [IntoFuture documentation](https://doc.rust-lang.org/std/future/trait.IntoFuture.html) for more details."]
-            fn into_future(self) -> Self::IntoFuture {
-                Box::pin(async move { self.send().await?.into_body().await })
-            }
-        }
-    }
     pub mod get {
         use super::models;
         pub struct Response(azure_core::Response);
@@ -579,6 +473,116 @@ pub mod configurations {
                             .query_pairs_mut()
                             .append_pair(azure_core::query_param::API_VERSION, "7.1-preview");
                         let req_body = azure_core::EMPTY_BODY;
+                        req.set_body(req_body);
+                        Ok(Response(this.client.send(&mut req).await?))
+                    }
+                })
+            }
+        }
+        impl std::future::IntoFuture for RequestBuilder {
+            type Output = azure_core::Result<models::PolicyConfiguration>;
+            type IntoFuture = futures::future::BoxFuture<
+                'static,
+                azure_core::Result<models::PolicyConfiguration>,
+            >;
+            #[doc = "Returns a future that sends the request and returns the parsed response body."]
+            #[doc = ""]
+            #[doc = "You should not normally call this method directly, simply invoke `.await` which implicitly calls `IntoFuture::into_future`."]
+            #[doc = ""]
+            #[doc = "See [IntoFuture documentation](https://doc.rust-lang.org/std/future/trait.IntoFuture.html) for more details."]
+            fn into_future(self) -> Self::IntoFuture {
+                Box::pin(async move { self.send().await?.into_body().await })
+            }
+        }
+    }
+    pub mod create {
+        use super::models;
+        pub struct Response(azure_core::Response);
+        impl Response {
+            pub async fn into_body(self) -> azure_core::Result<models::PolicyConfiguration> {
+                let bytes = self.0.into_body().collect().await?;
+                let body: models::PolicyConfiguration =
+                    serde_json::from_slice(&bytes).map_err(|e| {
+                        azure_core::error::Error::full(
+                            azure_core::error::ErrorKind::DataConversion,
+                            e,
+                            format!(
+                                "Failed to deserialize response:\n{}",
+                                String::from_utf8_lossy(&bytes)
+                            ),
+                        )
+                    })?;
+                Ok(body)
+            }
+            pub fn into_raw_response(self) -> azure_core::Response {
+                self.0
+            }
+            pub fn as_raw_response(&self) -> &azure_core::Response {
+                &self.0
+            }
+        }
+        impl From<Response> for azure_core::Response {
+            fn from(rsp: Response) -> Self {
+                rsp.into_raw_response()
+            }
+        }
+        impl AsRef<azure_core::Response> for Response {
+            fn as_ref(&self) -> &azure_core::Response {
+                self.as_raw_response()
+            }
+        }
+        #[derive(Clone)]
+        #[doc = r" `RequestBuilder` provides a mechanism for setting optional parameters on a request."]
+        #[doc = r""]
+        #[doc = r" Each `RequestBuilder` parameter method call returns `Self`, so setting of multiple"]
+        #[doc = r" parameters can be chained."]
+        #[doc = r""]
+        #[doc = r" The building of a request is typically finalized by invoking `.await` on"]
+        #[doc = r" `RequestBuilder`. This implicitly invokes the [`IntoFuture::into_future()`](#method.into_future)"]
+        #[doc = r" method, which converts `RequestBuilder` into a future that executes the request"]
+        #[doc = r" operation and returns a `Result` with the parsed response."]
+        #[doc = r""]
+        #[doc = r" If you need lower-level access to the raw response details (e.g. to inspect"]
+        #[doc = r" response headers or raw body data) then you can finalize the request using the"]
+        #[doc = r" [`RequestBuilder::send()`] method which returns a future that resolves to a lower-level"]
+        #[doc = r" [`Response`] value."]
+        pub struct RequestBuilder {
+            pub(crate) client: super::super::Client,
+            pub(crate) organization: String,
+            pub(crate) body: models::PolicyConfiguration,
+            pub(crate) project: String,
+            pub(crate) configuration_id: i32,
+        }
+        impl RequestBuilder {
+            #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
+            #[doc = ""]
+            #[doc = "You should typically use `.await` (which implicitly calls `IntoFuture::into_future()`) to finalize and send requests rather than `send()`."]
+            #[doc = "However, this function can provide more flexibility when required."]
+            pub fn send(self) -> futures::future::BoxFuture<'static, azure_core::Result<Response>> {
+                Box::pin({
+                    let this = self.clone();
+                    async move {
+                        let url = azure_core::Url::parse(&format!(
+                            "{}/{}/{}/_apis/policy/configurations/{}",
+                            this.client.endpoint(),
+                            &this.organization,
+                            &this.project,
+                            &this.configuration_id
+                        ))?;
+                        let mut req = azure_core::Request::new(url, azure_core::Method::Post);
+                        if let Some(auth_header) = this
+                            .client
+                            .token_credential()
+                            .http_authorization_header(&this.client.scopes)
+                            .await?
+                        {
+                            req.insert_header(azure_core::headers::AUTHORIZATION, auth_header);
+                        }
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair(azure_core::query_param::API_VERSION, "7.1-preview");
+                        req.insert_header("content-type", "application/json");
+                        let req_body = azure_core::to_json(&this.body)?;
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?))
                     }

--- a/azure_devops_rust_api/src/processadmin/mod.rs
+++ b/azure_devops_rust_api/src/processadmin/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/processes/mod.rs
+++ b/azure_devops_rust_api/src/processes/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/profile/mod.rs
+++ b/azure_devops_rust_api/src/profile/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/release/mod.rs
+++ b/azure_devops_rust_api/src/release/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/search/mod.rs
+++ b/azure_devops_rust_api/src/search/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/security/mod.rs
+++ b/azure_devops_rust_api/src/security/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/service_endpoint/mod.rs
+++ b/azure_devops_rust_api/src/service_endpoint/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/status/mod.rs
+++ b/azure_devops_rust_api/src/status/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/symbol/mod.rs
+++ b/azure_devops_rust_api/src/symbol/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/test/mod.rs
+++ b/azure_devops_rust_api/src/test/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/test_plan/mod.rs
+++ b/azure_devops_rust_api/src/test_plan/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/test_results/mod.rs
+++ b/azure_devops_rust_api/src/test_results/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/tfvc/mod.rs
+++ b/azure_devops_rust_api/src/tfvc/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/token_admin/mod.rs
+++ b/azure_devops_rust_api/src/token_admin/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/wiki/mod.rs
+++ b/azure_devops_rust_api/src/wiki/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/wit/mod.rs
+++ b/azure_devops_rust_api/src/wit/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }

--- a/azure_devops_rust_api/src/work/mod.rs
+++ b/azure_devops_rust_api/src/work/mod.rs
@@ -68,7 +68,9 @@ impl ClientBuilder {
     #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
-        let scopes = self.scopes.unwrap_or_else(|| vec![format!("{endpoint}/")]);
+        let scopes = self
+            .scopes
+            .unwrap_or_else(|| vec![crate::ADO_SCOPE.to_string()]);
         Client::new(endpoint, self.credential, scopes, self.options)
     }
 }


### PR DESCRIPTION
Using the endpoint as the scope doesn't work when using Azure CLI authentication, but specifying the correct scope per https://learn.microsoft.com/en-us/rest/api/azure/devops/tokens/?view=azure-devops-rest-7.0&tabs=powershell does.