### PR TITLE
Release 0.11.0. 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     - name: cleanup code generator build artifacts
       run: rm -rf vsts-api-patcher/target && rm -rf autorust/target
     - name: azure_devops_rust_api clippy
-      run: cd azure_devops_rust_api && cargo clippy --all-features
+      run: cd azure_devops_rust_api && cargo clippy --all-features -- --deny warnings
     - name: azure_devops_rust_api build
       run: cd azure_devops_rust_api && cargo build --all-features
     - name: cleanup azure_devops_rust_api build artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0]
+
+### Changes
+
+- Upgrade `azure_core`, `azure_identity` to 0.15
+
 ## [0.10.0]
 
 ### Changes
@@ -311,7 +317,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.10.0...HEAD
+[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.11.0...HEAD
+[0.11.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.10.0...0.11.0
 [0.10.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.9.0...0.10.0
 [0.9.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.7.7...0.8.0

--- a/autorust/codegen/src/codegen_operations.rs
+++ b/autorust/codegen/src/codegen_operations.rs
@@ -154,8 +154,8 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
                 self.scopes.iter().map(String::as_str).collect()
             }
             pub(crate) async fn send(&self, request: &mut azure_core::Request) -> azure_core::Result<azure_core::Response> {
-                let mut context = azure_core::Context::default();
-                self.pipeline.send(&mut context, request).await
+                let context = azure_core::Context::default();
+                self.pipeline.send(&context, request).await
             }
 
             #[doc = "Create a new `ClientBuilder`."]
@@ -192,11 +192,12 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
 pub fn create_operations(cg: &CodeGen) -> Result<TokenStream> {
     let mut file = TokenStream::new();
     file.extend(quote! {
-
         #![allow(unused_mut)]
         #![allow(unused_variables)]
         #![allow(unused_imports)]
+        #![allow(clippy::too_many_arguments)]
         #![allow(clippy::redundant_clone)]
+        #![allow(clippy::module_inception)]
         pub mod models;
     });
     let mut operations_code: IndexMap<Option<String>, OperationCode> = IndexMap::new();

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_devops_rust_api"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["John Batty <johnbatty@microsoft.com>"]
 description = "Rust API library for Azure DevOps"
@@ -23,7 +23,7 @@ rust-version = "1.64.0"
 doctest = false
 
 [dependencies]
-azure_core = { version = "0.14", default-features = true }
+azure_core = { version = "0.15", default-features = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -32,7 +32,7 @@ base64 = "0.21"
 time = "0.3"
 
 [dev-dependencies]
-azure_identity = "0.14"
+azure_identity = "0.15"
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1"
 log = "0.4"

--- a/azure_devops_rust_api/README.md
+++ b/azure_devops_rust_api/README.md
@@ -67,7 +67,7 @@ Example application `Cargo.toml` dependency spec showing how to specify desired 
 ```toml
 [dependencies]
 ...
-azure_devops_rust_api = { version = "0.10.0", features = ["git", "pipelines"] }
+azure_devops_rust_api = { version = "0.11.0", features = ["git", "pipelines"] }
 ```
 
 ## Examples

--- a/azure_devops_rust_api/src/accounts/mod.rs
+++ b/azure_devops_rust_api/src/accounts/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/approvals_and_checks/mod.rs
+++ b/azure_devops_rust_api/src/approvals_and_checks/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/artifacts/mod.rs
+++ b/azure_devops_rust_api/src/artifacts/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/artifacts_package_types/mod.rs
+++ b/azure_devops_rust_api/src/artifacts_package_types/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/audit/mod.rs
+++ b/azure_devops_rust_api/src/audit/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/build/mod.rs
+++ b/azure_devops_rust_api/src/build/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/core/mod.rs
+++ b/azure_devops_rust_api/src/core/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/dashboard/mod.rs
+++ b/azure_devops_rust_api/src/dashboard/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/distributed_task/mod.rs
+++ b/azure_devops_rust_api/src/distributed_task/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/extension_management/mod.rs
+++ b/azure_devops_rust_api/src/extension_management/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/favorite/mod.rs
+++ b/azure_devops_rust_api/src/favorite/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/git/mod.rs
+++ b/azure_devops_rust_api/src/git/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/graph/mod.rs
+++ b/azure_devops_rust_api/src/graph/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/hooks/mod.rs
+++ b/azure_devops_rust_api/src/hooks/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/ims/mod.rs
+++ b/azure_devops_rust_api/src/ims/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/member_entitlement_management/mod.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/operations/mod.rs
+++ b/azure_devops_rust_api/src/operations/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/permissions_report/mod.rs
+++ b/azure_devops_rust_api/src/permissions_report/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/pipelines/mod.rs
+++ b/azure_devops_rust_api/src/pipelines/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/policy/mod.rs
+++ b/azure_devops_rust_api/src/policy/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/processadmin/mod.rs
+++ b/azure_devops_rust_api/src/processadmin/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/processes/mod.rs
+++ b/azure_devops_rust_api/src/processes/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/profile/mod.rs
+++ b/azure_devops_rust_api/src/profile/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/release/mod.rs
+++ b/azure_devops_rust_api/src/release/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/search/mod.rs
+++ b/azure_devops_rust_api/src/search/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/security/mod.rs
+++ b/azure_devops_rust_api/src/security/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/security_roles/mod.rs
+++ b/azure_devops_rust_api/src/security_roles/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/service_endpoint/mod.rs
+++ b/azure_devops_rust_api/src/service_endpoint/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/status/mod.rs
+++ b/azure_devops_rust_api/src/status/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/symbol/mod.rs
+++ b/azure_devops_rust_api/src/symbol/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/test/mod.rs
+++ b/azure_devops_rust_api/src/test/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/test_plan/mod.rs
+++ b/azure_devops_rust_api/src/test_plan/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/test_results/mod.rs
+++ b/azure_devops_rust_api/src/test_results/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/tfvc/mod.rs
+++ b/azure_devops_rust_api/src/tfvc/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/token_admin/mod.rs
+++ b/azure_devops_rust_api/src/token_admin/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/tokens/mod.rs
+++ b/azure_devops_rust_api/src/tokens/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/wiki/mod.rs
+++ b/azure_devops_rust_api/src/wiki/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/wit/mod.rs
+++ b/azure_devops_rust_api/src/wit/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]

--- a/azure_devops_rust_api/src/work/mod.rs
+++ b/azure_devops_rust_api/src/work/mod.rs
@@ -3,7 +3,9 @@
 #![allow(unused_mut)]
 #![allow(unused_variables)]
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 #![allow(clippy::redundant_clone)]
+#![allow(clippy::module_inception)]
 pub mod models;
 #[derive(Clone)]
 pub struct Client {
@@ -89,8 +91,8 @@ impl Client {
         &self,
         request: &mut azure_core::Request,
     ) -> azure_core::Result<azure_core::Response> {
-        let mut context = azure_core::Context::default();
-        self.pipeline.send(&mut context, request).await
+        let context = azure_core::Context::default();
+        self.pipeline.send(&context, request).await
     }
     #[doc = "Create a new `ClientBuilder`."]
     #[must_use]


### PR DESCRIPTION
- Update azure_core, azure_identity to 0.15.
- Fix up clippy lints in autogenerated code.
- Add `--deny warnings` to clippy command for autogenerated crate