### PR TITLE
Release 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0]
+
 ### Changes
 
 - Update `azure_core`, `azure_identity` to 0.23
-  - Update minimum rust-version to 1.80.0
+  - Update minimum rust-version to 1.80.0 (required by `azure_core`)
 
 ## [0.26.1]
 
@@ -578,7 +580,8 @@ breaking changes over previous versions.
 
 - Initial release.
 
-[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.26.1...HEAD
+[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.27.0...HEAD
+[0.27.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.26.1...0.27.0
 [0.26.1]: https://github.com/microsoft/azure-devops-rust-api/compare/0.26.0...0.26.1
 [0.26.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.25.0...0.26.0
 [0.25.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.24.0...0.25.0

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_devops_rust_api"
-version = "0.26.1"
+version = "0.27.0"
 edition = "2021"
 authors = ["John Batty <johnbatty@microsoft.com>"]
 description = "Rust API library for Azure DevOps"

--- a/azure_devops_rust_api/README.md
+++ b/azure_devops_rust_api/README.md
@@ -67,7 +67,7 @@ Example application `Cargo.toml` dependency spec showing how to specify desired 
 ```toml
 [dependencies]
 ...
-azure_devops_rust_api = { version = "0.26.1", features = ["git", "pipelines"] }
+azure_devops_rust_api = { version = "0.27.0", features = ["git", "pipelines"] }
 ```
 
 ## Examples


### PR DESCRIPTION
- Update `azure_core`, `azure_identity` to 0.23
  - Update minimum rust-version to 1.80.0 (required by `azure_core`)