### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [0.15.0]
+
 ### Changes
 
 - Upgrade `azure_core`, `azure_identity` to 0.18
@@ -368,7 +370,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.14.3...HEAD
+[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.15.0...HEAD
+[0.15.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.14.3...0.15.0
 [0.14.3]: https://github.com/microsoft/azure-devops-rust-api/compare/0.14.2...0.14.3
 [0.14.2]: https://github.com/microsoft/azure-devops-rust-api/compare/0.14.1...0.14.2
 [0.14.1]: https://github.com/microsoft/azure-devops-rust-api/compare/0.14.0...0.14.1

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_devops_rust_api"
-version = "0.14.3"
+version = "0.15.0"
 edition = "2021"
 authors = ["John Batty <johnbatty@microsoft.com>"]
 description = "Rust API library for Azure DevOps"

--- a/azure_devops_rust_api/README.md
+++ b/azure_devops_rust_api/README.md
@@ -67,7 +67,7 @@ Example application `Cargo.toml` dependency spec showing how to specify desired 
 ```toml
 [dependencies]
 ...
-azure_devops_rust_api = { version = "0.14.3", features = ["git", "pipelines"] }
+azure_devops_rust_api = { version = "0.15.0", features = ["git", "pipelines"] }
 ```
 
 ## Examples


### PR DESCRIPTION
- Upgrade `azure_core`, `azure_identity` to 0.18
  - Note: `AutoRefreshingTokenCredential` is no longer required (and has been removed from `azure_identity`), as token refreshing is now built in to each credential provider