### PR TITLE
Update github actions to help avoid running out of disk space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
       run: ./build.sh
     - name: check autogeneration matches git repo
       run: git diff --exit-code HEAD
+    - name: cleanup code generator build artifacts
+      run: cargo clean
     - name: azure_devops_rust_api clippy
       run: cd azure_devops_rust_api && cargo clippy --all-features
     - name: azure_devops_rust_api build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: vsts-api-patcher fmt
       run: cd vsts-api-patcher && cargo fmt --check
     - name: azure_devops_rust_api fmt
-      run: cd vsts-api-patcher && cargo fmt --check
+      run: cd azure_devops_rust_api && cargo fmt --check
     - name: codegen clippy
       run: cd autorust && cargo clippy
     - name: vsts-api-patcher clippy
@@ -29,11 +29,13 @@ jobs:
     - name: check autogeneration matches git repo
       run: git diff --exit-code HEAD
     - name: cleanup code generator build artifacts
-      run: cargo clean
+      run: rm -rf vsts-api-patcher/target && rm -rf autorust/target
     - name: azure_devops_rust_api clippy
       run: cd azure_devops_rust_api && cargo clippy --all-features
     - name: azure_devops_rust_api build
       run: cd azure_devops_rust_api && cargo build --all-features
+    - name: cleanup azure_devops_rust_api build artifacts
+      run: rm -rf azure_devops_rust_api/target
     - name: azure_devops_rust_api test
       run: cd azure_devops_rust_api && cargo test --all-features
     - name: azure_devops_rust_api documentation generation


### PR DESCRIPTION
Recent Github Actions builds have failed in the `azure_devops_rust_api test` step due to lack of disk space.
This PR attempts to resolve this by removing all the build artifacts following the code generation phase.