### PR TITLE
Patch Ado Api for Git ChangeType "edit, rename"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- New value added to git `ChangeType` enum: `edit, rename`
+
 ### [0.14.2]
 
 ### Added

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -411,8 +411,6 @@ pub mod change {
         All,
         #[serde(rename = "delete, sourceRename")]
         DeleteSourceRename,
-        #[serde(rename = "delete, targetRename")]
-        DeleteTargetRename,
         #[serde(rename = "edit, rename")]
         EditRename,
     }

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -411,6 +411,10 @@ pub mod change {
         All,
         #[serde(rename = "delete, sourceRename")]
         DeleteSourceRename,
+        #[serde(rename = "delete, targetRename")]
+        DeleteTargetRename,
+        #[serde(rename = "edit, rename")]
+        EditRename,
     }
 }
 #[doc = ""]

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -607,6 +607,8 @@ impl Patcher {
                 let mut value = value.clone();
                 // Add extra value discovered in testing.
                 value.push(JsonValue::from("delete, sourceRename")).unwrap();
+                value.push(JsonValue::from("delete, targetRename")).unwrap();
+                value.push(JsonValue::from("edit, rename")).unwrap();
                 Some(value)
             }
             _ => None,

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -605,9 +605,8 @@ impl Patcher {
             ["definitions", "Change", "properties", "changeType", "enum"] => {
                 println!("Update git Change changeType definition");
                 let mut value = value.clone();
-                // Add extra value discovered in testing.
+                // Add extra values discovered in testing.
                 value.push(JsonValue::from("delete, sourceRename")).unwrap();
-                value.push(JsonValue::from("delete, targetRename")).unwrap();
                 value.push(JsonValue::from("edit, rename")).unwrap();
                 Some(value)
             }


### PR DESCRIPTION
Through testing the SDK on many large pull requests, we've found 1 more undocumented value returned from the API for GitChanges.