### PR TITLE
Add headers module with rate limiting header definitions. Release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [0.15.1]
+
+### Added
+
+- New `headers` module with Azure DevOps custom rate-limiting response header definitions.
+
 ### [0.15.0]
 
 ### Changes
@@ -370,7 +376,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.15.0...HEAD
+[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.15.1...HEAD
+[0.15.1]: https://github.com/microsoft/azure-devops-rust-api/compare/0.15.0...0.15.1
 [0.15.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.14.3...0.15.0
 [0.14.3]: https://github.com/microsoft/azure-devops-rust-api/compare/0.14.2...0.14.3
 [0.14.2]: https://github.com/microsoft/azure-devops-rust-api/compare/0.14.1...0.14.2

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_devops_rust_api"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 authors = ["John Batty <johnbatty@microsoft.com>"]
 description = "Rust API library for Azure DevOps"

--- a/azure_devops_rust_api/README.md
+++ b/azure_devops_rust_api/README.md
@@ -67,7 +67,7 @@ Example application `Cargo.toml` dependency spec showing how to specify desired 
 ```toml
 [dependencies]
 ...
-azure_devops_rust_api = { version = "0.15.0", features = ["git", "pipelines"] }
+azure_devops_rust_api = { version = "0.15.1", features = ["git", "pipelines"] }
 ```
 
 ## Examples

--- a/azure_devops_rust_api/src/headers.rs
+++ b/azure_devops_rust_api/src/headers.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Azure DevOps rate limit headers.
+//! For more information see [Azure DevOps Rate and usage limits](https://learn.microsoft.com/en-us/azure/devops/integrate/concepts/rate-limits?view=azure-devops).
+
+use azure_core::headers::HeaderName;
+
+/// A custom header indicating the service and type of threshold that was reached. Threshold types and service names might vary over time and without warning.
+/// We recommend displaying this string to a human, but not relying on it for computation.
+pub const X_RATELIMIT_RESOURCE: HeaderName = HeaderName::from_static("x-ratelimit-resource");
+
+/// How long the request was delayed. Units: seconds with up to three decimal places (milliseconds).
+pub const X_RATELIMIT_DELAY: HeaderName = HeaderName::from_static("x-ratelimit-delay");
+
+/// Total number of TSTUs allowed before delays are imposed.
+pub const X_RATELIMIT_LIMIT: HeaderName = HeaderName::from_static("x-ratelimit-limit");
+
+/// Number of TSTUs remaining before being delayed. If requests are already being delayed or blocked, it's 0.
+pub const X_RATELIMIT_REMAINING: HeaderName = HeaderName::from_static("x-ratelimit-remaining");
+
+/// Time at which, if all resource consumption stopped immediately, tracked usage would return to 0 TSTUs. Expressed in Unix epoch time.
+pub const X_RATELIMIT_RESET: HeaderName = HeaderName::from_static("x-ratelimit-reset");

--- a/azure_devops_rust_api/src/lib.rs
+++ b/azure_devops_rust_api/src/lib.rs
@@ -135,6 +135,7 @@ mod auth;
 pub use auth::Credential;
 
 pub mod date_time;
+pub mod headers;
 
 pub(crate) mod serde;
 


### PR DESCRIPTION
- Add Azure DevOps rate-limit header definitions from: https://github.com/Azure/azure-sdk-for-rust/pull/1510
- Release 0.15.1

