### PR TITLE
Fix datetime serialization issue when model field is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix datetime model fields being serialized when empty, causing invalid JSON to be sent to ADO for some requests
 - Fix clippy failure with empty doc comments.
 - Cleanup vsts-api-patcher structure.
 

--- a/autorust/codegen/src/codegen_models.rs
+++ b/autorust/codegen/src/codegen_models.rs
@@ -1154,6 +1154,7 @@ fn create_struct(
             if type_name.is_date_time() {
                 // Must specify `default` when using `with` for `Option`
                 serde.add_default();
+                serde.add_skip_serializing_if("Option::is_none");
                 #[cfg(feature = "azure_devops")]
                 serde.add_with("crate::date_time::rfc3339::option");
                 #[cfg(not(feature = "azure_devops"))]
@@ -1161,6 +1162,7 @@ fn create_struct(
             } else if type_name.is_date_time_rfc1123() {
                 // Must specify `default` when using `with` for `Option`
                 serde.add_default();
+                serde.add_skip_serializing_if("Option::is_none");
                 serde.add_with("azure_core::date::rfc1123::option");
             } else if type_name.is_vec() {
                 serde.add_default();

--- a/azure_devops_rust_api/src/accounts/models.rs
+++ b/azure_devops_rust_api/src/accounts/models.rs
@@ -52,6 +52,7 @@ pub struct Account {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -68,6 +69,7 @@ pub struct Account {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/approvals_and_checks/models.rs
+++ b/azure_devops_rust_api/src/approvals_and_checks/models.rs
@@ -22,6 +22,7 @@ pub struct Approval {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -42,6 +43,7 @@ pub struct Approval {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -294,6 +296,7 @@ pub struct ApprovalStep {
     #[serde(
         rename = "initiatedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub initiated_on: Option<time::OffsetDateTime>,
@@ -307,6 +310,7 @@ pub struct ApprovalStep {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -388,6 +392,7 @@ pub struct ApprovalStepHistory {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -536,6 +541,7 @@ pub struct CheckConfiguration {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -559,6 +565,7 @@ pub struct CheckConfiguration {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -810,12 +817,14 @@ pub struct CheckRun {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -888,6 +897,7 @@ pub struct CheckSuite {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -1105,6 +1115,7 @@ pub struct Permission {
     #[serde(
         rename = "authorizedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub authorized_on: Option<time::OffsetDateTime>,
@@ -1153,6 +1164,7 @@ pub struct PipelineResourceReference {
     #[serde(
         rename = "authorizedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub authorized_on: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/artifacts/models.rs
+++ b/azure_devops_rust_api/src/artifacts/models.rs
@@ -241,6 +241,7 @@ pub struct Feed {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -258,6 +259,7 @@ pub struct Feed {
     #[serde(
         rename = "permanentDeletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub permanent_deleted_date: Option<time::OffsetDateTime>,
@@ -272,6 +274,7 @@ pub struct Feed {
     #[serde(
         rename = "scheduledPermanentDeleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_permanent_delete_date: Option<time::OffsetDateTime>,
@@ -279,6 +282,7 @@ pub struct Feed {
     #[serde(
         rename = "upstreamEnabledChangedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub upstream_enabled_changed_date: Option<time::OffsetDateTime>,
@@ -952,6 +956,7 @@ pub struct MinimalPackageVersion {
     #[serde(
         rename = "publishDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub publish_date: Option<time::OffsetDateTime>,
@@ -1200,6 +1205,7 @@ pub struct PackageMetrics {
     #[serde(
         rename = "lastDownloaded",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_downloaded: Option<time::OffsetDateTime>,
@@ -1260,6 +1266,7 @@ pub struct PackageVersion {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -1402,6 +1409,7 @@ pub struct PackageVersionMetrics {
     #[serde(
         rename = "lastDownloaded",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_downloaded: Option<time::OffsetDateTime>,
@@ -1553,6 +1561,7 @@ pub struct RecycleBinPackageVersion {
     #[serde(
         rename = "scheduledPermanentDeleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_permanent_delete_date: Option<time::OffsetDateTime>,
@@ -1802,6 +1811,7 @@ pub struct UpstreamSource {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/artifacts_package_types/models.rs
+++ b/azure_devops_rust_api/src/artifacts_package_types/models.rs
@@ -136,6 +136,7 @@ pub struct MavenPackage {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -192,6 +193,7 @@ pub struct MavenPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -656,6 +658,7 @@ pub struct NpmPackageVersionDeletionState {
     #[serde(
         rename = "unpublishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub unpublished_date: Option<time::OffsetDateTime>,
@@ -727,6 +730,7 @@ pub struct NuGetPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -802,6 +806,7 @@ pub struct Package {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -815,6 +820,7 @@ pub struct Package {
     #[serde(
         rename = "permanentlyDeletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub permanently_deleted_date: Option<time::OffsetDateTime>,
@@ -879,6 +885,7 @@ pub struct PyPiPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -972,6 +979,7 @@ pub struct UPackPackageVersionDeletionState {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/audit/models.rs
+++ b/azure_devops_rust_api/src/audit/models.rs
@@ -122,7 +122,11 @@ pub struct AuditLogEntry {
     #[serde(rename = "scopeType", default, skip_serializing_if = "Option::is_none")]
     pub scope_type: Option<audit_log_entry::ScopeType>,
     #[doc = "The time when the event occurred in UTC"]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub timestamp: Option<time::OffsetDateTime>,
     #[doc = "The user agent from the request"]
     #[serde(rename = "userAgent", default, skip_serializing_if = "Option::is_none")]
@@ -198,6 +202,7 @@ pub struct AuditStream {
     #[serde(
         rename = "createdTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_time: Option<time::OffsetDateTime>,
@@ -225,6 +230,7 @@ pub struct AuditStream {
     #[serde(
         rename = "updatedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_time: Option<time::OffsetDateTime>,
@@ -378,7 +384,11 @@ pub struct DecoratedAuditLogEntry {
     #[serde(rename = "scopeType", default, skip_serializing_if = "Option::is_none")]
     pub scope_type: Option<decorated_audit_log_entry::ScopeType>,
     #[doc = "The time when the event occurred in UTC"]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub timestamp: Option<time::OffsetDateTime>,
     #[doc = "The user agent from the request"]
     #[serde(rename = "userAgent", default, skip_serializing_if = "Option::is_none")]

--- a/azure_devops_rust_api/src/build/models.rs
+++ b/azure_devops_rust_api/src/build/models.rs
@@ -491,6 +491,7 @@ pub struct Build {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -512,6 +513,7 @@ pub struct Build {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -527,6 +529,7 @@ pub struct Build {
     #[serde(
         rename = "lastChangedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_date: Option<time::OffsetDateTime>,
@@ -581,6 +584,7 @@ pub struct Build {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -629,6 +633,7 @@ pub struct Build {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -835,6 +840,7 @@ pub struct BuildAgent {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -871,6 +877,7 @@ pub struct BuildAgent {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -1048,6 +1055,7 @@ pub struct BuildController {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1064,6 +1072,7 @@ pub struct BuildController {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -1573,6 +1582,7 @@ pub struct BuildDefinitionRevision {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -1653,6 +1663,7 @@ pub struct BuildDefinitionSourceProvider {
     #[serde(
         rename = "lastModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified: Option<time::OffsetDateTime>,
@@ -1940,6 +1951,7 @@ pub struct BuildLog {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -1947,6 +1959,7 @@ pub struct BuildLog {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -2000,7 +2013,11 @@ impl BuildLogReference {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BuildMetric {
     #[doc = "The date for the scope."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "The value."]
     #[serde(rename = "intValue", default, skip_serializing_if = "Option::is_none")]
@@ -2368,6 +2385,7 @@ pub struct BuildReference {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -2378,6 +2396,7 @@ pub struct BuildReference {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -2394,6 +2413,7 @@ pub struct BuildReference {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -2613,6 +2633,7 @@ pub struct BuildRetentionSample {
     #[serde(
         rename = "sampleTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub sample_time: Option<time::OffsetDateTime>,
@@ -2655,6 +2676,7 @@ pub struct BuildServer {
     #[serde(
         rename = "statusChangedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub status_changed_date: Option<time::OffsetDateTime>,
@@ -2717,6 +2739,7 @@ pub struct BuildSummary {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -2739,6 +2762,7 @@ pub struct BuildSummary {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -2961,7 +2985,11 @@ pub struct Change {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pusher: Option<String>,
     #[doc = "The timestamp for the change."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub timestamp: Option<time::OffsetDateTime>,
     #[doc = "The type of change. \"commit\", \"changeset\", etc."]
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
@@ -3229,6 +3257,7 @@ pub struct DefinitionReference {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -3484,6 +3513,7 @@ pub struct Folder {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3500,6 +3530,7 @@ pub struct Folder {
     #[serde(
         rename = "lastChangedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_date: Option<time::OffsetDateTime>,
@@ -3695,6 +3726,7 @@ pub struct InformationNode {
     #[serde(
         rename = "lastModifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
@@ -4533,6 +4565,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -4547,6 +4580,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
@@ -4674,6 +4708,7 @@ pub struct RetentionLease {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -4704,6 +4739,7 @@ pub struct RetentionLease {
     #[serde(
         rename = "validUntil",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_until: Option<time::OffsetDateTime>,
@@ -5519,6 +5555,7 @@ pub struct TeamProjectReference {
     #[serde(
         rename = "lastUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
@@ -5640,6 +5677,7 @@ pub struct Timeline {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -5709,6 +5747,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -5728,6 +5767,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "lastModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified: Option<time::OffsetDateTime>,
@@ -5774,6 +5814,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -6174,6 +6215,7 @@ pub struct WorkspaceTemplate {
     #[serde(
         rename = "lastModifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
@@ -6239,6 +6281,7 @@ pub struct XamlBuildDefinition {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/core/models.rs
+++ b/azure_devops_rust_api/src/core/models.rs
@@ -438,6 +438,7 @@ pub struct ProjectInfo {
     #[serde(
         rename = "lastUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
@@ -875,6 +876,7 @@ pub struct TeamProjectReference {
     #[serde(
         rename = "lastUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
@@ -965,6 +967,7 @@ pub struct TemporaryDataCreatedDto {
     #[serde(
         rename = "expirationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub expiration_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/dashboard/models.rs
+++ b/azure_devops_rust_api/src/dashboard/models.rs
@@ -118,6 +118,7 @@ pub struct Dashboard {
     #[serde(
         rename = "lastAccessedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_accessed_date: Option<time::OffsetDateTime>,
@@ -132,6 +133,7 @@ pub struct Dashboard {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/distributed_task/models.rs
+++ b/azure_devops_rust_api/src/distributed_task/models.rs
@@ -63,6 +63,7 @@ pub struct AgentJobRequestMessage {
     #[serde(
         rename = "lockedUntil",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub locked_until: Option<time::OffsetDateTime>,
@@ -185,6 +186,7 @@ pub struct AzureKeyVaultVariableGroupProviderData {
     #[serde(
         rename = "lastRefreshedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_refreshed_on: Option<time::OffsetDateTime>,
@@ -214,7 +216,11 @@ pub struct AzureKeyVaultVariableValue {
     pub content_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub expires: Option<time::OffsetDateTime>,
 }
 impl AzureKeyVaultVariableValue {
@@ -1151,6 +1157,7 @@ pub struct ElasticNode {
     #[serde(
         rename = "stateChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub state_changed_on: Option<time::OffsetDateTime>,
@@ -1417,6 +1424,7 @@ pub struct ElasticPool {
     #[serde(
         rename = "offlineSince",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub offline_since: Option<time::OffsetDateTime>,
@@ -1569,7 +1577,11 @@ pub struct ElasticPoolLog {
     #[serde(rename = "poolId", default, skip_serializing_if = "Option::is_none")]
     pub pool_id: Option<i32>,
     #[doc = "Datetime that the log occurred"]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub timestamp: Option<time::OffsetDateTime>,
 }
 impl ElasticPoolLog {
@@ -1789,6 +1801,7 @@ pub struct EnvironmentDeploymentExecutionRecord {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -1817,6 +1830,7 @@ pub struct EnvironmentDeploymentExecutionRecord {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -1861,6 +1875,7 @@ pub struct EnvironmentDeploymentExecutionRecord {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -1914,6 +1929,7 @@ pub struct EnvironmentInstance {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -1933,6 +1949,7 @@ pub struct EnvironmentInstance {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -2003,6 +2020,7 @@ pub struct EnvironmentResource {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -2023,6 +2041,7 @@ pub struct EnvironmentResource {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -2073,6 +2092,7 @@ pub struct EnvironmentResourceDeploymentExecutionRecord {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -2093,6 +2113,7 @@ pub struct EnvironmentResourceDeploymentExecutionRecord {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -3140,6 +3161,7 @@ pub struct PackageMetadata {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3423,6 +3445,7 @@ pub struct ResourceLockRequest {
     #[serde(
         rename = "assignTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub assign_time: Option<time::OffsetDateTime>,
@@ -3444,6 +3467,7 @@ pub struct ResourceLockRequest {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -3470,6 +3494,7 @@ pub struct ResourceLockRequest {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -3617,6 +3642,7 @@ pub struct SecureFile {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3631,6 +3657,7 @@ pub struct SecureFile {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -3846,6 +3873,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -3864,6 +3892,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -4189,6 +4218,7 @@ pub struct TaskAgent {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -4220,6 +4250,7 @@ pub struct TaskAgent {
     #[serde(
         rename = "statusChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub status_changed_on: Option<time::OffsetDateTime>,
@@ -4368,6 +4399,7 @@ pub struct TaskAgentCloudRequest {
     #[serde(
         rename = "agentConnectedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub agent_connected_time: Option<time::OffsetDateTime>,
@@ -4384,18 +4416,21 @@ pub struct TaskAgentCloudRequest {
     #[serde(
         rename = "provisionedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub provisioned_time: Option<time::OffsetDateTime>,
     #[serde(
         rename = "provisionRequestTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub provision_request_time: Option<time::OffsetDateTime>,
     #[serde(
         rename = "releaseRequestTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub release_request_time: Option<time::OffsetDateTime>,
@@ -4520,6 +4555,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "assignTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub assign_time: Option<time::OffsetDateTime>,
@@ -4539,6 +4575,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -4555,6 +4592,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "lockedUntil",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub locked_until: Option<time::OffsetDateTime>,
@@ -4599,6 +4637,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -4606,6 +4645,7 @@ pub struct TaskAgentJobRequest {
     #[serde(
         rename = "receiveTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub receive_time: Option<time::OffsetDateTime>,
@@ -4863,6 +4903,7 @@ pub struct TaskAgentPool {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -4964,6 +5005,7 @@ pub struct TaskAgentPoolMaintenanceJob {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -4990,6 +5032,7 @@ pub struct TaskAgentPoolMaintenanceJob {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -5006,6 +5049,7 @@ pub struct TaskAgentPoolMaintenanceJob {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -5504,6 +5548,7 @@ pub struct TaskAgentUpdate {
     #[serde(
         rename = "requestTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub request_time: Option<time::OffsetDateTime>,
@@ -5565,6 +5610,7 @@ pub struct TaskAttachment {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -5577,6 +5623,7 @@ pub struct TaskAttachment {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -5956,6 +6003,7 @@ pub struct TaskGroup {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -5972,6 +6020,7 @@ pub struct TaskGroup {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -6164,6 +6213,7 @@ pub struct TaskGroupRevision {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -6588,6 +6638,7 @@ pub struct TaskLog {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -6602,6 +6653,7 @@ pub struct TaskLog {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -6765,6 +6817,7 @@ pub struct TaskOrchestrationPlan {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -6800,6 +6853,7 @@ pub struct TaskOrchestrationPlan {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -6929,6 +6983,7 @@ pub struct TaskOrchestrationQueuedPlan {
     #[serde(
         rename = "assignTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub assign_time: Option<time::OffsetDateTime>,
@@ -6951,6 +7006,7 @@ pub struct TaskOrchestrationQueuedPlan {
     #[serde(
         rename = "queueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queue_time: Option<time::OffsetDateTime>,
@@ -7145,6 +7201,7 @@ pub struct Timeline {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -7222,6 +7279,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -7242,6 +7300,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "lastModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified: Option<time::OffsetDateTime>,
@@ -7295,6 +7354,7 @@ pub struct TimelineRecord {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -7444,6 +7504,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -7466,6 +7527,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/extension_management/models.rs
+++ b/azure_devops_rust_api/src/extension_management/models.rs
@@ -708,6 +708,7 @@ pub struct ExtensionAuditLogEntry {
     #[serde(
         rename = "auditDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub audit_date: Option<time::OffsetDateTime>,
@@ -1166,6 +1167,7 @@ pub struct ExtensionRequest {
     #[serde(
         rename = "requestDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub request_date: Option<time::OffsetDateTime>,
@@ -1193,6 +1195,7 @@ pub struct ExtensionRequest {
     #[serde(
         rename = "resolveDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub resolve_date: Option<time::OffsetDateTime>,
@@ -1354,6 +1357,7 @@ pub struct ExtensionState {
     #[serde(
         rename = "lastVersionCheck",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_version_check: Option<time::OffsetDateTime>,
@@ -1436,6 +1440,7 @@ pub struct ExtensionVersion {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -1634,6 +1639,7 @@ pub struct InstalledExtension {
     #[serde(
         rename = "lastPublished",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_published: Option<time::OffsetDateTime>,
@@ -1722,6 +1728,7 @@ pub struct InstalledExtensionState {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -1846,6 +1853,7 @@ pub struct PublishedExtension {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -1866,6 +1874,7 @@ pub struct PublishedExtension {
     #[serde(
         rename = "publishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub published_date: Option<time::OffsetDateTime>,
@@ -1876,6 +1885,7 @@ pub struct PublishedExtension {
     #[serde(
         rename = "releaseDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub release_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/favorite/models.rs
+++ b/azure_devops_rust_api/src/favorite/models.rs
@@ -81,6 +81,7 @@ pub struct Favorite {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -18,6 +18,7 @@ pub struct AdvSecEnablementStatus {
     #[serde(
         rename = "changedOnDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_on_date: Option<time::OffsetDateTime>,
@@ -28,6 +29,7 @@ pub struct AdvSecEnablementStatus {
     #[serde(
         rename = "enabledChangedOnDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub enabled_changed_on_date: Option<time::OffsetDateTime>,
@@ -205,6 +207,7 @@ pub struct Attachment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -293,6 +296,7 @@ pub struct BillableCommitterDetail {
     #[serde(
         rename = "commitTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub commit_time: Option<time::OffsetDateTime>,
@@ -310,6 +314,7 @@ pub struct BillableCommitterDetail {
     #[serde(
         rename = "pushedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub pushed_time: Option<time::OffsetDateTime>,
@@ -456,6 +461,7 @@ pub struct ChangeList {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -478,6 +484,7 @@ pub struct ChangeList {
     #[serde(
         rename = "sortDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub sort_date: Option<time::OffsetDateTime>,
@@ -602,6 +609,7 @@ pub struct Comment {
     #[serde(
         rename = "lastContentUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_content_updated_date: Option<time::OffsetDateTime>,
@@ -609,6 +617,7 @@ pub struct Comment {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -623,6 +632,7 @@ pub struct Comment {
     #[serde(
         rename = "publishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub published_date: Option<time::OffsetDateTime>,
@@ -734,6 +744,7 @@ pub struct CommentThread {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -744,6 +755,7 @@ pub struct CommentThread {
     #[serde(
         rename = "publishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub published_date: Option<time::OffsetDateTime>,
@@ -1640,6 +1652,7 @@ pub struct GitConflict {
     #[serde(
         rename = "resolvedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub resolved_date: Option<time::OffsetDateTime>,
@@ -2155,6 +2168,7 @@ pub struct GitDeletedRepository {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -2163,6 +2177,7 @@ pub struct GitDeletedRepository {
     #[serde(
         rename = "deletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_date: Option<time::OffsetDateTime>,
@@ -2812,6 +2827,7 @@ pub struct GitLastChangeTreeItems {
     #[serde(
         rename = "lastExploredTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_explored_time: Option<time::OffsetDateTime>,
@@ -3077,6 +3093,7 @@ pub struct GitPullRequest {
     #[serde(
         rename = "closedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub closed_date: Option<time::OffsetDateTime>,
@@ -3105,6 +3122,7 @@ pub struct GitPullRequest {
     #[serde(
         rename = "completionQueueTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completion_queue_time: Option<time::OffsetDateTime>,
@@ -3608,6 +3626,7 @@ pub struct GitPullRequestIteration {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -3661,6 +3680,7 @@ pub struct GitPullRequestIteration {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -3864,6 +3884,7 @@ pub struct GitPullRequestSearchCriteria {
     #[serde(
         rename = "maxTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_time: Option<time::OffsetDateTime>,
@@ -3871,6 +3892,7 @@ pub struct GitPullRequestSearchCriteria {
     #[serde(
         rename = "minTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub min_time: Option<time::OffsetDateTime>,
@@ -4093,7 +4115,11 @@ pub struct GitPushRef {
     #[doc = "The class to represent a collection of REST reference links."]
     #[serde(rename = "_links", default, skip_serializing_if = "Option::is_none")]
     pub links: Option<ReferenceLinks>,
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[serde(rename = "pushedBy", default, skip_serializing_if = "Option::is_none")]
     pub pushed_by: Option<IdentityRef>,
@@ -4112,6 +4138,7 @@ pub struct GitPushSearchCriteria {
     #[serde(
         rename = "fromDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub from_date: Option<time::OffsetDateTime>,
@@ -4132,7 +4159,12 @@ pub struct GitPushSearchCriteria {
     pub pusher_id: Option<String>,
     #[serde(rename = "refName", default, skip_serializing_if = "Option::is_none")]
     pub ref_name: Option<String>,
-    #[serde(rename = "toDate", default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        rename = "toDate",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub to_date: Option<time::OffsetDateTime>,
 }
 impl GitPushSearchCriteria {
@@ -4958,6 +4990,7 @@ pub struct GitStatus {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -4977,6 +5010,7 @@ pub struct GitStatus {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -5371,7 +5405,11 @@ impl GitTreeRef {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitUserDate {
     #[doc = "Date of the Git operation."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Email address of the user performing the Git operation."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5754,6 +5792,7 @@ pub struct IncludedGitCommit {
     #[serde(
         rename = "commitTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub commit_time: Option<time::OffsetDateTime>,
@@ -6029,6 +6068,7 @@ pub struct PolicyConfiguration {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -6515,6 +6555,7 @@ pub struct TeamProjectReference {
     #[serde(
         rename = "lastUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
@@ -6651,6 +6692,7 @@ pub struct TfvcBranchRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -6802,6 +6844,7 @@ pub struct TfvcChangesetRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -6931,6 +6974,7 @@ pub struct TfvcItem {
     #[serde(
         rename = "changeDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub change_date: Option<time::OffsetDateTime>,
@@ -7139,6 +7183,7 @@ pub struct TfvcLabelRef {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -7351,6 +7396,7 @@ pub struct TfvcShelvesetRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/graph/models.rs
+++ b/azure_devops_rust_api/src/graph/models.rs
@@ -45,6 +45,7 @@ pub struct Avatar {
     #[serde(
         rename = "timeStamp",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/hooks/models.rs
+++ b/azure_devops_rust_api/src/hooks/models.rs
@@ -181,6 +181,7 @@ pub struct Event {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -756,6 +757,7 @@ pub struct Notification {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -772,6 +774,7 @@ pub struct Notification {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -835,6 +838,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -863,6 +867,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "dequeuedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub dequeued_date: Option<time::OffsetDateTime>,
@@ -890,6 +895,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "processedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub processed_date: Option<time::OffsetDateTime>,
@@ -911,6 +917,7 @@ pub struct NotificationDetails {
     #[serde(
         rename = "queuedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queued_date: Option<time::OffsetDateTime>,
@@ -1035,6 +1042,7 @@ pub struct NotificationsQuery {
     #[serde(
         rename = "maxCreatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_created_date: Option<time::OffsetDateTime>,
@@ -1056,6 +1064,7 @@ pub struct NotificationsQuery {
     #[serde(
         rename = "minCreatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub min_created_date: Option<time::OffsetDateTime>,
@@ -1319,6 +1328,7 @@ pub struct SessionToken {
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
@@ -1364,6 +1374,7 @@ pub struct Subscription {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1380,6 +1391,7 @@ pub struct Subscription {
     #[serde(
         rename = "lastProbationRetryDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_probation_retry_date: Option<time::OffsetDateTime>,
@@ -1392,6 +1404,7 @@ pub struct Subscription {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -1538,6 +1551,7 @@ pub struct SubscriptionTracing {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -1552,6 +1566,7 @@ pub struct SubscriptionTracing {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/ims/models.rs
+++ b/azure_devops_rust_api/src/ims/models.rs
@@ -52,6 +52,7 @@ pub struct AccessTokenResult {
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/member_entitlement_management/models.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/models.rs
@@ -200,6 +200,7 @@ pub struct EntitlementBase {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
@@ -218,6 +219,7 @@ pub struct EntitlementBase {
     #[serde(
         rename = "lastAccessedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_accessed_date: Option<time::OffsetDateTime>,
@@ -361,6 +363,7 @@ pub struct ExtensionSummaryData {
     #[serde(
         rename = "trialExpiryDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub trial_expiry_date: Option<time::OffsetDateTime>,
@@ -558,6 +561,7 @@ pub struct GroupEntitlement {
     #[serde(
         rename = "lastExecuted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_executed: Option<time::OffsetDateTime>,
@@ -773,6 +777,7 @@ pub struct LicenseSummaryData {
     #[serde(
         rename = "nextBillingDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub next_billing_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/permissions_report/models.rs
+++ b/azure_devops_rust_api/src/permissions_report/models.rs
@@ -29,12 +29,14 @@ pub struct PermissionsReport {
     #[serde(
         rename = "reportStatusLastUpdatedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub report_status_last_updated_time: Option<time::OffsetDateTime>,
     #[serde(
         rename = "requestedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub requested_time: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/pipelines/models.rs
+++ b/azure_devops_rust_api/src/pipelines/models.rs
@@ -153,6 +153,7 @@ pub struct Log {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -163,6 +164,7 @@ pub struct Log {
     #[serde(
         rename = "lastChangedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_on: Option<time::OffsetDateTime>,
@@ -480,6 +482,7 @@ pub struct Run {
     #[serde(
         rename = "finishedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finished_date: Option<time::OffsetDateTime>,
@@ -670,6 +673,7 @@ pub struct SignedUrl {
     #[serde(
         rename = "signatureExpires",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub signature_expires: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/policy/models.rs
+++ b/azure_devops_rust_api/src/policy/models.rs
@@ -122,6 +122,7 @@ pub struct PolicyConfiguration {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -205,6 +206,7 @@ pub struct PolicyEvaluationRecord {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -225,6 +227,7 @@ pub struct PolicyEvaluationRecord {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/profile/models.rs
+++ b/azure_devops_rust_api/src/profile/models.rs
@@ -63,6 +63,7 @@ pub struct Avatar {
     #[serde(
         rename = "timeStamp",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,
@@ -238,6 +239,7 @@ pub struct Profile {
     #[serde(
         rename = "timeStamp",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,
@@ -283,6 +285,7 @@ pub struct ProfileAttributeBase {
     #[serde(
         rename = "timeStamp",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub time_stamp: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/release/models.rs
+++ b/azure_devops_rust_api/src/release/models.rs
@@ -774,6 +774,7 @@ pub struct AzureKeyVaultVariableGroupProviderData {
     #[serde(
         rename = "lastRefreshedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_refreshed_on: Option<time::OffsetDateTime>,
@@ -808,7 +809,11 @@ pub struct AzureKeyVaultVariableValue {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     #[doc = "Gets or sets the expire time of key vault variable value."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub expires: Option<time::OffsetDateTime>,
 }
 impl AzureKeyVaultVariableValue {
@@ -965,7 +970,11 @@ pub struct Change {
     #[serde(rename = "pushedBy", default, skip_serializing_if = "Option::is_none")]
     pub pushed_by: Option<IdentityRef>,
     #[doc = "A timestamp for the change."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub timestamp: Option<time::OffsetDateTime>,
 }
 impl Change {
@@ -1461,6 +1470,7 @@ pub struct Deployment {
     #[serde(
         rename = "completedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_on: Option<time::OffsetDateTime>,
@@ -1498,6 +1508,7 @@ pub struct Deployment {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -1534,6 +1545,7 @@ pub struct Deployment {
     #[serde(
         rename = "queuedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queued_on: Option<time::OffsetDateTime>,
@@ -1570,6 +1582,7 @@ pub struct Deployment {
     #[serde(
         rename = "scheduledDeploymentTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_deployment_time: Option<time::OffsetDateTime>,
@@ -1577,6 +1590,7 @@ pub struct Deployment {
     #[serde(
         rename = "startedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_on: Option<time::OffsetDateTime>,
@@ -1746,6 +1760,7 @@ pub struct DeploymentAttempt {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -1772,6 +1787,7 @@ pub struct DeploymentAttempt {
     #[serde(
         rename = "queuedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub queued_on: Option<time::OffsetDateTime>,
@@ -2443,6 +2459,7 @@ pub struct Folder {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -2459,6 +2476,7 @@ pub struct Folder {
     #[serde(
         rename = "lastChangedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_changed_date: Option<time::OffsetDateTime>,
@@ -2668,6 +2686,7 @@ pub struct IgnoredGate {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -3030,6 +3049,7 @@ pub struct MailMessage {
     #[serde(
         rename = "replyBy",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub reply_by: Option<time::OffsetDateTime>,
@@ -3082,6 +3102,7 @@ pub struct ManualIntervention {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3095,6 +3116,7 @@ pub struct ManualIntervention {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -3670,6 +3692,7 @@ pub struct Release {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3717,6 +3740,7 @@ pub struct Release {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -3861,6 +3885,7 @@ pub struct ReleaseApproval {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3885,6 +3910,7 @@ pub struct ReleaseApproval {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -3966,6 +3992,7 @@ pub struct ReleaseApprovalHistory {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -3973,6 +4000,7 @@ pub struct ReleaseApprovalHistory {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -4177,6 +4205,7 @@ pub struct ReleaseDefinition {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -4209,6 +4238,7 @@ pub struct ReleaseDefinition {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -4656,6 +4686,7 @@ pub struct ReleaseDefinitionRevision {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -4831,6 +4862,7 @@ pub struct ReleaseDeployPhase {
     #[serde(
         rename = "startedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_on: Option<time::OffsetDateTime>,
@@ -4895,6 +4927,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -4934,6 +4967,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -4944,6 +4978,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "nextScheduledUtcTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub next_scheduled_utc_time: Option<time::OffsetDateTime>,
@@ -5019,6 +5054,7 @@ pub struct ReleaseEnvironment {
     #[serde(
         rename = "scheduledDeploymentTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_deployment_time: Option<time::OffsetDateTime>,
@@ -5325,6 +5361,7 @@ pub struct ReleaseEnvironmentUpdateMetadata {
     #[serde(
         rename = "scheduledDeploymentTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub scheduled_deployment_time: Option<time::OffsetDateTime>,
@@ -5402,6 +5439,7 @@ pub struct ReleaseGates {
     #[serde(
         rename = "lastModifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_on: Option<time::OffsetDateTime>,
@@ -5412,6 +5450,7 @@ pub struct ReleaseGates {
     #[serde(
         rename = "stabilizationCompletedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub stabilization_completed_on: Option<time::OffsetDateTime>,
@@ -5419,6 +5458,7 @@ pub struct ReleaseGates {
     #[serde(
         rename = "startedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_on: Option<time::OffsetDateTime>,
@@ -5429,6 +5469,7 @@ pub struct ReleaseGates {
     #[serde(
         rename = "succeedingSince",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub succeeding_since: Option<time::OffsetDateTime>,
@@ -5473,6 +5514,7 @@ pub struct ReleaseGatesPhase {
     #[serde(
         rename = "stabilizationCompletedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub stabilization_completed_on: Option<time::OffsetDateTime>,
@@ -5480,6 +5522,7 @@ pub struct ReleaseGatesPhase {
     #[serde(
         rename = "succeedingSince",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub succeeding_since: Option<time::OffsetDateTime>,
@@ -5585,6 +5628,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -5643,6 +5687,7 @@ pub struct ReleaseRevision {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -5887,6 +5932,7 @@ pub struct ReleaseTask {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -5930,6 +5976,7 @@ pub struct ReleaseTask {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -5987,6 +6034,7 @@ pub struct ReleaseTaskAttachment {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -6000,6 +6048,7 @@ pub struct ReleaseTaskAttachment {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -6362,6 +6411,7 @@ pub struct SourcePullRequestVersion {
     #[serde(
         rename = "pullRequestMergedAt",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub pull_request_merged_at: Option<time::OffsetDateTime>,
@@ -6641,6 +6691,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -6663,6 +6714,7 @@ pub struct VariableGroup {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/search/models.rs
+++ b/azure_devops_rust_api/src/search/models.rs
@@ -169,6 +169,7 @@ pub struct CustomRepositoryBranchStatusResponse {
     #[serde(
         rename = "lastIndexedChangeIdChangeTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_indexed_change_id_change_time: Option<time::OffsetDateTime>,
@@ -181,6 +182,7 @@ pub struct CustomRepositoryBranchStatusResponse {
     #[serde(
         rename = "latestChangeIdChangeTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub latest_change_id_change_time: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/service_endpoint/models.rs
+++ b/azure_devops_rust_api/src/service_endpoint/models.rs
@@ -1116,6 +1116,7 @@ pub struct OAuthConfiguration {
     #[serde(
         rename = "createdOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on: Option<time::OffsetDateTime>,
@@ -1139,6 +1140,7 @@ pub struct OAuthConfiguration {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -1490,6 +1492,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "finishTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_time: Option<time::OffsetDateTime>,
@@ -1516,6 +1519,7 @@ pub struct ServiceEndpointExecutionData {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/status/models.rs
+++ b/azure_devops_rust_api/src/status/models.rs
@@ -66,6 +66,7 @@ pub struct LiveSiteEvent {
     #[serde(
         rename = "endTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_time: Option<time::OffsetDateTime>,
@@ -94,6 +95,7 @@ pub struct LiveSiteEvent {
     #[serde(
         rename = "nextUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub next_update_time: Option<time::OffsetDateTime>,
@@ -102,6 +104,7 @@ pub struct LiveSiteEvent {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -181,6 +184,7 @@ pub struct LiveSiteEventLog {
     #[serde(
         rename = "creationDateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date_time: Option<time::OffsetDateTime>,
@@ -199,6 +203,7 @@ pub struct LiveSiteEventLog {
     #[serde(
         rename = "lastUpdatedDateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date_time: Option<time::OffsetDateTime>,
@@ -238,6 +243,7 @@ pub struct LiveSiteEventLogAttachment {
     #[serde(
         rename = "creationDateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date_time: Option<time::OffsetDateTime>,
@@ -478,6 +484,7 @@ pub struct Status {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/symbol/models.rs
+++ b/azure_devops_rust_api/src/symbol/models.rs
@@ -227,6 +227,7 @@ pub struct Request {
     #[serde(
         rename = "expirationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub expiration_date: Option<time::OffsetDateTime>,
@@ -272,6 +273,7 @@ pub struct ResourceBase {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/test/models.rs
+++ b/azure_devops_rust_api/src/test/models.rs
@@ -38,6 +38,7 @@ pub struct AfnStrip {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -560,6 +561,7 @@ pub struct BuildConfiguration {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -772,6 +774,7 @@ pub struct BuildReference2 {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -827,6 +830,7 @@ pub struct CloneOperationInformation {
     #[serde(
         rename = "completionDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completion_date: Option<time::OffsetDateTime>,
@@ -834,6 +838,7 @@ pub struct CloneOperationInformation {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -1253,12 +1258,14 @@ pub struct Coverage2 {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_modified: Option<time::OffsetDateTime>,
@@ -1445,7 +1452,11 @@ pub mod custom_test_field_definition {
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DatedTestFieldData {
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub value: Option<TestFieldData>,
@@ -1552,7 +1563,11 @@ pub struct FailingSince {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<BuildReference>,
     #[doc = "Time since failing(UTC)."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Reference to a release."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2045,6 +2060,7 @@ pub struct LastResultDetails {
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
@@ -2122,12 +2138,14 @@ pub struct LegacyBuildConfiguration {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -2174,6 +2192,7 @@ pub struct LegacyReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
@@ -2198,6 +2217,7 @@ pub struct LegacyReleaseReference {
     #[serde(
         rename = "releaseCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub release_creation_date: Option<time::OffsetDateTime>,
@@ -2334,6 +2354,7 @@ pub struct LegacyTestCaseResult {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -2347,12 +2368,14 @@ pub struct LegacyTestCaseResult {
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
@@ -2384,6 +2407,7 @@ pub struct LegacyTestCaseResult {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -2608,6 +2632,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "completeDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub complete_date: Option<time::OffsetDateTime>,
@@ -2623,6 +2648,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -2668,6 +2694,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "dueDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
@@ -2705,6 +2732,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -2808,6 +2836,7 @@ pub struct LegacyTestRun {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -2943,6 +2972,7 @@ pub struct LegacyTestSettings {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -2961,6 +2991,7 @@ pub struct LegacyTestSettings {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -3428,6 +3459,7 @@ pub struct PointLastResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -3563,6 +3595,7 @@ pub struct PointsResults2 {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -3830,6 +3863,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -3844,6 +3878,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
@@ -3894,6 +3929,7 @@ pub struct ReleaseReference2 {
     #[serde(
         rename = "environmentCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
@@ -3902,6 +3938,7 @@ pub struct ReleaseReference2 {
     #[serde(
         rename = "releaseCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub release_creation_date: Option<time::OffsetDateTime>,
@@ -3968,6 +4005,7 @@ pub struct RequirementsToTestsMapping2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -3976,6 +4014,7 @@ pub struct RequirementsToTestsMapping2 {
     #[serde(
         rename = "deletionDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deletion_date: Option<time::OffsetDateTime>,
@@ -4161,6 +4200,7 @@ pub struct ResultRetentionSettings {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -4308,6 +4348,7 @@ pub struct ResultUpdateResponse {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -4442,6 +4483,7 @@ pub struct ResultsFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -5484,6 +5526,7 @@ pub struct TeamProjectReference {
     #[serde(
         rename = "lastUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
@@ -5563,18 +5606,21 @@ pub struct TestActionResult {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
@@ -5597,6 +5643,7 @@ pub struct TestActionResult {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -5639,18 +5686,21 @@ pub struct TestActionResult2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
@@ -5671,6 +5721,7 @@ pub struct TestActionResult2 {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -5760,6 +5811,7 @@ pub struct TestAttachment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -5867,6 +5919,7 @@ pub struct TestAuthoringDetails {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -5979,12 +6032,14 @@ pub struct TestCaseReference2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "lastRefTestRunDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_ref_test_run_date: Option<time::OffsetDateTime>,
@@ -6103,6 +6158,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -6120,6 +6176,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -6180,6 +6237,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -6248,6 +6306,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -6530,6 +6589,7 @@ pub struct TestConfiguration {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -6885,6 +6945,7 @@ pub struct TestHistoryQuery {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -6955,6 +7016,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -6989,6 +7051,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -7034,6 +7097,7 @@ pub struct TestLog {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -7185,6 +7249,7 @@ pub struct TestLogStoreAttachment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -7324,6 +7389,7 @@ pub struct TestMessageLogDetails {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
@@ -7344,6 +7410,7 @@ pub struct TestMessageLogEntry {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
@@ -7378,6 +7445,7 @@ pub struct TestMessageLogEntry2 {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
@@ -7461,6 +7529,7 @@ pub struct TestParameter2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -7469,6 +7538,7 @@ pub struct TestParameter2 {
     #[serde(
         rename = "dateModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_modified: Option<time::OffsetDateTime>,
@@ -7527,6 +7597,7 @@ pub struct TestPlan {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -7568,6 +7639,7 @@ pub struct TestPlan {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -7586,6 +7658,7 @@ pub struct TestPlan {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -7718,6 +7791,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastResetToActive",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_reset_to_active: Option<time::OffsetDateTime>,
@@ -7773,6 +7847,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -7957,18 +8032,21 @@ pub struct TestResult2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateStarted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_started: Option<time::OffsetDateTime>,
@@ -7987,6 +8065,7 @@ pub struct TestResult2 {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -8079,6 +8158,7 @@ pub struct TestResultAttachment {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -8523,6 +8603,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -8547,6 +8628,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -8670,6 +8752,7 @@ pub struct TestResultReset2 {
     #[serde(
         rename = "dateModified",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_modified: Option<time::OffsetDateTime>,
@@ -8775,6 +8858,7 @@ pub struct TestResultTrendFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -8898,12 +8982,14 @@ pub struct TestResultsEx2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateTimeValue",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_time_value: Option<time::OffsetDateTime>,
@@ -9057,6 +9143,7 @@ pub struct TestResultsWithWatermark {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -9097,6 +9184,7 @@ pub struct TestRun {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -9107,6 +9195,7 @@ pub struct TestRun {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -9150,6 +9239,7 @@ pub struct TestRun {
     #[serde(
         rename = "dueDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
@@ -9193,6 +9283,7 @@ pub struct TestRun {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -9269,6 +9360,7 @@ pub struct TestRun {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -9379,6 +9471,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "completeDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub complete_date: Option<time::OffsetDateTime>,
@@ -9393,12 +9486,14 @@ pub struct TestRun2 {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "deletedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub deleted_on: Option<time::OffsetDateTime>,
@@ -9411,6 +9506,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "dueDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
@@ -9449,6 +9545,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -9515,6 +9612,7 @@ pub struct TestRun2 {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -9689,12 +9787,14 @@ pub struct TestRunEx2 {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
     #[serde(
         rename = "dateTimeValue",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_time_value: Option<time::OffsetDateTime>,
@@ -9862,6 +9962,7 @@ pub struct TestRunSummary2 {
     #[serde(
         rename = "testRunCompletedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub test_run_completed_date: Option<time::OffsetDateTime>,
@@ -9933,6 +10034,7 @@ pub struct TestSession {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -9949,6 +10051,7 @@ pub struct TestSession {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -9974,6 +10077,7 @@ pub struct TestSession {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -10045,6 +10149,7 @@ pub struct TestSessionExploredWorkItemReference {
     #[serde(
         rename = "endTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_time: Option<time::OffsetDateTime>,
@@ -10052,6 +10157,7 @@ pub struct TestSessionExploredWorkItemReference {
     #[serde(
         rename = "startTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_time: Option<time::OffsetDateTime>,
@@ -10148,6 +10254,7 @@ pub struct TestSettings2 {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -10166,6 +10273,7 @@ pub struct TestSettings2 {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -10229,6 +10337,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -10278,6 +10387,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -10312,6 +10422,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -10402,6 +10513,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastPopulatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_populated_date: Option<time::OffsetDateTime>,
@@ -10415,6 +10527,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -10686,6 +10799,7 @@ pub struct UpdatedProperties {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/test_plan/models.rs
+++ b/azure_devops_rust_api/src/test_plan/models.rs
@@ -34,6 +34,7 @@ pub struct CloneOperationCommonResponse {
     #[serde(
         rename = "completionDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completion_date: Option<time::OffsetDateTime>,
@@ -41,6 +42,7 @@ pub struct CloneOperationCommonResponse {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -600,6 +602,7 @@ pub struct LastResultDetails {
     #[serde(
         rename = "dateCompleted",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_completed: Option<time::OffsetDateTime>,
@@ -1078,6 +1081,7 @@ pub struct TeamProjectReference {
     #[serde(
         rename = "lastUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
@@ -1184,6 +1188,7 @@ pub struct TestCaseAssociatedResult {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -1512,6 +1517,7 @@ pub struct TestPlan {
     #[serde(
         rename = "updatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub updated_date: Option<time::OffsetDateTime>,
@@ -1544,6 +1550,7 @@ pub struct TestPlanCreateParams {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -1566,6 +1573,7 @@ pub struct TestPlanCreateParams {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -1597,6 +1605,7 @@ pub struct TestPlanDetailedReference {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -1614,6 +1623,7 @@ pub struct TestPlanDetailedReference {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -1845,6 +1855,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastResetToActive",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_reset_to_active: Option<time::OffsetDateTime>,
@@ -1858,6 +1869,7 @@ pub struct TestPoint {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -2199,6 +2211,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastPopulatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_populated_date: Option<time::OffsetDateTime>,
@@ -2212,6 +2225,7 @@ pub struct TestSuite {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/test_results/models.rs
+++ b/azure_devops_rust_api/src/test_results/models.rs
@@ -392,6 +392,7 @@ pub struct BuildConfiguration {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -795,7 +796,11 @@ pub struct FailingSince {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<BuildReference>,
     #[doc = "Time since failing(UTC)."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Reference to a release."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1260,6 +1265,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "creationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub creation_date: Option<time::OffsetDateTime>,
@@ -1274,6 +1280,7 @@ pub struct ReleaseReference {
     #[serde(
         rename = "environmentCreationDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub environment_creation_date: Option<time::OffsetDateTime>,
@@ -1382,6 +1389,7 @@ pub struct ResultsFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -2175,6 +2183,7 @@ pub struct TeamProjectReference {
     #[serde(
         rename = "lastUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
@@ -2292,6 +2301,7 @@ pub struct TestAttachment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -2455,6 +2465,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -2472,6 +2483,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -2532,6 +2544,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -2600,6 +2613,7 @@ pub struct TestCaseResult {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -2871,6 +2885,7 @@ pub struct TestHistoryQuery {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -2941,6 +2956,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -2975,6 +2991,7 @@ pub struct TestIterationDetailsModel {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -3004,6 +3021,7 @@ pub struct TestLog {
     #[serde(
         rename = "modifiedOn",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_on: Option<time::OffsetDateTime>,
@@ -3108,6 +3126,7 @@ pub struct TestLogStoreAttachment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -3249,6 +3268,7 @@ pub struct TestMessageLogDetails {
     #[serde(
         rename = "dateCreated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub date_created: Option<time::OffsetDateTime>,
@@ -3576,6 +3596,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -3600,6 +3621,7 @@ pub struct TestResultModelBase {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -3758,6 +3780,7 @@ pub struct TestResultTrendFilter {
     #[serde(
         rename = "maxCompleteDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub max_complete_date: Option<time::OffsetDateTime>,
@@ -3960,6 +3983,7 @@ pub struct TestRun {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -3970,6 +3994,7 @@ pub struct TestRun {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -4013,6 +4038,7 @@ pub struct TestRun {
     #[serde(
         rename = "dueDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub due_date: Option<time::OffsetDateTime>,
@@ -4056,6 +4082,7 @@ pub struct TestRun {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -4132,6 +4159,7 @@ pub struct TestRun {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,
@@ -4355,6 +4383,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "completedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub completed_date: Option<time::OffsetDateTime>,
@@ -4404,6 +4433,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "lastUpdatedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated_date: Option<time::OffsetDateTime>,
@@ -4438,6 +4468,7 @@ pub struct TestSubResult {
     #[serde(
         rename = "startedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub started_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/tfvc/models.rs
+++ b/azure_devops_rust_api/src/tfvc/models.rs
@@ -452,6 +452,7 @@ pub struct TeamProjectReference {
     #[serde(
         rename = "lastUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
@@ -604,6 +605,7 @@ pub struct TfvcBranchRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -783,6 +785,7 @@ pub struct TfvcChangesetRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -898,6 +901,7 @@ pub struct TfvcItem {
     #[serde(
         rename = "changeDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub change_date: Option<time::OffsetDateTime>,
@@ -1104,6 +1108,7 @@ pub struct TfvcLabelRef {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -1332,6 +1337,7 @@ pub struct TfvcShelvesetRef {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/token_admin/models.rs
+++ b/azure_devops_rust_api/src/token_admin/models.rs
@@ -68,12 +68,14 @@ pub struct SessionToken {
     #[serde(
         rename = "validFrom",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_from: Option<time::OffsetDateTime>,
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
@@ -224,6 +226,7 @@ pub struct TokenAdminRevocationRule {
     #[serde(
         rename = "createdBefore",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_before: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/tokens/models.rs
+++ b/azure_devops_rust_api/src/tokens/models.rs
@@ -52,6 +52,7 @@ pub struct AccessTokenResult {
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
@@ -248,6 +249,7 @@ pub struct PatToken {
     #[serde(
         rename = "validFrom",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_from: Option<time::OffsetDateTime>,
@@ -255,6 +257,7 @@ pub struct PatToken {
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
@@ -284,6 +287,7 @@ pub struct PatTokenCreateRequest {
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
@@ -412,6 +416,7 @@ pub struct PatTokenUpdateRequest {
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,
@@ -496,12 +501,14 @@ pub struct SessionToken {
     #[serde(
         rename = "validFrom",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_from: Option<time::OffsetDateTime>,
     #[serde(
         rename = "validTo",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub valid_to: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/wiki/models.rs
+++ b/azure_devops_rust_api/src/wiki/models.rs
@@ -23,6 +23,7 @@ pub struct Comment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -49,6 +50,7 @@ pub struct Comment {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -111,6 +113,7 @@ pub struct CommentAttachment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -575,6 +578,7 @@ pub struct TeamProjectReference {
     #[serde(
         rename = "lastUpdateTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_update_time: Option<time::OffsetDateTime>,
@@ -973,7 +977,11 @@ pub struct WikiPageStat {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub count: Option<i32>,
     #[doc = "Day of the stat"]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub day: Option<time::OffsetDateTime>,
 }
 impl WikiPageStat {
@@ -991,6 +999,7 @@ pub struct WikiPageViewStats {
     #[serde(
         rename = "lastViewedTime",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_viewed_time: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/wit/models.rs
+++ b/azure_devops_rust_api/src/wit/models.rs
@@ -86,6 +86,7 @@ pub struct AccountRecentActivityWorkItemModelBase {
     #[serde(
         rename = "activityDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub activity_date: Option<time::OffsetDateTime>,
@@ -100,6 +101,7 @@ pub struct AccountRecentActivityWorkItemModelBase {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -171,6 +173,7 @@ pub struct AccountRecentMentionWorkItemModel {
     #[serde(
         rename = "mentionedDateField",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub mentioned_date_field: Option<time::OffsetDateTime>,
@@ -211,6 +214,7 @@ pub struct AccountWorkWorkItemModel {
     #[serde(
         rename = "changedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub changed_date: Option<time::OffsetDateTime>,
@@ -294,6 +298,7 @@ pub struct Comment {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -301,6 +306,7 @@ pub struct Comment {
     #[serde(
         rename = "createdOnBehalfDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on_behalf_date: Option<time::OffsetDateTime>,
@@ -336,6 +342,7 @@ pub struct Comment {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -584,6 +591,7 @@ pub struct CommentVersion {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -591,6 +599,7 @@ pub struct CommentVersion {
     #[serde(
         rename = "createdOnBehalfDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_on_behalf_date: Option<time::OffsetDateTime>,
@@ -616,6 +625,7 @@ pub struct CommentVersion {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -743,6 +753,7 @@ pub struct ExternalDeployment {
     #[serde(
         rename = "statusDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub status_date: Option<time::OffsetDateTime>,
@@ -1309,6 +1320,7 @@ pub struct QueryHierarchyItem {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1355,6 +1367,7 @@ pub struct QueryHierarchyItem {
     #[serde(
         rename = "lastExecutedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_executed_date: Option<time::OffsetDateTime>,
@@ -1368,6 +1381,7 @@ pub struct QueryHierarchyItem {
     #[serde(
         rename = "lastModifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_modified_date: Option<time::OffsetDateTime>,
@@ -1876,7 +1890,12 @@ pub struct WorkItemBatchGetRequest {
     #[serde(rename = "$expand", default, skip_serializing_if = "Option::is_none")]
     pub expand: Option<work_item_batch_get_request::Expand>,
     #[doc = "AsOf UTC date time string"]
-    #[serde(rename = "asOf", default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        rename = "asOf",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub as_of: Option<time::OffsetDateTime>,
     #[doc = "The flag to control error policy in a bulk get work items request. Possible options are {Fail, Omit}."]
     #[serde(
@@ -2035,6 +2054,7 @@ pub struct WorkItemComment {
     #[serde(
         rename = "revisedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub revised_date: Option<time::OffsetDateTime>,
@@ -2569,6 +2589,7 @@ pub struct WorkItemHistory {
     #[serde(
         rename = "revisedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub revised_date: Option<time::OffsetDateTime>,
@@ -2755,7 +2776,12 @@ pub mod work_item_query_clause {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct WorkItemQueryResult {
     #[doc = "The date the query was run in the context of."]
-    #[serde(rename = "asOf", default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        rename = "asOf",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub as_of: Option<time::OffsetDateTime>,
     #[doc = "The columns of the query."]
     #[serde(
@@ -2988,6 +3014,7 @@ pub struct WorkItemTagDefinition {
     #[serde(
         rename = "lastUpdated",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_updated: Option<time::OffsetDateTime>,
@@ -3566,6 +3593,7 @@ pub struct WorkItemUpdate {
     #[serde(
         rename = "revisedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub revised_date: Option<time::OffsetDateTime>,

--- a/azure_devops_rust_api/src/work/models.rs
+++ b/azure_devops_rust_api/src/work/models.rs
@@ -788,10 +788,18 @@ pub mod create_plan {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DateRange {
     #[doc = "End of the date range."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub end: Option<time::OffsetDateTime>,
     #[doc = "Start of the date range."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub start: Option<time::OffsetDateTime>,
 }
 impl DateRange {
@@ -821,6 +829,7 @@ pub struct DeliveryViewData {
     #[serde(
         rename = "endDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub end_date: Option<time::OffsetDateTime>,
@@ -843,6 +852,7 @@ pub struct DeliveryViewData {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -1221,7 +1231,11 @@ pub struct Marker {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     #[doc = "Where the marker should be displayed on the timeline."]
-    #[serde(default, with = "crate::date_time::rfc3339::option")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::date_time::rfc3339::option"
+    )]
     pub date: Option<time::OffsetDateTime>,
     #[doc = "Label/title for the marker."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1312,6 +1326,7 @@ pub struct Plan {
     #[serde(
         rename = "createdDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub created_date: Option<time::OffsetDateTime>,
@@ -1325,6 +1340,7 @@ pub struct Plan {
     #[serde(
         rename = "lastAccessed",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub last_accessed: Option<time::OffsetDateTime>,
@@ -1338,6 +1354,7 @@ pub struct Plan {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -1426,6 +1443,7 @@ pub struct PlanMetadata {
     #[serde(
         rename = "modifiedDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub modified_date: Option<time::OffsetDateTime>,
@@ -1930,6 +1948,7 @@ pub struct TeamIterationAttributes {
     #[serde(
         rename = "finishDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_date: Option<time::OffsetDateTime>,
@@ -1937,6 +1956,7 @@ pub struct TeamIterationAttributes {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,
@@ -2389,6 +2409,7 @@ pub struct TimelineTeamIteration {
     #[serde(
         rename = "finishDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub finish_date: Option<time::OffsetDateTime>,
@@ -2410,6 +2431,7 @@ pub struct TimelineTeamIteration {
     #[serde(
         rename = "startDate",
         default,
+        skip_serializing_if = "Option::is_none",
         with = "crate::date_time::rfc3339::option"
     )]
     pub start_date: Option<time::OffsetDateTime>,


### PR DESCRIPTION
Fixes #461 - in the update from 0.20.1 to 0.21.0, the `serde.add_skip_serializing_if("Option::is_none");` tag was removed from the datetime type, causing API requests with models that had a datetime type property not set to be serialized in JSON as "null" which ADO rejected for some POST requests.

Tested by running the example for Git push, which failed starting in 0.21.0 and now works again:
> cargo run --example git_push  --features="git" {repo} {branch} {branch} {filename} "1234567"