### PR TITLE
Fix return type for git::items::get_items_batch()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- Fix response type for `git::items::get_items_batch()`
+
+### Added
+
+- New example: `git_items_get_items_batch`
+
 ### [0.15.1]
 
 ### Added

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -132,6 +132,10 @@ name = "git_items_get"
 required-features = ["git"]
 
 [[example]]
+name = "git_items_get_items_batch"
+required-features = ["git"]
+
+[[example]]
 name = "git_commit_changes"
 required-features = ["git"]
 

--- a/azure_devops_rust_api/examples/git_items_get_items_batch.rs
+++ b/azure_devops_rust_api/examples/git_items_get_items_batch.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// git_items_get_items_batch.rs
+// Git get items (files and folders) batch example.
+use anyhow::Result;
+use azure_devops_rust_api::git;
+use azure_devops_rust_api::git::models::{GitItemDescriptor, GitItemRequestData};
+use std::env;
+
+mod utils;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    env_logger::init();
+
+    // Get authentication credential
+    let credential = utils::get_credential();
+
+    // Get ADO server configuration via environment variables
+    let organization = env::var("ADO_ORGANIZATION").expect("Must define ADO_ORGANIZATION");
+    let project = env::var("ADO_PROJECT").expect("Must define ADO_PROJECT");
+    let repository_name = env::args()
+        .nth(1)
+        .expect("Usage: git_items_get <repository-name> <file_path>");
+    let file_path = env::args()
+        .nth(2)
+        .expect("Usage: git_items_get <repository-name> <file_path>");
+
+    let git_item_request_data = GitItemRequestData {
+        include_content_metadata: Some(true),
+        include_links: Some(true),
+        item_descriptors: vec![GitItemDescriptor {
+            path: Some(file_path.clone()),
+            recursion_level: None,
+            version: None,
+            version_options: None,
+            version_type: None,
+        }],
+        latest_processed_change: Some(true),
+    };
+
+    // Create a git client
+    let git_client = git::ClientBuilder::new(credential.clone()).build();
+
+    let items_batch = git_client
+        .items_client()
+        .get_items_batch(
+            &organization,
+            git_item_request_data,
+            &repository_name,
+            &project,
+        )
+        .await?;
+
+    println!("\n{file_path} metadata items batch:\n{:#?}", items_batch);
+
+    Ok(())
+}

--- a/azure_devops_rust_api/src/git/mod.rs
+++ b/azure_devops_rust_api/src/git/mod.rs
@@ -3297,9 +3297,9 @@ pub mod items {
         use futures::future::LocalBoxFuture as BoxFuture;
         pub struct Response(azure_core::Response);
         impl Response {
-            pub async fn into_body(self) -> azure_core::Result<Vec<String>> {
+            pub async fn into_body(self) -> azure_core::Result<models::GitItemsList> {
                 let bytes = self.0.into_body().collect().await?;
-                let body: Vec<String> = serde_json::from_slice(&bytes).map_err(|e| {
+                let body: models::GitItemsList = serde_json::from_slice(&bytes).map_err(|e| {
                     azure_core::error::Error::full(
                         azure_core::error::ErrorKind::DataConversion,
                         e,
@@ -3387,8 +3387,8 @@ pub mod items {
             }
         }
         impl std::future::IntoFuture for RequestBuilder {
-            type Output = azure_core::Result<Vec<String>>;
-            type IntoFuture = BoxFuture<'static, azure_core::Result<Vec<String>>>;
+            type Output = azure_core::Result<models::GitItemsList>;
+            type IntoFuture = BoxFuture<'static, azure_core::Result<models::GitItemsList>>;
             #[doc = "Returns a future that sends the request and returns the parsed response body."]
             #[doc = ""]
             #[doc = "You should not normally call this method directly, simply invoke `.await` which implicitly calls `IntoFuture::into_future`."]

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -2864,6 +2864,24 @@ impl GitItemRequestData {
         Self::default()
     }
 }
+pub type GitItems = Vec<GitItem>;
+#[doc = ""]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+pub struct GitItemsList {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub count: Option<i32>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "crate::serde::deserialize_null_default"
+    )]
+    pub value: Vec<GitItems>,
+}
+impl GitItemsList {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 #[doc = ""]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitLastChangeItem {

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -149,8 +149,8 @@ impl Patcher {
         Patcher::patch_json_reference_links,
         Patcher::patch_teamproject_visibility_enum,
         Patcher::patch_array_array_schema,
-        Patcher::patch_response_schema,
         Patcher::patch_git_reference_links,
+        Patcher::patch_git_get_items_batch,
         Patcher::patch_pipelines_reference_links,
         Patcher::patch_build_reference_links,
         Patcher::patch_pipelines_pipeline_configuration,
@@ -172,6 +172,7 @@ impl Patcher {
         Patcher::patch_jobjects,
         Patcher::patch_identity_descriptors,
         Patcher::patch_security,
+        Patcher::patch_response_schema,
         // This must be done after the other patches
         Patcher::patch_definition_required_fields,
     ];
@@ -691,6 +692,36 @@ impl Patcher {
             _ => None,
         }
     }
+
+    fn patch_git_get_items_batch(&mut self, key: &[&str], _value: &JsonValue) -> Option<JsonValue> {
+        // Only applies to git specs
+        if !self.spec_path.ends_with("git.json") {
+            return None;
+        }
+        match key {
+            ["paths", "/{organization}/{project}/_apis/git/repositories/{repositoryId}/itemsbatch", "post", "responses", "200", "schema"] => {
+                println!("Replace git GetItemsBatch response schema definition");
+                self.new_definitions.insert(
+                    "GitItems".to_string(),
+                    json::object! {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/GitItem"
+                        }
+                    },
+                );
+                Some(json::object! {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/GitItems"
+                    }
+                })
+            },
+            _ => None,
+        }
+    }
+
 
     fn patch_git_pull_request_create(
         &mut self,

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -699,7 +699,8 @@ impl Patcher {
             return None;
         }
         match key {
-            ["paths", "/{organization}/{project}/_apis/git/repositories/{repositoryId}/itemsbatch", "post", "responses", "200", "schema"] => {
+            ["paths", "/{organization}/{project}/_apis/git/repositories/{repositoryId}/itemsbatch", "post", "responses", "200", "schema"] =>
+            {
                 println!("Replace git GetItemsBatch response schema definition");
                 self.new_definitions.insert(
                     "GitItems".to_string(),
@@ -717,11 +718,10 @@ impl Patcher {
                         "$ref": "#/definitions/GitItems"
                     }
                 })
-            },
+            }
             _ => None,
         }
     }
-
 
     fn patch_git_pull_request_create(
         &mut self,


### PR DESCRIPTION
Fixes: https://github.com/microsoft/azure-devops-rust-api/issues/331

The OpenAPI spec for the return type is wrong (as in many other cases!).  This case was a bit harder to fix than usual as I assumed the response would be an array of `GitItem`.  However it turns out it returns an array of arrays of `GitItem` (although I don't understand why!).

From the example response in the [docs here](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/get-items-batch?view=azure-devops-rest-7.1&tabs=HTTP) - note the double open square brackets.

```json
{
  "count": 5,
  "value": [
    [
      {
        "objectId": "d1d5c2d49045d52bba6419652d6ecb2cd560dc29",
        "gitObjectType": "tree",
        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
        "path": "/MyWebSite/MyWebSite/Views",
        "isFolder": true,
        "contentMetadata": {
          "fileName": "Views"
        },
        "url": "https://dev.azure.com/fabrikam/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/MyWebSite/MyWebSite/Views?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014&versionOptions=None"
      },
      ...
    ]
  ]
}
```

To fix this I created a new type called `GitItems` (a `Vec<GitItem>`), and return an array of them.

I added a new example to test that it works.
