### PR TITLE
Fix: Cannot create a project

### DIFF
--- a/azure_devops_rust_api/src/build/models.rs
+++ b/azure_devops_rust_api/src/build/models.rs
@@ -5511,17 +5511,24 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
-    pub last_update_time: time::OffsetDateTime,
+    #[serde(
+        rename = "lastUpdateTime",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
+    pub last_update_time: Option<time::OffsetDateTime>,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    pub state: team_project_reference::State,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<team_project_reference::State>,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -5529,22 +5536,16 @@ pub struct TeamProjectReference {
     pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new(
-        id: String,
-        last_update_time: time::OffsetDateTime,
-        name: String,
-        state: team_project_reference::State,
-        visibility: team_project_reference::Visibility,
-    ) -> Self {
+    pub fn new(name: String, visibility: team_project_reference::Visibility) -> Self {
         Self {
             abbreviation: None,
             default_team_image_url: None,
             description: None,
-            id,
-            last_update_time,
+            id: None,
+            last_update_time: None,
             name,
             revision: None,
-            state,
+            state: None,
             url: None,
             visibility,
         }

--- a/azure_devops_rust_api/src/core/models.rs
+++ b/azure_devops_rust_api/src/core/models.rs
@@ -888,17 +888,24 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
-    pub last_update_time: time::OffsetDateTime,
+    #[serde(
+        rename = "lastUpdateTime",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
+    pub last_update_time: Option<time::OffsetDateTime>,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    pub state: team_project_reference::State,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<team_project_reference::State>,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -906,22 +913,16 @@ pub struct TeamProjectReference {
     pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new(
-        id: String,
-        last_update_time: time::OffsetDateTime,
-        name: String,
-        state: team_project_reference::State,
-        visibility: team_project_reference::Visibility,
-    ) -> Self {
+    pub fn new(name: String, visibility: team_project_reference::Visibility) -> Self {
         Self {
             abbreviation: None,
             default_team_image_url: None,
             description: None,
-            id,
-            last_update_time,
+            id: None,
+            last_update_time: None,
             name,
             revision: None,
-            state,
+            state: None,
             url: None,
             visibility,
         }

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -6745,17 +6745,24 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
-    pub last_update_time: time::OffsetDateTime,
+    #[serde(
+        rename = "lastUpdateTime",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
+    pub last_update_time: Option<time::OffsetDateTime>,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    pub state: team_project_reference::State,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<team_project_reference::State>,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -6763,22 +6770,16 @@ pub struct TeamProjectReference {
     pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new(
-        id: String,
-        last_update_time: time::OffsetDateTime,
-        name: String,
-        state: team_project_reference::State,
-        visibility: team_project_reference::Visibility,
-    ) -> Self {
+    pub fn new(name: String, visibility: team_project_reference::Visibility) -> Self {
         Self {
             abbreviation: None,
             default_team_image_url: None,
             description: None,
-            id,
-            last_update_time,
+            id: None,
+            last_update_time: None,
             name,
             revision: None,
-            state,
+            state: None,
             url: None,
             visibility,
         }

--- a/azure_devops_rust_api/src/test/models.rs
+++ b/azure_devops_rust_api/src/test/models.rs
@@ -5573,17 +5573,24 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
-    pub last_update_time: time::OffsetDateTime,
+    #[serde(
+        rename = "lastUpdateTime",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
+    pub last_update_time: Option<time::OffsetDateTime>,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    pub state: team_project_reference::State,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<team_project_reference::State>,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -5591,22 +5598,16 @@ pub struct TeamProjectReference {
     pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new(
-        id: String,
-        last_update_time: time::OffsetDateTime,
-        name: String,
-        state: team_project_reference::State,
-        visibility: team_project_reference::Visibility,
-    ) -> Self {
+    pub fn new(name: String, visibility: team_project_reference::Visibility) -> Self {
         Self {
             abbreviation: None,
             default_team_image_url: None,
             description: None,
-            id,
-            last_update_time,
+            id: None,
+            last_update_time: None,
             name,
             revision: None,
-            state,
+            state: None,
             url: None,
             visibility,
         }

--- a/azure_devops_rust_api/src/test_plan/models.rs
+++ b/azure_devops_rust_api/src/test_plan/models.rs
@@ -1053,17 +1053,24 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
-    pub last_update_time: time::OffsetDateTime,
+    #[serde(
+        rename = "lastUpdateTime",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
+    pub last_update_time: Option<time::OffsetDateTime>,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    pub state: team_project_reference::State,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<team_project_reference::State>,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -1071,22 +1078,16 @@ pub struct TeamProjectReference {
     pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new(
-        id: String,
-        last_update_time: time::OffsetDateTime,
-        name: String,
-        state: team_project_reference::State,
-        visibility: team_project_reference::Visibility,
-    ) -> Self {
+    pub fn new(name: String, visibility: team_project_reference::Visibility) -> Self {
         Self {
             abbreviation: None,
             default_team_image_url: None,
             description: None,
-            id,
-            last_update_time,
+            id: None,
+            last_update_time: None,
             name,
             revision: None,
-            state,
+            state: None,
             url: None,
             visibility,
         }

--- a/azure_devops_rust_api/src/test_results/models.rs
+++ b/azure_devops_rust_api/src/test_results/models.rs
@@ -2094,34 +2094,35 @@ pub struct TeamProjectReference {
     pub default_team_image_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub id: String,
-    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
-    pub last_update_time: time::OffsetDateTime,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(
+        rename = "lastUpdateTime",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
+    pub last_update_time: Option<time::OffsetDateTime>,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
-    pub state: team_project_reference::State,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<team_project_reference::State>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new(
-        id: String,
-        last_update_time: time::OffsetDateTime,
-        name: String,
-        state: team_project_reference::State,
-        visibility: team_project_reference::Visibility,
-    ) -> Self {
+    pub fn new(name: String, visibility: team_project_reference::Visibility) -> Self {
         Self {
             abbreviation: None,
             default_team_image_url: None,
             description: None,
-            id,
-            last_update_time,
+            id: None,
+            last_update_time: None,
             name,
             revision: None,
-            state,
+            state: None,
             url: None,
             visibility,
         }

--- a/azure_devops_rust_api/src/tfvc/models.rs
+++ b/azure_devops_rust_api/src/tfvc/models.rs
@@ -460,17 +460,24 @@ pub struct TeamProjectReference {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[doc = "Project identifier."]
-    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     #[doc = "Project last update time."]
-    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
-    pub last_update_time: time::OffsetDateTime,
+    #[serde(
+        rename = "lastUpdateTime",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
+    pub last_update_time: Option<time::OffsetDateTime>,
     #[doc = "Project name."]
     pub name: String,
     #[doc = "Project revision."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
     #[doc = "Project state."]
-    pub state: team_project_reference::State,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<team_project_reference::State>,
     #[doc = "Url to the full version of the object."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -478,22 +485,16 @@ pub struct TeamProjectReference {
     pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new(
-        id: String,
-        last_update_time: time::OffsetDateTime,
-        name: String,
-        state: team_project_reference::State,
-        visibility: team_project_reference::Visibility,
-    ) -> Self {
+    pub fn new(name: String, visibility: team_project_reference::Visibility) -> Self {
         Self {
             abbreviation: None,
             default_team_image_url: None,
             description: None,
-            id,
-            last_update_time,
+            id: None,
+            last_update_time: None,
             name,
             revision: None,
-            state,
+            state: None,
             url: None,
             visibility,
         }

--- a/azure_devops_rust_api/src/wiki/models.rs
+++ b/azure_devops_rust_api/src/wiki/models.rs
@@ -587,34 +587,35 @@ pub struct TeamProjectReference {
     pub default_team_image_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub id: String,
-    #[serde(rename = "lastUpdateTime", with = "crate::date_time::rfc3339")]
-    pub last_update_time: time::OffsetDateTime,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(
+        rename = "lastUpdateTime",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
+    pub last_update_time: Option<time::OffsetDateTime>,
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision: Option<i64>,
-    pub state: team_project_reference::State,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<team_project_reference::State>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     pub visibility: team_project_reference::Visibility,
 }
 impl TeamProjectReference {
-    pub fn new(
-        id: String,
-        last_update_time: time::OffsetDateTime,
-        name: String,
-        state: team_project_reference::State,
-        visibility: team_project_reference::Visibility,
-    ) -> Self {
+    pub fn new(name: String, visibility: team_project_reference::Visibility) -> Self {
         Self {
             abbreviation: None,
             default_team_image_url: None,
             description: None,
-            id,
-            last_update_time,
+            id: None,
+            last_update_time: None,
             name,
             revision: None,
-            state,
+            state: None,
             url: None,
             visibility,
         }

--- a/vsts-api-patcher/src/main.rs
+++ b/vsts-api-patcher/src/main.rs
@@ -1284,11 +1284,11 @@ impl Patcher {
                 //   description
                 //   revision
                 //   url
+                //   lastUpdateTime
+                //   id
+                //   state
                 r#"[
-                    "id",
-                    "lastUpdateTime",
                     "name",
-                    "state",
                     "visibility"
                 ]"#,
             ),


### PR DESCRIPTION
TeamProjectReference has requiered fields id,state and lastUpdateTime which error if trying to create a project with any set (id is a matter of not existing before creation).

This pr makes those fields optional.

Same issue as #352 but with projects.