### PR TITLE
Release 0.31.0. Make more name and description fields optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0]
+
+- Change `AgentPoolQueue` field to be optional:
+  - `name`
+- Change `ProjectReference` field to be optional:
+  - `name`
+- Change `ServiceEndpointProjectReference` fields to be optional:
+  - `description`
+  - `name`
+
 ## [0.30.1]
 
 - Change `ServiceEndpoint` field to be optional:
@@ -614,7 +624,8 @@ breaking changes over previous versions.
 
 - Initial release.
 
-[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.30.1...HEAD
+[Unreleased]: https://github.com/microsoft/azure-devops-rust-api/compare/0.31.0...HEAD
+[0.31.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.30.1...0.31.0
 [0.30.1]: https://github.com/microsoft/azure-devops-rust-api/compare/0.30.0...0.30.1
 [0.30.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.29.0...0.30.0
 [0.29.0]: https://github.com/microsoft/azure-devops-rust-api/compare/0.28.0...0.29.0

--- a/azure_devops_rust_api/Cargo.toml
+++ b/azure_devops_rust_api/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "azure_devops_rust_api"
-version = "0.30.1"
+version = "0.31.0"
 edition = "2021"
 authors = ["John Batty <johnbatty@microsoft.com>"]
 description = "Rust API library for Azure DevOps"

--- a/azure_devops_rust_api/README.md
+++ b/azure_devops_rust_api/README.md
@@ -67,7 +67,7 @@ Example application `Cargo.toml` dependency spec showing how to specify desired 
 ```toml
 [dependencies]
 ...
-azure_devops_rust_api = { version = "0.30.1", features = ["git", "pipelines"] }
+azure_devops_rust_api = { version = "0.31.0", features = ["git", "pipelines"] }
 ```
 
 ## Examples

--- a/azure_devops_rust_api/src/build/models.rs
+++ b/azure_devops_rust_api/src/build/models.rs
@@ -14,7 +14,8 @@ pub struct AgentPoolQueue {
     #[doc = "The ID of the queue."]
     pub id: i32,
     #[doc = "The name of the queue."]
-    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[doc = "Represents a reference to an agent pool."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pool: Option<TaskAgentPoolReference>,
@@ -23,11 +24,11 @@ pub struct AgentPoolQueue {
     pub url: Option<String>,
 }
 impl AgentPoolQueue {
-    pub fn new(id: i32, name: String) -> Self {
+    pub fn new(id: i32) -> Self {
         Self {
             links: None,
             id,
-            name,
+            name: None,
             pool: None,
             url: None,
         }

--- a/azure_devops_rust_api/src/service_endpoint/models.rs
+++ b/azure_devops_rust_api/src/service_endpoint/models.rs
@@ -1218,11 +1218,12 @@ impl Parameter {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProjectReference {
     pub id: String,
-    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 impl ProjectReference {
-    pub fn new(id: String, name: String) -> Self {
-        Self { id, name }
+    pub fn new(id: String) -> Self {
+        Self { id, name: None }
     }
 }
 #[doc = "The class to represent a collection of REST reference links."]
@@ -1664,17 +1665,19 @@ impl ServiceEndpointOAuthConfigurationReference {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ServiceEndpointProjectReference {
     #[doc = "Gets or sets description of the service endpoint."]
-    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     #[doc = "Gets or sets name of the service endpoint."]
-    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[serde(rename = "projectReference")]
     pub project_reference: ProjectReference,
 }
 impl ServiceEndpointProjectReference {
-    pub fn new(description: String, name: String, project_reference: ProjectReference) -> Self {
+    pub fn new(project_reference: ProjectReference) -> Self {
         Self {
-            description,
-            name,
+            description: None,
+            name: None,
             project_reference,
         }
     }

--- a/vsts-api-patcher/src/patcher.rs
+++ b/vsts-api-patcher/src/patcher.rs
@@ -1059,18 +1059,20 @@ impl Patcher {
             (
                 "serviceEndpoint.json",
                 "ServiceEndpointProjectReference",
+                // Excluded:
+                //   description
+                //   name
                 r#"[
-                    "description",
-                    "name",
                     "projectReference"
                 ]"#,
             ),
             (
                 "serviceEndpoint.json",
                 "ProjectReference",
+                // Excluded:
+                //   name
                 r#"[
-                    "id",
-                    "name"
+                    "id"
                 ]"#,
             ),
             // (
@@ -1313,10 +1315,10 @@ impl Patcher {
                 // Excluded
                 //   _links
                 //   url
-                //   pool"
+                //   name
+                //   pool
                 r#"[
-                    "id",
-                    "name"
+                    "id"
                 ]"#,
             ),
             (


### PR DESCRIPTION
Release 0.31.0.

- Change `AgentPoolQueue` field to be optional:
  - `name`
- Change `ProjectReference` field to be optional:
  - `name`
- Change `ServiceEndpointProjectReference` fields to be optional:
  - `description`
  - `name`
