### PR TITLE
Add per-retry policies to ClientBuilders

### DIFF
--- a/autorust/codegen/src/codegen_operations.rs
+++ b/autorust/codegen/src/codegen_operations.rs
@@ -133,6 +133,16 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
                 self
             }
 
+            #[doc = "set per-retry policies."]
+            #[must_use]
+            pub fn per_retry_policies(
+                mut self,
+                policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+            ) -> Self {
+                self.options = self.options.per_retry_policies(policies);
+                self
+            }
+
             #[doc = "Convert the builder into a `Client` instance."]
             #[must_use]
             pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/accounts/mod.rs
+++ b/azure_devops_rust_api/src/accounts/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/approvals_and_checks/mod.rs
+++ b/azure_devops_rust_api/src/approvals_and_checks/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/artifacts/mod.rs
+++ b/azure_devops_rust_api/src/artifacts/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/artifacts_package_types/mod.rs
+++ b/azure_devops_rust_api/src/artifacts_package_types/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/audit/mod.rs
+++ b/azure_devops_rust_api/src/audit/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/build/mod.rs
+++ b/azure_devops_rust_api/src/build/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/core/mod.rs
+++ b/azure_devops_rust_api/src/core/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/dashboard/mod.rs
+++ b/azure_devops_rust_api/src/dashboard/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/distributed_task/mod.rs
+++ b/azure_devops_rust_api/src/distributed_task/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/extension_management/mod.rs
+++ b/azure_devops_rust_api/src/extension_management/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/favorite/mod.rs
+++ b/azure_devops_rust_api/src/favorite/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/git/mod.rs
+++ b/azure_devops_rust_api/src/git/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/graph/mod.rs
+++ b/azure_devops_rust_api/src/graph/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/hooks/mod.rs
+++ b/azure_devops_rust_api/src/hooks/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/ims/mod.rs
+++ b/azure_devops_rust_api/src/ims/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/member_entitlement_management/mod.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/operations/mod.rs
+++ b/azure_devops_rust_api/src/operations/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/permissions_report/mod.rs
+++ b/azure_devops_rust_api/src/permissions_report/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/pipelines/mod.rs
+++ b/azure_devops_rust_api/src/pipelines/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/policy/mod.rs
+++ b/azure_devops_rust_api/src/policy/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/processadmin/mod.rs
+++ b/azure_devops_rust_api/src/processadmin/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/processes/mod.rs
+++ b/azure_devops_rust_api/src/processes/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/profile/mod.rs
+++ b/azure_devops_rust_api/src/profile/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/release/mod.rs
+++ b/azure_devops_rust_api/src/release/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/search/mod.rs
+++ b/azure_devops_rust_api/src/search/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/security/mod.rs
+++ b/azure_devops_rust_api/src/security/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/security_roles/mod.rs
+++ b/azure_devops_rust_api/src/security_roles/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/service_endpoint/mod.rs
+++ b/azure_devops_rust_api/src/service_endpoint/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/status/mod.rs
+++ b/azure_devops_rust_api/src/status/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/symbol/mod.rs
+++ b/azure_devops_rust_api/src/symbol/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/test/mod.rs
+++ b/azure_devops_rust_api/src/test/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/test_plan/mod.rs
+++ b/azure_devops_rust_api/src/test_plan/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/test_results/mod.rs
+++ b/azure_devops_rust_api/src/test_results/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/tfvc/mod.rs
+++ b/azure_devops_rust_api/src/tfvc/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/token_admin/mod.rs
+++ b/azure_devops_rust_api/src/token_admin/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/tokens/mod.rs
+++ b/azure_devops_rust_api/src/tokens/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/wiki/mod.rs
+++ b/azure_devops_rust_api/src/wiki/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/wit/mod.rs
+++ b/azure_devops_rust_api/src/wit/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {

--- a/azure_devops_rust_api/src/work/mod.rs
+++ b/azure_devops_rust_api/src/work/mod.rs
@@ -66,6 +66,15 @@ impl ClientBuilder {
         self.options = self.options.per_call_policies(policies);
         self
     }
+    #[doc = "set per-retry policies."]
+    #[must_use]
+    pub fn per_retry_policies(
+        mut self,
+        policies: impl Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+    ) -> Self {
+        self.options = self.options.per_retry_policies(policies);
+        self
+    }
     #[doc = "Convert the builder into a `Client` instance."]
     #[must_use]
     pub fn build(self) -> Client {


### PR DESCRIPTION
This PR extends the ClientBuilders interface to allow setting per-retry policies in the ClientOptions.