### PR TITLE
Generate windows build scripts via Github Copilot

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Exit on error
+$ErrorActionPreference = "Stop"
+
+# Fetch the vsts-rest-api-specs submodule
+Write-Host "Fetch vsts-rest-api-specs"
+git submodule init
+git submodule update
+
+# Patch the API
+Write-Host "Create vsts-rest-api-specs.patched"
+Remove-Item -Recurse -Force vsts-rest-api-specs.patched -ErrorAction Ignore
+Set-Location vsts-api-patcher
+cargo run --release
+Set-Location ..
+
+# Autogen the Rust crate
+Write-Host "Autogen Rust crate"
+Remove-Item -Recurse -Force azure_devops_rust_api/target -ErrorAction Ignore
+Set-Location autorust/codegen
+cargo run --release
+Set-Location ../..
+
+# Format and build Rust crate
+Set-Location azure_devops_rust_api
+Write-Host "Format azure_devops_rust_api"
+cargo fmt
+Write-Host "Build azure_devops_rust_api"
+cargo build --all-features
+Set-Location ..
+
+Write-Host "Done"

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Exit on error
+$ErrorActionPreference = "Stop"
+
+Write-Host "Publish crate to crates.io"
+Set-Location azure_devops_rust_api
+cargo publish --verbose --all-features
+Set-Location ..
+
+Write-Host "Done"


### PR DESCRIPTION
These scripts were generated using GitHub CoPilot chat to provide a quick build/publish path on Windows matching the one on Mac. Since the command run are all cross-platform it's a fairly simple conversion which GH got right on the first try!