### PR TITLE
Restore removed fields in GitChange and Change. Make GitCommitRef com…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Change definitions of `GitChange` and `Change` to reinstate some optional fields that
+  were previously removed in the mistaken belief that they were unused.
+  - `GitChange`:
+    - `change_id`
+    - `new_content_template`
+    - `original_path`
+  - `Change`:
+    - `new_content`
+    - `source_server_item`
+    - `url`
+- Change `GitCommitRef` to make `commit_id` optional.
+
 ### [0.16.0]
 
 ### Changes

--- a/azure_devops_rust_api/examples/git_pr_files_changed.rs
+++ b/azure_devops_rust_api/examples/git_pr_files_changed.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
     // Get each commit in the PR
     println!("\nCommits:");
     for commit in pr_commits.iter() {
-        let commit_id = &commit.commit_id;
+        let commit_id = commit.commit_id.clone().unwrap_or("".to_string());
         let comment = match &commit.comment {
             Some(comment) => comment.clone(),
             _ => "".to_string(),

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -368,10 +368,33 @@ pub struct Change {
     #[serde(rename = "changeType")]
     pub change_type: change::ChangeType,
     pub item: serde_json::Value,
+    #[doc = ""]
+    #[serde(
+        rename = "newContent",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub new_content: Option<ItemContent>,
+    #[doc = "Path of the item on the server."]
+    #[serde(
+        rename = "sourceServerItem",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub source_server_item: Option<String>,
+    #[doc = "URL to retrieve the item."]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 impl Change {
     pub fn new(change_type: change::ChangeType, item: serde_json::Value) -> Self {
-        Self { change_type, item }
+        Self {
+            change_type,
+            item,
+            new_content: None,
+            source_server_item: None,
+            url: None,
+        }
     }
 }
 pub mod change {
@@ -1348,10 +1371,32 @@ impl GitBranchStatsList {
 pub struct GitChange {
     #[serde(flatten)]
     pub change: Change,
+    #[doc = "ID of the change within the group of changes."]
+    #[serde(rename = "changeId", default, skip_serializing_if = "Option::is_none")]
+    pub change_id: Option<i32>,
+    #[doc = ""]
+    #[serde(
+        rename = "newContentTemplate",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub new_content_template: Option<GitTemplate>,
+    #[doc = "Original path of item if different from current path."]
+    #[serde(
+        rename = "originalPath",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub original_path: Option<String>,
 }
 impl GitChange {
     pub fn new(change: Change) -> Self {
-        Self { change }
+        Self {
+            change,
+            change_id: None,
+            new_content_template: None,
+            original_path: None,
+        }
     }
 }
 #[doc = "This object is returned from Cherry Pick operations and provides the id and status of the operation"]
@@ -1372,7 +1417,7 @@ impl GitCherryPick {
     }
 }
 #[doc = ""]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitCommit {
     #[serde(flatten)]
     pub git_commit_ref: GitCommitRef,
@@ -1380,11 +1425,8 @@ pub struct GitCommit {
     pub tree_id: Option<String>,
 }
 impl GitCommit {
-    pub fn new(git_commit_ref: GitCommitRef) -> Self {
-        Self {
-            git_commit_ref,
-            tree_id: None,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 #[doc = ""]
@@ -1466,7 +1508,7 @@ impl GitCommitDiffs {
     }
 }
 #[doc = "Provides properties that describe a Git commit and associated metadata."]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitCommitRef {
     #[doc = "Links"]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
@@ -1498,8 +1540,8 @@ pub struct GitCommitRef {
     )]
     pub comment_truncated: Option<bool>,
     #[doc = "ID (SHA-1) of the commit."]
-    #[serde(rename = "commitId")]
-    pub commit_id: String,
+    #[serde(rename = "commitId", default, skip_serializing_if = "Option::is_none")]
+    pub commit_id: Option<String>,
     #[doc = "User info and date for Git operations."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub committer: Option<GitUserDate>,
@@ -1543,24 +1585,8 @@ pub struct GitCommitRef {
     pub work_items: Vec<ResourceRef>,
 }
 impl GitCommitRef {
-    pub fn new(commit_id: String) -> Self {
-        Self {
-            links: None,
-            author: None,
-            change_counts: None,
-            changes: Vec::new(),
-            comment: None,
-            comment_truncated: None,
-            commit_id,
-            committer: None,
-            commit_too_many_changes: None,
-            parents: Vec::new(),
-            push: None,
-            remote_url: None,
-            statuses: Vec::new(),
-            url: None,
-            work_items: Vec::new(),
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 #[doc = ""]

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -574,24 +574,6 @@ impl Patcher {
             return None;
         }
         match key {
-            ["definitions", "GitChange", "properties"] => {
-                println!("Remove unused git GitChange properties");
-                // Remove properties that never seem to be used
-                let mut value = value.clone();
-                value.remove("changeId");
-                value.remove("newContentTemplate");
-                value.remove("originalPath");
-                Some(value)
-            }
-            ["definitions", "Change", "properties"] => {
-                println!("Remove unused git Change properties");
-                // Remove properties that never seem to be used
-                let mut value = value.clone();
-                value.remove("newContent");
-                value.remove("sourceServerItem");
-                value.remove("url");
-                Some(value)
-            }
             ["definitions", "Change", "properties", "item"] => {
                 println!("Replace git Change item definition");
 
@@ -1286,13 +1268,6 @@ impl Patcher {
                 "IdentityRef",
                 r#"[
                     "id"
-                ]"#,
-            ),
-            (
-                "git.json",
-                "GitCommitRef",
-                r#"[
-                    "commitId"
                 ]"#,
             ),
             (


### PR DESCRIPTION
`git` module fixes:
- Restore previously removed fields in `GitChange` and `Change`
- Make `GitCommitRef` `commit_id` field optional

Fixes: https://github.com/microsoft/azure-devops-rust-api/issues/352