### PR TITLE
Release 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [0.20.1]
+
 ### Changes
 
 - Add missing `distributed_task` submodules:
@@ -491,7 +493,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.20.0...HEAD
+[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.20.1...HEAD
+[0.20.1]: https://github.com/microsoft/azure-devops-rust-api/compare/0.20.0...0.20.1
 [0.20.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.19.2...0.20.0
 [0.19.2]: https://github.com/microsoft/azure-devops-rust-api/compare/0.19.1...0.19.2
 [0.19.1]: https://github.com/microsoft/azure-devops-rust-api/compare/0.19.0...0.19.1

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_devops_rust_api"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 authors = ["John Batty <johnbatty@microsoft.com>"]
 description = "Rust API library for Azure DevOps"

--- a/azure_devops_rust_api/README.md
+++ b/azure_devops_rust_api/README.md
@@ -67,7 +67,7 @@ Example application `Cargo.toml` dependency spec showing how to specify desired 
 ```toml
 [dependencies]
 ...
-azure_devops_rust_api = { version = "0.20.0", features = ["git", "pipelines"] }
+azure_devops_rust_api = { version = "0.20.1", features = ["git", "pipelines"] }
 ```
 
 ## Examples


### PR DESCRIPTION
Release 0.20.1

- Add missing `distributed_task` submodules:
  - `events`
  - `logs`
  - `oidctoken`
  - `records`
- Add missing `artifacts` SBOM-related data structures.