### PR TITLE
Updates vsts-api-patcher to reflect valid use of 'Change'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Clippy fixes for `needless_lifetime` warnings.
 
+### Breaking change
+- Change git 'Change::item' field to be optional. 
+  - Discovered that in some returned values this field is not present.
+    Any code accessing this field now needs to wrap it in an `Option`, or deal with the returned value being wrapped in an `Option`.
+
 ## [0.24.0]
 
 ### Breaking change

--- a/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
+++ b/azure_devops_rust_api/examples/git_diff_files_between_base_and_target_branch.rs
@@ -53,10 +53,12 @@ async fn main() -> Result<()> {
 
     // Get files name which are present in the target branch
     for diff in diffs.iter() {
-        let git_object_type = diff.change.item["gitObjectType"].as_str().unwrap();
-        if git_object_type == "blob" {
-            let file_name = diff.change.item["path"].as_str().unwrap();
-            files_diff_between_branches.insert(file_name.to_string());
+        if let Some(item) = &diff.change.item {
+            let git_object_type = item["gitObjectType"].as_str().unwrap();
+            if git_object_type == "blob" {
+                let file_name = item["path"].as_str().unwrap();
+                files_diff_between_branches.insert(file_name.to_string());
+            }
         }
     }
 

--- a/azure_devops_rust_api/examples/git_pr_files_changed.rs
+++ b/azure_devops_rust_api/examples/git_pr_files_changed.rs
@@ -63,13 +63,14 @@ async fn main() -> Result<()> {
 
         // Get files changed in the commit
         for change in pr_commits_changes.iter() {
-            let item = &change.change.item;
-            // We are only interested in files not directories.
-            // files are "blob" type, directories are "folder" type.
-            if let (Some("blob"), Some(filename)) =
-                (item["git_object_type"].as_str(), item["path"].as_str())
-            {
-                files_changed.insert(filename.to_string());
+            if let Some(item) = &change.change.item {
+                // We are only interested in files not directories.
+                // files are "blob" type, directories are "folder" type.
+                if let (Some("blob"), Some(filename)) =
+                    (item["git_object_type"].as_str(), item["path"].as_str())
+                {
+                    files_changed.insert(filename.to_string());
+                }
             }
         }
     }

--- a/azure_devops_rust_api/examples/git_push.rs
+++ b/azure_devops_rust_api/examples/git_push.rs
@@ -51,9 +51,9 @@ fn new_git_change_with_content(
     GitChange {
         change: Change {
             change_type,
-            item: json!({
+            item: Some(json!({
                 "path": filename
-            }),
+            })),
             new_content: Some(ItemContent {
                 content: file_content,
                 content_type: ContentType::RawText,

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -353,7 +353,8 @@ pub struct Change {
     #[doc = "The type of change that was made to the item."]
     #[serde(rename = "changeType")]
     pub change_type: change::ChangeType,
-    pub item: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item: Option<serde_json::Value>,
     #[serde(
         rename = "newContent",
         default,
@@ -372,10 +373,10 @@ pub struct Change {
     pub url: Option<String>,
 }
 impl Change {
-    pub fn new(change_type: change::ChangeType, item: serde_json::Value) -> Self {
+    pub fn new(change_type: change::ChangeType) -> Self {
         Self {
             change_type,
-            item,
+            item: None,
             new_content: None,
             source_server_item: None,
             url: None,

--- a/vsts-api-patcher/src/patcher.rs
+++ b/vsts-api-patcher/src/patcher.rs
@@ -1186,8 +1186,7 @@ impl Patcher {
                 "git.json",
                 "Change",
                 r#"[
-                    "changeType",
-                    "item"
+                    "changeType"
                 ]"#,
             ),
             (


### PR DESCRIPTION
Fixes issue #538 

vsts-api-patcher is making the `item` property required when it is not valid for the `Change` returned by the commits search API. This causes a deserialization error because the API does not return the `item` property.