### PR TITLE
Add missing completionOptions field to GitPullRequestUpdateOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- Add missing `completionOptions` field to `GitPullRequestUpdateOptions`.
+
 ## [0.26.0]
 
 This is a significant change due to updating to the first offical releases of
 `azure_core` (0.22) and `azure_identity` (0.22).  These crates have a number of
 breaking changes over previous versions.
 
-## Breaking changes
+### Breaking changes
 - Update `azure_core`, `azure_identity` to 0.22.
 - `ClientBuilder::per_retry_policies()` renamed to `per_try_policies()` to align with
   `azure_core` API naming.

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -4042,6 +4042,13 @@ pub struct GitPullRequestUpdateOptions {
         skip_serializing_if = "Option::is_none"
     )]
     pub auto_complete_set_by: Option<IdentityRef>,
+    #[doc = "Preferences about how the pull request should be completed."]
+    #[serde(
+        rename = "completionOptions",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub completion_options: Option<GitPullRequestCompletionOptions>,
 }
 impl GitPullRequestUpdateOptions {
     pub fn new() -> Self {

--- a/vsts-api-patcher/src/patcher.rs
+++ b/vsts-api-patcher/src/patcher.rs
@@ -826,6 +826,10 @@ impl Patcher {
                           "autoCompleteSetBy": {
                             "description": "If set, auto-complete is enabled for this pull request and this is the identity that enabled it.",
                             "$ref": "#/definitions/IdentityRef"
+                          },
+                          "completionOptions": {
+                            "description": "Options which affect how the pull request will be merged when it is completed.",
+                            "$ref": "#/definitions/GitPullRequestCompletionOptions"
                           }
                         }
                     },


### PR DESCRIPTION
Fix up `vets-api-patcher` to add missing `completionOptions` field to `GitPullRequestUpdateOptions`

Fixes https://github.com/microsoft/azure-devops-rust-api/issues/600