### PR TITLE
Fix inline enum query/path params to use typed enums instead of String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- All generated enum types now implement `std::fmt::Display`.
+
+### Changed
+
+- **Breaking:** Query and path parameters that accept a fixed set of values are
+  now typed as enums instead of `impl Into<String>`. This affects 105 parameters
+  across all API areas. Examples:
+  - `git::items::list` / `git::items::get`: `recursion_level` now takes
+    `models::VersionControlRecursionType` (also applies to `tfvc` and `wiki`)
+  - `build::builds::list`: `status_filter` takes `models::BuildStatus`,
+    `result_filter` takes `models::BuildResult`, `reason_filter` takes
+    `models::BuildReason`, `query_order` takes `models::BuildQueryOrder`
+  - `release`: `status_filter` takes `models::ReleaseStatus`, `query_order`
+    takes `models::ReleaseQueryOrder`, `deployment_status` takes
+    `models::DeploymentStatus`
+  - `git::pull_requests::list`: `search_criteria_status` takes
+    `models::PullRequestStatus`
+  - `wit::work_items::get_work_item`: `expand` takes `models::WorkItemExpand`
+
+  The enum types are defined in each module's `models` and carry the same
+  variant names as the API documentation (e.g. `VersionControlRecursionType::Full`,
+  `BuildStatus::InProgress`).
+
 ## [0.36.0]
 
 ### Added

--- a/autorust/codegen/src/codegen_models.rs
+++ b/autorust/codegen/src/codegen_models.rs
@@ -926,6 +926,29 @@ fn create_enum(
         quote! {}
     };
 
+    let mut display_arms = TokenStream::new();
+    for enum_value in &enum_values {
+        let value = &enum_value.value;
+        let variant_nm = value.to_camel_case_ident()?;
+        display_arms.extend(quote! {
+            Self::#variant_nm => write!(f, #value),
+        });
+    }
+    if property.is_model_as_string_enum() {
+        display_arms.extend(quote! {
+            Self::UnknownValue(s) => write!(f, "{}", s),
+        });
+    }
+    let display_code = quote! {
+        impl std::fmt::Display for #nm {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    #display_arms
+                }
+            }
+        }
+    };
+
     let doc_comment = DocCommentCode::from(&property.schema.common.description);
 
     let code = quote! {
@@ -937,6 +960,7 @@ fn create_enum(
         }
         #custom_serde_code
         #default_code
+        #display_code
     };
     let type_name = TypeNameCode::from(vec![namespace, Some(id)]);
 

--- a/autorust/codegen/src/codegen_models.rs
+++ b/autorust/codegen/src/codegen_models.rs
@@ -391,6 +391,17 @@ fn all_schemas(spec: &Spec) -> Result<IndexMap<RefKey, SchemaGen>> {
         }
     }
 
+    // synthetic schemas for inline enum query parameters (e.g. `type: string` + `enum` + `x-ms-enum`)
+    for (ref_key, schema) in spec.inline_parameter_enum_schemas()? {
+        if !all_schemas.contains_key(&ref_key) {
+            let doc_file = ref_key.file_path.clone();
+            all_schemas.insert(
+                ref_key.clone(),
+                SchemaGen::new(Some(ref_key), schema, doc_file),
+            );
+        }
+    }
+
     Ok(all_schemas)
 }
 

--- a/autorust/codegen/src/spec.rs
+++ b/autorust/codegen/src/spec.rs
@@ -322,6 +322,61 @@ impl Spec {
         Ok(resolved)
     }
 
+    /// Collect synthetic schemas for inline enum parameters across all operations.
+    ///
+    /// Parameters with `type: string`, a non-empty `enum` field, and an `x-ms-enum`
+    /// extension carry enough information to generate a proper named Rust enum type.
+    /// This method extracts those and returns them as schemas so the models codegen
+    /// can emit a top-level enum definition for each one.
+    pub fn inline_parameter_enum_schemas(&self) -> Result<Vec<(RefKey, Schema)>> {
+        let mut result: Vec<(RefKey, Schema)> = Vec::new();
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for (doc_file, doc) in self.docs() {
+            if !self.is_input_file(doc_file) {
+                continue;
+            }
+            let paths = self.resolve_path_map(doc_file, &doc.paths())?;
+            for (_path, item) in &paths {
+                let all_params: Vec<&autorust_openapi::Parameter> = item
+                    .parameters
+                    .iter()
+                    .filter_map(|p| match p {
+                        ReferenceOr::Item(p) => Some(p),
+                        _ => None,
+                    })
+                    .chain(item.operations().flat_map(|op| {
+                        op.parameters.iter().filter_map(|p| match p {
+                            ReferenceOr::Item(p) => Some(p),
+                            _ => None,
+                        })
+                    }))
+                    .collect();
+                for param in all_params {
+                    if param.common.enum_.is_empty() {
+                        continue;
+                    }
+                    if let Some(x_ms_enum) = &param.common.x_ms_enum {
+                        let name = x_ms_enum.name.clone();
+                        if seen.insert(name.clone()) {
+                            let schema = Schema {
+                                common: param.common.clone(),
+                                ..Default::default()
+                            };
+                            result.push((
+                                RefKey {
+                                    file_path: doc_file.clone(),
+                                    name,
+                                },
+                                schema,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(result)
+    }
+
     // only operations from listed input files
     fn operations_unresolved(&self) -> Result<Vec<WebOperationUnresolved>> {
         let mut operations: Vec<WebOperationUnresolved> = Vec::new();
@@ -629,6 +684,13 @@ impl WebParameter {
     }
 
     pub fn type_name(&self) -> Result<TypeName> {
+        // Inline enum parameters with an x-ms-enum name are generated as a named
+        // enum type in models, referenced here by that name.
+        if !self.0.common.enum_.is_empty() {
+            if let Some(x_ms_enum) = &self.0.common.x_ms_enum {
+                return Ok(TypeName::Reference(x_ms_enum.name.clone()));
+            }
+        }
         Ok(if let Some(_data_type) = self.data_type() {
             get_type_name_for_schema(&self.0.common)?
         } else if let Some(schema) = &self.0.schema {

--- a/azure_devops_rust_api/examples/git_items_list.rs
+++ b/azure_devops_rust_api/examples/git_items_list.rs
@@ -5,6 +5,7 @@
 // Git items (files and folders) list example.
 use anyhow::Result;
 use azure_devops_rust_api::git;
+use azure_devops_rust_api::git::models::VersionControlRecursionType;
 use std::env;
 
 mod utils;
@@ -28,7 +29,7 @@ async fn main() -> Result<()> {
     let items = git_client
         .items_client()
         .list(organization, repository_name, project)
-        .recursion_level("Full")
+        .recursion_level(VersionControlRecursionType::Full)
         .await?
         .value;
 

--- a/azure_devops_rust_api/examples/git_repo_download_zip.rs
+++ b/azure_devops_rust_api/examples/git_repo_download_zip.rs
@@ -6,6 +6,7 @@
 use anyhow::Result;
 use azure_devops_rust_api::git;
 use azure_devops_rust_api::git::models::git_item::GitObjectType;
+use azure_devops_rust_api::git::models::VersionControlRecursionType;
 use azure_devops_rust_api::git::models::GitItem;
 use std::env;
 use std::io::Write;
@@ -23,7 +24,7 @@ async fn all_repo_items(
     let items = git_client
         .items_client()
         .list(organization, repository_name, project)
-        .recursion_level("Full")
+        .recursion_level(VersionControlRecursionType::Full)
         .await?
         .value;
     Ok(items)

--- a/azure_devops_rust_api/examples/git_repo_download_zip.rs
+++ b/azure_devops_rust_api/examples/git_repo_download_zip.rs
@@ -6,8 +6,8 @@
 use anyhow::Result;
 use azure_devops_rust_api::git;
 use azure_devops_rust_api::git::models::git_item::GitObjectType;
-use azure_devops_rust_api::git::models::VersionControlRecursionType;
 use azure_devops_rust_api::git::models::GitItem;
+use azure_devops_rust_api::git::models::VersionControlRecursionType;
 use std::env;
 use std::io::Write;
 

--- a/azure_devops_rust_api/examples/wit_work_item_get.rs
+++ b/azure_devops_rust_api/examples/wit_work_item_get.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
     let work_item = wit_client
         .work_items_client()
         .get_work_item(&organization, work_item_id, &project)
-        .expand("All")
+        .expand(wit::models::WorkItemExpand::All)
         .await?;
 
     println!("Work item [{work_item_id}]:\n{work_item:#?}");

--- a/azure_devops_rust_api/src/accounts/models.rs
+++ b/azure_devops_rust_api/src/accounts/models.rs
@@ -125,6 +125,17 @@ pub mod account {
         #[serde(rename = "moved")]
         Moved,
     }
+    impl std::fmt::Display for AccountStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Enabled => write!(f, "enabled"),
+                Self::Disabled => write!(f, "disabled"),
+                Self::Deleted => write!(f, "deleted"),
+                Self::Moved => write!(f, "moved"),
+            }
+        }
+    }
     #[doc = "Type of account: Personal, Organization"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum AccountType {
@@ -132,6 +143,14 @@ pub mod account {
         Personal,
         #[serde(rename = "organization")]
         Organization,
+    }
+    impl std::fmt::Display for AccountType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Personal => write!(f, "personal"),
+                Self::Organization => write!(f, "organization"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/approvals_and_checks/mod.rs
+++ b/azure_devops_rust_api/src/approvals_and_checks/mod.rs
@@ -694,7 +694,7 @@ pub mod check_configurations {
             pub(crate) project: String,
             pub(crate) resource_type: Option<String>,
             pub(crate) resource_id: Option<String>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::CheckConfigurationExpandParameter>,
         }
         impl RequestBuilder {
             #[doc = "resource type"]
@@ -707,7 +707,10 @@ pub mod check_configurations {
                 self.resource_id = Some(resource_id.into());
                 self
             }
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(
+                mut self,
+                expand: impl Into<models::CheckConfigurationExpandParameter>,
+            ) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -746,7 +749,7 @@ pub mod check_configurations {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -920,10 +923,13 @@ pub mod check_configurations {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) id: i32,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::CheckConfigurationExpandParameter>,
         }
         impl RequestBuilder {
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(
+                mut self,
+                expand: impl Into<models::CheckConfigurationExpandParameter>,
+            ) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -952,7 +958,7 @@ pub mod check_configurations {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1227,11 +1233,14 @@ pub mod check_configurations {
             pub(crate) organization: String,
             pub(crate) body: Vec<models::Resource>,
             pub(crate) project: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::CheckConfigurationExpandParameter>,
         }
         impl RequestBuilder {
             #[doc = "The properties that should be expanded in the list of check configurations."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(
+                mut self,
+                expand: impl Into<models::CheckConfigurationExpandParameter>,
+            ) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1262,7 +1271,7 @@ pub mod check_configurations {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))
@@ -1385,10 +1394,10 @@ pub mod check_evaluations {
             pub(crate) organization: String,
             pub(crate) body: models::CheckSuiteRequest,
             pub(crate) project: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::CheckSuiteExpandParameter>,
         }
         impl RequestBuilder {
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::CheckSuiteExpandParameter>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1419,7 +1428,7 @@ pub mod check_evaluations {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))
@@ -1493,10 +1502,10 @@ pub mod check_evaluations {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) check_suite_id: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::CheckSuiteExpandParameter>,
         }
         impl RequestBuilder {
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::CheckSuiteExpandParameter>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1525,7 +1534,7 @@ pub mod check_evaluations {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1670,9 +1679,9 @@ pub mod approvals {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) approval_ids: Option<String>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::ApprovalDetailsExpandParameter>,
             pub(crate) user_ids: Option<String>,
-            pub(crate) state: Option<String>,
+            pub(crate) state: Option<models::ApprovalStatus>,
             pub(crate) top: Option<i32>,
         }
         impl RequestBuilder {
@@ -1682,7 +1691,10 @@ pub mod approvals {
                 self
             }
             #[doc = "Include these additional details in the returned objects."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(
+                mut self,
+                expand: impl Into<models::ApprovalDetailsExpandParameter>,
+            ) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1692,7 +1704,7 @@ pub mod approvals {
                 self
             }
             #[doc = "Approval status. Returns approvals of any status if not provided"]
-            pub fn state(mut self, state: impl Into<String>) -> Self {
+            pub fn state(mut self, state: impl Into<models::ApprovalStatus>) -> Self {
                 self.state = Some(state.into());
                 self
             }
@@ -1731,7 +1743,7 @@ pub mod approvals {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(user_ids) = &this.user_ids {
                             req.url_mut()
@@ -1739,7 +1751,9 @@ pub mod approvals {
                                 .append_pair("userIds", user_ids);
                         }
                         if let Some(state) = &this.state {
-                            req.url_mut().query_pairs_mut().append_pair("state", state);
+                            req.url_mut()
+                                .query_pairs_mut()
+                                .append_pair("state", &state.to_string());
                         }
                         if let Some(top) = &this.top {
                             req.url_mut()
@@ -1917,10 +1931,13 @@ pub mod approvals {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) approval_id: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::ApprovalDetailsExpandParameter>,
         }
         impl RequestBuilder {
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(
+                mut self,
+                expand: impl Into<models::ApprovalDetailsExpandParameter>,
+            ) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1949,7 +1966,7 @@ pub mod approvals {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/approvals_and_checks/models.rs
+++ b/azure_devops_rust_api/src/approvals_and_checks/models.rs
@@ -264,6 +264,25 @@ impl ApprovalConfigSettings {
         Self::default()
     }
 }
+#[doc = "Include these additional details in the returned objects."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ApprovalDetailsExpandParameter {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "steps")]
+    Steps,
+    #[serde(rename = "permissions")]
+    Permissions,
+}
+impl std::fmt::Display for ApprovalDetailsExpandParameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Steps => write!(f, "steps"),
+            Self::Permissions => write!(f, "permissions"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ApprovalList {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -310,6 +329,49 @@ pub struct ApprovalRequest {
 impl ApprovalRequest {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Approval status. Returns approvals of any status if not provided"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ApprovalStatus {
+    #[serde(rename = "undefined")]
+    Undefined,
+    #[serde(rename = "uninitiated")]
+    Uninitiated,
+    #[serde(rename = "pending")]
+    Pending,
+    #[serde(rename = "approved")]
+    Approved,
+    #[serde(rename = "rejected")]
+    Rejected,
+    #[serde(rename = "skipped")]
+    Skipped,
+    #[serde(rename = "canceled")]
+    Canceled,
+    #[serde(rename = "timedOut")]
+    TimedOut,
+    #[serde(rename = "failed")]
+    Failed,
+    #[serde(rename = "completed")]
+    Completed,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for ApprovalStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Undefined => write!(f, "undefined"),
+            Self::Uninitiated => write!(f, "uninitiated"),
+            Self::Pending => write!(f, "pending"),
+            Self::Approved => write!(f, "approved"),
+            Self::Rejected => write!(f, "rejected"),
+            Self::Skipped => write!(f, "skipped"),
+            Self::Canceled => write!(f, "canceled"),
+            Self::TimedOut => write!(f, "timedOut"),
+            Self::Failed => write!(f, "failed"),
+            Self::Completed => write!(f, "completed"),
+            Self::All => write!(f, "all"),
+        }
     }
 }
 #[doc = "Data for a single approval step."]
@@ -707,6 +769,21 @@ impl CheckConfigurationData {
         Self::default()
     }
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum CheckConfigurationExpandParameter {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "settings")]
+    Settings,
+}
+impl std::fmt::Display for CheckConfigurationExpandParameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Settings => write!(f, "settings"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct CheckConfigurationList {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1085,6 +1162,21 @@ pub mod check_suite {
                 Self::Completed => write!(f, "completed"),
                 Self::All => write!(f, "all"),
             }
+        }
+    }
+}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum CheckSuiteExpandParameter {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "resources")]
+    Resources,
+}
+impl std::fmt::Display for CheckSuiteExpandParameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Resources => write!(f, "resources"),
         }
     }
 }

--- a/azure_devops_rust_api/src/approvals_and_checks/models.rs
+++ b/azure_devops_rust_api/src/approvals_and_checks/models.rs
@@ -83,6 +83,14 @@ pub mod approval {
         #[serde(rename = "inSequence")]
         InSequence,
     }
+    impl std::fmt::Display for ExecutionOrder {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::AnyOrder => write!(f, "anyOrder"),
+                Self::InSequence => write!(f, "inSequence"),
+            }
+        }
+    }
     #[doc = "Current user permissions for approval object."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Permissions {
@@ -98,6 +106,18 @@ pub mod approval {
         ResourceAdmin,
         #[serde(rename = "queueBuild")]
         QueueBuild,
+    }
+    impl std::fmt::Display for Permissions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::View => write!(f, "view"),
+                Self::Update => write!(f, "update"),
+                Self::Reassign => write!(f, "reassign"),
+                Self::ResourceAdmin => write!(f, "resourceAdmin"),
+                Self::QueueBuild => write!(f, "queueBuild"),
+            }
+        }
     }
     #[doc = "Overall status of the approval."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -124,6 +144,23 @@ pub mod approval {
         Completed,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Uninitiated => write!(f, "uninitiated"),
+                Self::Pending => write!(f, "pending"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::Failed => write!(f, "failed"),
+                Self::Completed => write!(f, "completed"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -199,6 +236,14 @@ pub mod approval_config {
         AnyOrder,
         #[serde(rename = "inSequence")]
         InSequence,
+    }
+    impl std::fmt::Display for ExecutionOrder {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::AnyOrder => write!(f, "anyOrder"),
+                Self::InSequence => write!(f, "inSequence"),
+            }
+        }
     }
 }
 #[doc = "Config to create a new approval."]
@@ -347,6 +392,18 @@ pub mod approval_step {
         #[serde(rename = "queueBuild")]
         QueueBuild,
     }
+    impl std::fmt::Display for Permissions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::View => write!(f, "view"),
+                Self::Update => write!(f, "update"),
+                Self::Reassign => write!(f, "reassign"),
+                Self::ResourceAdmin => write!(f, "resourceAdmin"),
+                Self::QueueBuild => write!(f, "queueBuild"),
+            }
+        }
+    }
     #[doc = "Current status of this step."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -372,6 +429,23 @@ pub mod approval_step {
         Completed,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Uninitiated => write!(f, "uninitiated"),
+                Self::Pending => write!(f, "pending"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::Failed => write!(f, "failed"),
+                Self::Completed => write!(f, "completed"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[doc = "Data for a single approval step history."]
@@ -464,6 +538,23 @@ pub mod approval_update_parameters {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Uninitiated => write!(f, "uninitiated"),
+                Self::Pending => write!(f, "pending"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::Failed => write!(f, "failed"),
+                Self::Completed => write!(f, "completed"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ApprovalsQueryParameters {
@@ -526,6 +617,23 @@ pub mod approvals_query_parameters {
         Completed,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for ApproverStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Uninitiated => write!(f, "uninitiated"),
+                Self::Pending => write!(f, "pending"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::Failed => write!(f, "failed"),
+                Self::Completed => write!(f, "completed"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -780,6 +888,14 @@ pub mod check_issue {
         #[serde(rename = "warning")]
         Warning,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Error => write!(f, "error"),
+                Self::Warning => write!(f, "warning"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct CheckIssueData {
@@ -877,6 +993,22 @@ pub mod check_run_result {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Queued => write!(f, "queued"),
+                Self::Running => write!(f, "running"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::Failed => write!(f, "failed"),
+                Self::Completed => write!(f, "completed"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct CheckSuite {
@@ -938,6 +1070,22 @@ pub mod check_suite {
         Completed,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Queued => write!(f, "queued"),
+                Self::Running => write!(f, "running"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::Failed => write!(f, "failed"),
+                Self::Completed => write!(f, "completed"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/artifacts/mod.rs
+++ b/azure_devops_rust_api/src/artifacts/mod.rs
@@ -1467,13 +1467,13 @@ pub mod feed_management {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) project: String,
-            pub(crate) feed_role: Option<String>,
+            pub(crate) feed_role: Option<models::FeedRole>,
             pub(crate) include_deleted_upstreams: Option<bool>,
             pub(crate) include_urls: Option<bool>,
         }
         impl RequestBuilder {
             #[doc = "Filter by this role, either Administrator(4), Contributor(3), or Reader(2) level permissions."]
-            pub fn feed_role(mut self, feed_role: impl Into<String>) -> Self {
+            pub fn feed_role(mut self, feed_role: impl Into<models::FeedRole>) -> Self {
                 self.feed_role = Some(feed_role.into());
                 self
             }
@@ -1512,7 +1512,7 @@ pub mod feed_management {
                         if let Some(feed_role) = &this.feed_role {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("feedRole", feed_role);
+                                .append_pair("feedRole", &feed_role.to_string());
                         }
                         if let Some(include_deleted_upstreams) = &this.include_deleted_upstreams {
                             req.url_mut().query_pairs_mut().append_pair(

--- a/azure_devops_rust_api/src/artifacts/models.rs
+++ b/azure_devops_rust_api/src/artifacts/models.rs
@@ -667,6 +667,34 @@ impl FeedRetentionPolicy {
         Self::default()
     }
 }
+#[doc = "Filter by this role, either Administrator(4), Contributor(3), or Reader(2) level permissions."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum FeedRole {
+    #[serde(rename = "custom")]
+    Custom,
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "reader")]
+    Reader,
+    #[serde(rename = "contributor")]
+    Contributor,
+    #[serde(rename = "administrator")]
+    Administrator,
+    #[serde(rename = "collaborator")]
+    Collaborator,
+}
+impl std::fmt::Display for FeedRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Custom => write!(f, "custom"),
+            Self::None => write!(f, "none"),
+            Self::Reader => write!(f, "reader"),
+            Self::Contributor => write!(f, "contributor"),
+            Self::Administrator => write!(f, "administrator"),
+            Self::Collaborator => write!(f, "collaborator"),
+        }
+    }
+}
 #[doc = "Update a feed definition with these new values."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct FeedUpdate {

--- a/azure_devops_rust_api/src/artifacts/models.rs
+++ b/azure_devops_rust_api/src/artifacts/models.rs
@@ -199,6 +199,16 @@ pub mod configuration {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for ManifestToolAction {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Validate => write!(f, "validate"),
+                Self::Generate => write!(f, "generate"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
 }
 #[doc = "Encapsulates a configuration setting to provide metadata about the setting source and type."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -314,6 +324,13 @@ pub mod feed_batch_data {
         #[serde(rename = "saveCachedPackages")]
         SaveCachedPackages,
     }
+    impl std::fmt::Display for Operation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::SaveCachedPackages => write!(f, "saveCachedPackages"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct FeedBatchOperationData {}
@@ -366,6 +383,15 @@ pub mod feed_change {
         Delete,
         #[serde(rename = "permanentDelete")]
         PermanentDelete,
+    }
+    impl std::fmt::Display for ChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::AddOrUpdate => write!(f, "addOrUpdate"),
+                Self::Delete => write!(f, "delete"),
+                Self::PermanentDelete => write!(f, "permanentDelete"),
+            }
+        }
     }
 }
 #[doc = "A result set containing the feed changes for the range that was requested."]
@@ -477,6 +503,16 @@ pub mod feed_core {
         #[serde(rename = "defaultCapabilities")]
         DefaultCapabilities,
     }
+    impl std::fmt::Display for Capabilities {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::UpstreamV2 => write!(f, "upstreamV2"),
+                Self::UnderMaintenance => write!(f, "underMaintenance"),
+                Self::DefaultCapabilities => write!(f, "defaultCapabilities"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct FeedIdsResult {
@@ -571,6 +607,18 @@ pub mod feed_permission {
         Administrator,
         #[serde(rename = "collaborator")]
         Collaborator,
+    }
+    impl std::fmt::Display for Role {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Custom => write!(f, "custom"),
+                Self::None => write!(f, "none"),
+                Self::Reader => write!(f, "reader"),
+                Self::Contributor => write!(f, "contributor"),
+                Self::Administrator => write!(f, "administrator"),
+                Self::Collaborator => write!(f, "collaborator"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -719,6 +767,15 @@ pub mod feed_view {
         #[serde(rename = "implicit")]
         Implicit,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Release => write!(f, "release"),
+                Self::Implicit => write!(f, "implicit"),
+            }
+        }
+    }
     #[doc = "Visibility status of the view."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Visibility {
@@ -730,6 +787,16 @@ pub mod feed_view {
         Organization,
         #[serde(rename = "aadTenant")]
         AadTenant,
+    }
+    impl std::fmt::Display for Visibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Private => write!(f, "private"),
+                Self::Collection => write!(f, "collection"),
+                Self::Organization => write!(f, "organization"),
+                Self::AadTenant => write!(f, "aadTenant"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -809,6 +876,16 @@ pub mod global_permission {
         FeedCreator,
         #[serde(rename = "administrator")]
         Administrator,
+    }
+    impl std::fmt::Display for Role {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Custom => write!(f, "custom"),
+                Self::None => write!(f, "none"),
+                Self::FeedCreator => write!(f, "feedCreator"),
+                Self::Administrator => write!(f, "administrator"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -892,6 +969,18 @@ pub mod json_patch_operation {
         Copy,
         #[serde(rename = "test")]
         Test,
+    }
+    impl std::fmt::Display for Op {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Remove => write!(f, "remove"),
+                Self::Replace => write!(f, "replace"),
+                Self::Move => write!(f, "move"),
+                Self::Copy => write!(f, "copy"),
+                Self::Test => write!(f, "test"),
+            }
+        }
     }
 }
 #[doc = "Defines a manifest name and version."]
@@ -1017,6 +1106,18 @@ pub mod operation_reference {
         Succeeded,
         #[serde(rename = "failed")]
         Failed,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NotSet => write!(f, "notSet"),
+                Self::Queued => write!(f, "queued"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Cancelled => write!(f, "cancelled"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+            }
+        }
     }
 }
 #[doc = "A package, which is a container for one or more package versions."]
@@ -1370,6 +1471,15 @@ pub mod package_version_change {
         Delete,
         #[serde(rename = "permanentDelete")]
         PermanentDelete,
+    }
+    impl std::fmt::Display for ChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::AddOrUpdate => write!(f, "addOrUpdate"),
+                Self::Delete => write!(f, "delete"),
+                Self::PermanentDelete => write!(f, "permanentDelete"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1785,6 +1895,16 @@ pub mod sign_response_base {
         #[serde(rename = "failCanRetry")]
         FailCanRetry,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Success => write!(f, "success"),
+                Self::Failure => write!(f, "failure"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::FailCanRetry => write!(f, "failCanRetry"),
+            }
+        }
+    }
 }
 #[doc = "The response returned by the sign status api."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1910,6 +2030,14 @@ pub mod upstream_source {
         #[serde(rename = "disabled")]
         Disabled,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Ok => write!(f, "ok"),
+                Self::Disabled => write!(f, "disabled"),
+            }
+        }
+    }
     #[doc = "Source type, such as Public or Internal."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum UpstreamSourceType {
@@ -1917,6 +2045,14 @@ pub mod upstream_source {
         Public,
         #[serde(rename = "internal")]
         Internal,
+    }
+    impl std::fmt::Display for UpstreamSourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Public => write!(f, "public"),
+                Self::Internal => write!(f, "internal"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/artifacts_package_types/models.rs
+++ b/azure_devops_rust_api/src/artifacts_package_types/models.rs
@@ -76,6 +76,18 @@ pub mod json_patch_operation {
         #[serde(rename = "test")]
         Test,
     }
+    impl std::fmt::Display for Op {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Remove => write!(f, "remove"),
+                Self::Replace => write!(f, "replace"),
+                Self::Move => write!(f, "move"),
+                Self::Copy => write!(f, "copy"),
+                Self::Test => write!(f, "test"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct MavenDistributionManagement {
@@ -244,6 +256,16 @@ pub mod maven_packages_batch_request {
         PermanentDelete,
         #[serde(rename = "restoreToFeed")]
         RestoreToFeed,
+    }
+    impl std::fmt::Display for Operation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Promote => write!(f, "promote"),
+                Self::Delete => write!(f, "delete"),
+                Self::PermanentDelete => write!(f, "permanentDelete"),
+                Self::RestoreToFeed => write!(f, "restoreToFeed"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -711,6 +733,18 @@ pub mod npm_packages_batch_request {
         #[serde(rename = "delete")]
         Delete,
     }
+    impl std::fmt::Display for Operation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Promote => write!(f, "promote"),
+                Self::Deprecate => write!(f, "deprecate"),
+                Self::Unpublish => write!(f, "unpublish"),
+                Self::PermanentDelete => write!(f, "permanentDelete"),
+                Self::RestoreToFeed => write!(f, "restoreToFeed"),
+                Self::Delete => write!(f, "delete"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct NpmRecycleBinPackageVersionDetails {
@@ -783,6 +817,17 @@ pub mod nu_get_packages_batch_request {
         PermanentDelete,
         #[serde(rename = "restoreToFeed")]
         RestoreToFeed,
+    }
+    impl std::fmt::Display for Operation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Promote => write!(f, "promote"),
+                Self::List => write!(f, "list"),
+                Self::Delete => write!(f, "delete"),
+                Self::PermanentDelete => write!(f, "permanentDelete"),
+                Self::RestoreToFeed => write!(f, "restoreToFeed"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -937,6 +982,16 @@ pub mod py_pi_packages_batch_request {
         #[serde(rename = "restoreToFeed")]
         RestoreToFeed,
     }
+    impl std::fmt::Display for Operation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Promote => write!(f, "promote"),
+                Self::Delete => write!(f, "delete"),
+                Self::PermanentDelete => write!(f, "permanentDelete"),
+                Self::RestoreToFeed => write!(f, "restoreToFeed"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct PyPiRecycleBinPackageVersionDetails {
@@ -1031,6 +1086,16 @@ pub mod u_pack_packages_batch_request {
         #[serde(rename = "restoreToFeed")]
         RestoreToFeed,
     }
+    impl std::fmt::Display for Operation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Promote => write!(f, "promote"),
+                Self::Delete => write!(f, "delete"),
+                Self::PermanentDelete => write!(f, "permanentDelete"),
+                Self::RestoreToFeed => write!(f, "restoreToFeed"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct UPackRecycleBinPackageVersionDetails {
@@ -1085,6 +1150,14 @@ pub mod upstream_source_info {
         #[serde(rename = "internal")]
         Internal,
     }
+    impl std::fmt::Display for SourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Public => write!(f, "public"),
+                Self::Internal => write!(f, "internal"),
+            }
+        }
+    }
 }
 #[doc = "Describes upstreaming behavior for a given feed/protocol/package"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1112,5 +1185,13 @@ pub mod upstreaming_behavior {
         Auto,
         #[serde(rename = "allowExternalVersions")]
         AllowExternalVersions,
+    }
+    impl std::fmt::Display for VersionsFromExternalUpstreams {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Auto => write!(f, "auto"),
+                Self::AllowExternalVersions => write!(f, "allowExternalVersions"),
+            }
+        }
     }
 }

--- a/azure_devops_rust_api/src/audit/mod.rs
+++ b/azure_devops_rust_api/src/audit/mod.rs
@@ -678,7 +678,7 @@ pub mod streams {
             &self,
             organization: impl Into<String>,
             stream_id: i32,
-            status: impl Into<String>,
+            status: impl Into<models::AuditStreamStatus>,
         ) -> update_status::RequestBuilder {
             update_status::RequestBuilder {
                 client: self.0.clone(),
@@ -1129,7 +1129,7 @@ pub mod streams {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) stream_id: i32,
-            pub(crate) status: String,
+            pub(crate) status: models::AuditStreamStatus,
         }
         impl RequestBuilder {
             #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
@@ -1157,7 +1157,7 @@ pub mod streams {
                         let status = &this.status;
                         req.url_mut()
                             .query_pairs_mut()
-                            .append_pair("status", status);
+                            .append_pair("status", &status.to_string());
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))

--- a/azure_devops_rust_api/src/audit/models.rs
+++ b/azure_devops_rust_api/src/audit/models.rs
@@ -40,6 +40,18 @@ pub mod audit_action_info {
         #[serde(rename = "execute")]
         Execute,
     }
+    impl std::fmt::Display for Category {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Modify => write!(f, "modify"),
+                Self::Remove => write!(f, "remove"),
+                Self::Create => write!(f, "create"),
+                Self::Access => write!(f, "access"),
+                Self::Execute => write!(f, "execute"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AuditActionInfoList {
@@ -153,6 +165,17 @@ pub mod audit_log_entry {
         #[serde(rename = "project")]
         Project,
     }
+    impl std::fmt::Display for ScopeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Deployment => write!(f, "deployment"),
+                Self::Enterprise => write!(f, "enterprise"),
+                Self::Organization => write!(f, "organization"),
+                Self::Project => write!(f, "project"),
+            }
+        }
+    }
 }
 #[doc = "The object returned when the audit log is queried. It contains the log and the information needed to query more audit entries."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -257,6 +280,18 @@ pub mod audit_stream {
         Deleted,
         #[serde(rename = "backfilling")]
         Backfilling,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Enabled => write!(f, "enabled"),
+                Self::DisabledByUser => write!(f, "disabledByUser"),
+                Self::DisabledBySystem => write!(f, "disabledBySystem"),
+                Self::Deleted => write!(f, "deleted"),
+                Self::Backfilling => write!(f, "backfilling"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -417,6 +452,18 @@ pub mod decorated_audit_log_entry {
         #[serde(rename = "execute")]
         Execute,
     }
+    impl std::fmt::Display for Category {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Modify => write!(f, "modify"),
+                Self::Remove => write!(f, "remove"),
+                Self::Create => write!(f, "create"),
+                Self::Access => write!(f, "access"),
+                Self::Execute => write!(f, "execute"),
+            }
+        }
+    }
     #[doc = "The type of the scope (Organization is only scope currently supported)"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum ScopeType {
@@ -430,6 +477,17 @@ pub mod decorated_audit_log_entry {
         Organization,
         #[serde(rename = "project")]
         Project,
+    }
+    impl std::fmt::Display for ScopeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Deployment => write!(f, "deployment"),
+                Self::Enterprise => write!(f, "enterprise"),
+                Self::Organization => write!(f, "organization"),
+                Self::Project => write!(f, "project"),
+            }
+        }
     }
 }
 #[doc = "This class is used to serialize collections as a single JSON object on the wire."]

--- a/azure_devops_rust_api/src/audit/models.rs
+++ b/azure_devops_rust_api/src/audit/models.rs
@@ -310,6 +310,34 @@ impl AuditStreamList {
         Self::default()
     }
 }
+#[doc = "Status of the stream"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum AuditStreamStatus {
+    #[serde(rename = "unknown")]
+    Unknown,
+    #[serde(rename = "enabled")]
+    Enabled,
+    #[serde(rename = "disabledByUser")]
+    DisabledByUser,
+    #[serde(rename = "disabledBySystem")]
+    DisabledBySystem,
+    #[serde(rename = "deleted")]
+    Deleted,
+    #[serde(rename = "backfilling")]
+    Backfilling,
+}
+impl std::fmt::Display for AuditStreamStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unknown => write!(f, "unknown"),
+            Self::Enabled => write!(f, "enabled"),
+            Self::DisabledByUser => write!(f, "disabledByUser"),
+            Self::DisabledBySystem => write!(f, "disabledBySystem"),
+            Self::Deleted => write!(f, "deleted"),
+            Self::Backfilling => write!(f, "backfilling"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DecoratedAuditLogEntry {
     #[doc = "The action id for the event, i.e Git.CreateRepo, Project.RenameProject"]

--- a/azure_devops_rust_api/src/build/mod.rs
+++ b/azure_devops_rust_api/src/build/mod.rs
@@ -2979,16 +2979,16 @@ pub mod builds {
             pub(crate) min_time: Option<time::OffsetDateTime>,
             pub(crate) max_time: Option<time::OffsetDateTime>,
             pub(crate) requested_for: Option<String>,
-            pub(crate) reason_filter: Option<String>,
-            pub(crate) status_filter: Option<String>,
-            pub(crate) result_filter: Option<String>,
+            pub(crate) reason_filter: Option<models::BuildReason>,
+            pub(crate) status_filter: Option<models::BuildStatus>,
+            pub(crate) result_filter: Option<models::BuildResult>,
             pub(crate) tag_filters: Option<String>,
             pub(crate) properties: Option<String>,
             pub(crate) top: Option<i32>,
             pub(crate) continuation_token: Option<String>,
             pub(crate) max_builds_per_definition: Option<i32>,
-            pub(crate) deleted_filter: Option<String>,
-            pub(crate) query_order: Option<String>,
+            pub(crate) deleted_filter: Option<models::QueryDeletedOption>,
+            pub(crate) query_order: Option<models::BuildQueryOrder>,
             pub(crate) branch_name: Option<String>,
             pub(crate) build_ids: Option<String>,
             pub(crate) repository_id: Option<String>,
@@ -3026,17 +3026,17 @@ pub mod builds {
                 self
             }
             #[doc = "If specified, filters to builds that match this reason."]
-            pub fn reason_filter(mut self, reason_filter: impl Into<String>) -> Self {
+            pub fn reason_filter(mut self, reason_filter: impl Into<models::BuildReason>) -> Self {
                 self.reason_filter = Some(reason_filter.into());
                 self
             }
             #[doc = "If specified, filters to builds that match this status."]
-            pub fn status_filter(mut self, status_filter: impl Into<String>) -> Self {
+            pub fn status_filter(mut self, status_filter: impl Into<models::BuildStatus>) -> Self {
                 self.status_filter = Some(status_filter.into());
                 self
             }
             #[doc = "If specified, filters to builds that match this result."]
-            pub fn result_filter(mut self, result_filter: impl Into<String>) -> Self {
+            pub fn result_filter(mut self, result_filter: impl Into<models::BuildResult>) -> Self {
                 self.result_filter = Some(result_filter.into());
                 self
             }
@@ -3066,12 +3066,15 @@ pub mod builds {
                 self
             }
             #[doc = "Indicates whether to exclude, include, or only return deleted builds."]
-            pub fn deleted_filter(mut self, deleted_filter: impl Into<String>) -> Self {
+            pub fn deleted_filter(
+                mut self,
+                deleted_filter: impl Into<models::QueryDeletedOption>,
+            ) -> Self {
                 self.deleted_filter = Some(deleted_filter.into());
                 self
             }
             #[doc = "The order in which builds should be returned."]
-            pub fn query_order(mut self, query_order: impl Into<String>) -> Self {
+            pub fn query_order(mut self, query_order: impl Into<models::BuildQueryOrder>) -> Self {
                 self.query_order = Some(query_order.into());
                 self
             }
@@ -3152,17 +3155,17 @@ pub mod builds {
                         if let Some(reason_filter) = &this.reason_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("reasonFilter", reason_filter);
+                                .append_pair("reasonFilter", &reason_filter.to_string());
                         }
                         if let Some(status_filter) = &this.status_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("statusFilter", status_filter);
+                                .append_pair("statusFilter", &status_filter.to_string());
                         }
                         if let Some(result_filter) = &this.result_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("resultFilter", result_filter);
+                                .append_pair("resultFilter", &result_filter.to_string());
                         }
                         if let Some(tag_filters) = &this.tag_filters {
                             req.url_mut()
@@ -3193,12 +3196,12 @@ pub mod builds {
                         if let Some(deleted_filter) = &this.deleted_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("deletedFilter", deleted_filter);
+                                .append_pair("deletedFilter", &deleted_filter.to_string());
                         }
                         if let Some(query_order) = &this.query_order {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryOrder", query_order);
+                                .append_pair("queryOrder", &query_order.to_string());
                         }
                         if let Some(branch_name) = &this.branch_name {
                             req.url_mut()
@@ -7567,7 +7570,7 @@ pub mod definitions {
             pub(crate) name: Option<String>,
             pub(crate) repository_id: Option<String>,
             pub(crate) repository_type: Option<String>,
-            pub(crate) query_order: Option<String>,
+            pub(crate) query_order: Option<models::DefinitionQueryOrder>,
             pub(crate) top: Option<i32>,
             pub(crate) continuation_token: Option<String>,
             pub(crate) min_metrics_time: Option<time::OffsetDateTime>,
@@ -7598,7 +7601,10 @@ pub mod definitions {
                 self
             }
             #[doc = "Indicates the order in which definitions should be returned."]
-            pub fn query_order(mut self, query_order: impl Into<String>) -> Self {
+            pub fn query_order(
+                mut self,
+                query_order: impl Into<models::DefinitionQueryOrder>,
+            ) -> Self {
                 self.query_order = Some(query_order.into());
                 self
             }
@@ -7706,7 +7712,7 @@ pub mod definitions {
                         if let Some(query_order) = &this.query_order {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryOrder", query_order);
+                                .append_pair("queryOrder", &query_order.to_string());
                         }
                         if let Some(top) = &this.top {
                             req.url_mut()
@@ -10141,11 +10147,11 @@ pub mod folders {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) path: String,
-            pub(crate) query_order: Option<String>,
+            pub(crate) query_order: Option<models::FolderQueryOrder>,
         }
         impl RequestBuilder {
             #[doc = "The order in which folders should be returned."]
-            pub fn query_order(mut self, query_order: impl Into<String>) -> Self {
+            pub fn query_order(mut self, query_order: impl Into<models::FolderQueryOrder>) -> Self {
                 self.query_order = Some(query_order.into());
                 self
             }
@@ -10174,7 +10180,7 @@ pub mod folders {
                         if let Some(query_order) = &this.query_order {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryOrder", query_order);
+                                .append_pair("queryOrder", &query_order.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -12251,7 +12257,7 @@ pub mod source_providers {
             pub(crate) provider_name: String,
             pub(crate) service_endpoint_id: Option<String>,
             pub(crate) repository: Option<String>,
-            pub(crate) result_set: Option<String>,
+            pub(crate) result_set: Option<models::ResultSet>,
             pub(crate) page_results: Option<bool>,
             pub(crate) continuation_token: Option<String>,
         }
@@ -12267,7 +12273,7 @@ pub mod source_providers {
                 self
             }
             #[doc = "'top' for the repositories most relevant for the endpoint. If not set, all repositories are returned. Ignored if 'repository' is set."]
-            pub fn result_set(mut self, result_set: impl Into<String>) -> Self {
+            pub fn result_set(mut self, result_set: impl Into<models::ResultSet>) -> Self {
                 self.result_set = Some(result_set.into());
                 self
             }
@@ -12316,7 +12322,7 @@ pub mod source_providers {
                         if let Some(result_set) = &this.result_set {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("resultSet", result_set);
+                                .append_pair("resultSet", &result_set.to_string());
                         }
                         if let Some(page_results) = &this.page_results {
                             req.url_mut()

--- a/azure_devops_rust_api/src/build/models.rs
+++ b/azure_devops_rust_api/src/build/models.rs
@@ -232,6 +232,27 @@ pub mod aggregated_results_by_outcome {
         #[serde(rename = "notImpacted")]
         NotImpacted,
     }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::None => write!(f, "none"),
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Inconclusive => write!(f, "inconclusive"),
+                Self::Timeout => write!(f, "timeout"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Blocked => write!(f, "blocked"),
+                Self::NotExecuted => write!(f, "notExecuted"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Paused => write!(f, "paused"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AggregatedResultsDifference {
@@ -302,6 +323,16 @@ pub mod aggregated_runs_by_outcome {
         #[serde(rename = "others")]
         Others,
     }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+                Self::Others => write!(f, "others"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AggregatedRunsByState {
@@ -339,6 +370,19 @@ pub mod aggregated_runs_by_state {
         Waiting,
         #[serde(rename = "needsInvestigation")]
         NeedsInvestigation,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Waiting => write!(f, "waiting"),
+                Self::NeedsInvestigation => write!(f, "needsInvestigation"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -756,6 +800,17 @@ pub mod build {
         #[serde(rename = "high")]
         High,
     }
+    impl std::fmt::Display for Priority {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Low => write!(f, "low"),
+                Self::BelowNormal => write!(f, "belowNormal"),
+                Self::Normal => write!(f, "normal"),
+                Self::AboveNormal => write!(f, "aboveNormal"),
+                Self::High => write!(f, "high"),
+            }
+        }
+    }
     #[doc = "Additional options for queueing the build."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum QueueOptions {
@@ -763,6 +818,14 @@ pub mod build {
         None,
         #[serde(rename = "doNotRun")]
         DoNotRun,
+    }
+    impl std::fmt::Display for QueueOptions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::DoNotRun => write!(f, "doNotRun"),
+            }
+        }
     }
     #[doc = "The reason that the build was created."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -796,6 +859,26 @@ pub mod build {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::IndividualCi => write!(f, "individualCI"),
+                Self::BatchedCi => write!(f, "batchedCI"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::ScheduleForced => write!(f, "scheduleForced"),
+                Self::UserCreated => write!(f, "userCreated"),
+                Self::ValidateShelveset => write!(f, "validateShelveset"),
+                Self::CheckInShelveset => write!(f, "checkInShelveset"),
+                Self::PullRequest => write!(f, "pullRequest"),
+                Self::BuildCompletion => write!(f, "buildCompletion"),
+                Self::ResourceTrigger => write!(f, "resourceTrigger"),
+                Self::Triggered => write!(f, "triggered"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[doc = "The build result."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Result {
@@ -809,6 +892,17 @@ pub mod build {
         Failed,
         #[serde(rename = "canceled")]
         Canceled,
+    }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+            }
+        }
     }
     #[doc = "The status of the build."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -827,6 +921,19 @@ pub mod build {
         NotStarted,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Cancelling => write!(f, "cancelling"),
+                Self::Postponed => write!(f, "postponed"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -903,6 +1010,15 @@ pub mod build_agent {
         Available,
         #[serde(rename = "offline")]
         Offline,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unavailable => write!(f, "unavailable"),
+                Self::Available => write!(f, "available"),
+                Self::Offline => write!(f, "offline"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1099,6 +1215,15 @@ pub mod build_controller {
         #[serde(rename = "offline")]
         Offline,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unavailable => write!(f, "unavailable"),
+                Self::Available => write!(f, "available"),
+                Self::Offline => write!(f, "offline"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BuildControllerList {
@@ -1261,6 +1386,14 @@ pub mod build_definition {
         #[serde(rename = "project")]
         Project,
     }
+    impl std::fmt::Display for JobAuthorizationScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ProjectCollection => write!(f, "projectCollection"),
+                Self::Project => write!(f, "project"),
+            }
+        }
+    }
 }
 #[doc = "For back-compat with extensions that use the old Steps format instead of Process and Phases"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1418,6 +1551,14 @@ pub mod build_definition3_2 {
         #[serde(rename = "project")]
         Project,
     }
+    impl std::fmt::Display for JobAuthorizationScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ProjectCollection => write!(f, "projectCollection"),
+                Self::Project => write!(f, "project"),
+            }
+        }
+    }
 }
 #[doc = "Represents a reference to a build definition."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1496,6 +1637,14 @@ pub mod build_definition_reference {
         #[serde(rename = "draft")]
         Draft,
     }
+    impl std::fmt::Display for Quality {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Definition => write!(f, "definition"),
+                Self::Draft => write!(f, "draft"),
+            }
+        }
+    }
 }
 #[doc = "For back-compat with extensions that use the old Steps format instead of Process and Phases"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1557,6 +1706,14 @@ pub mod build_definition_reference3_2 {
         Definition,
         #[serde(rename = "draft")]
         Draft,
+    }
+    impl std::fmt::Display for Quality {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Definition => write!(f, "definition"),
+                Self::Draft => write!(f, "draft"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1628,6 +1785,15 @@ pub mod build_definition_revision {
         Update,
         #[serde(rename = "delete")]
         Delete,
+    }
+    impl std::fmt::Display for ChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Update => write!(f, "update"),
+                Self::Delete => write!(f, "delete"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1708,6 +1874,21 @@ pub mod build_definition_source_provider {
         BuildCompletion,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for SupportedTriggerTypes {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::ContinuousIntegration => write!(f, "continuousIntegration"),
+                Self::BatchedContinuousIntegration => write!(f, "batchedContinuousIntegration"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::GatedCheckIn => write!(f, "gatedCheckIn"),
+                Self::BatchedGatedCheckIn => write!(f, "batchedGatedCheckIn"),
+                Self::PullRequest => write!(f, "pullRequest"),
+                Self::BuildCompletion => write!(f, "buildCompletion"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[doc = "Represents a step in a build phase."]
@@ -2219,6 +2400,19 @@ pub mod build_option_input_definition {
         #[serde(rename = "branchFilter")]
         BranchFilter,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::String => write!(f, "string"),
+                Self::Boolean => write!(f, "boolean"),
+                Self::StringList => write!(f, "stringList"),
+                Self::Radio => write!(f, "radio"),
+                Self::PickList => write!(f, "pickList"),
+                Self::MultiLine => write!(f, "multiLine"),
+                Self::BranchFilter => write!(f, "branchFilter"),
+            }
+        }
+    }
 }
 #[doc = "Represents a build process."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2347,6 +2541,26 @@ pub mod build_process_template {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for SupportedReasons {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::IndividualCi => write!(f, "individualCI"),
+                Self::BatchedCi => write!(f, "batchedCI"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::ScheduleForced => write!(f, "scheduleForced"),
+                Self::UserCreated => write!(f, "userCreated"),
+                Self::ValidateShelveset => write!(f, "validateShelveset"),
+                Self::CheckInShelveset => write!(f, "checkInShelveset"),
+                Self::PullRequest => write!(f, "pullRequest"),
+                Self::BuildCompletion => write!(f, "buildCompletion"),
+                Self::ResourceTrigger => write!(f, "resourceTrigger"),
+                Self::Triggered => write!(f, "triggered"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum TemplateType {
         #[serde(rename = "custom")]
@@ -2355,6 +2569,15 @@ pub mod build_process_template {
         Default,
         #[serde(rename = "upgrade")]
         Upgrade,
+    }
+    impl std::fmt::Display for TemplateType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Custom => write!(f, "custom"),
+                Self::Default => write!(f, "default"),
+                Self::Upgrade => write!(f, "upgrade"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2444,6 +2667,17 @@ pub mod build_reference {
         #[serde(rename = "canceled")]
         Canceled,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+            }
+        }
+    }
     #[doc = "The build status."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -2461,6 +2695,19 @@ pub mod build_reference {
         NotStarted,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Cancelling => write!(f, "cancelling"),
+                Self::Postponed => write!(f, "postponed"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[doc = "Represents information about a build report."]
@@ -2563,6 +2810,15 @@ pub mod build_request_validation_result {
         Warning,
         #[serde(rename = "error")]
         Error,
+    }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Ok => write!(f, "ok"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+            }
+        }
     }
 }
 #[doc = "Represents information about resources used by builds in the system."]
@@ -2703,6 +2959,14 @@ pub mod build_server {
         #[serde(rename = "offline")]
         Offline,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Online => write!(f, "online"),
+                Self::Offline => write!(f, "offline"),
+            }
+        }
+    }
 }
 #[doc = "Represents system-wide build settings."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2809,6 +3073,26 @@ pub mod build_summary {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::IndividualCi => write!(f, "individualCI"),
+                Self::BatchedCi => write!(f, "batchedCI"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::ScheduleForced => write!(f, "scheduleForced"),
+                Self::UserCreated => write!(f, "userCreated"),
+                Self::ValidateShelveset => write!(f, "validateShelveset"),
+                Self::CheckInShelveset => write!(f, "checkInShelveset"),
+                Self::PullRequest => write!(f, "pullRequest"),
+                Self::BuildCompletion => write!(f, "buildCompletion"),
+                Self::ResourceTrigger => write!(f, "resourceTrigger"),
+                Self::Triggered => write!(f, "triggered"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
         #[serde(rename = "none")]
@@ -2825,6 +3109,19 @@ pub mod build_summary {
         NotStarted,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Cancelling => write!(f, "cancelling"),
+                Self::Postponed => write!(f, "postponed"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2890,6 +3187,21 @@ pub mod build_trigger {
         BuildCompletion,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for TriggerType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::ContinuousIntegration => write!(f, "continuousIntegration"),
+                Self::BatchedContinuousIntegration => write!(f, "batchedContinuousIntegration"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::GatedCheckIn => write!(f, "gatedCheckIn"),
+                Self::BatchedGatedCheckIn => write!(f, "batchedGatedCheckIn"),
+                Self::PullRequest => write!(f, "pullRequest"),
+                Self::BuildCompletion => write!(f, "buildCompletion"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3321,6 +3633,15 @@ pub mod definition_reference {
         #[serde(rename = "disabled")]
         Disabled,
     }
+    impl std::fmt::Display for QueueStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Enabled => write!(f, "enabled"),
+                Self::Paused => write!(f, "paused"),
+                Self::Disabled => write!(f, "disabled"),
+            }
+        }
+    }
     #[doc = "The type of the definition."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Type {
@@ -3328,6 +3649,14 @@ pub mod definition_reference {
         Xaml,
         #[serde(rename = "build")]
         Build,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Xaml => write!(f, "xaml"),
+                Self::Build => write!(f, "build"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3771,6 +4100,14 @@ pub mod issue {
         #[serde(rename = "warning")]
         Warning,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Error => write!(f, "error"),
+                Self::Warning => write!(f, "warning"),
+            }
+        }
+    }
 }
 #[doc = "Job in pipeline. This is related to matrixing in YAML."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3833,6 +4170,18 @@ pub mod json_patch_operation {
         Copy,
         #[serde(rename = "test")]
         Test,
+    }
+    impl std::fmt::Display for Op {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Remove => write!(f, "remove"),
+                Self::Replace => write!(f, "replace"),
+                Self::Move => write!(f, "move"),
+                Self::Copy => write!(f, "copy"),
+                Self::Test => write!(f, "test"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4024,6 +4373,14 @@ pub mod phase {
         ProjectCollection,
         #[serde(rename = "project")]
         Project,
+    }
+    impl std::fmt::Display for JobAuthorizationScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ProjectCollection => write!(f, "projectCollection"),
+                Self::Project => write!(f, "project"),
+            }
+        }
     }
 }
 #[doc = "Phase in pipeline"]
@@ -4932,6 +5289,21 @@ pub mod schedule {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for DaysToBuild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Monday => write!(f, "monday"),
+                Self::Tuesday => write!(f, "tuesday"),
+                Self::Wednesday => write!(f, "wednesday"),
+                Self::Thursday => write!(f, "thursday"),
+                Self::Friday => write!(f, "friday"),
+                Self::Saturday => write!(f, "saturday"),
+                Self::Sunday => write!(f, "sunday"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
 }
 #[doc = "Represents a schedule trigger."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5280,6 +5652,21 @@ pub mod supported_trigger {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::ContinuousIntegration => write!(f, "continuousIntegration"),
+                Self::BatchedContinuousIntegration => write!(f, "batchedContinuousIntegration"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::GatedCheckIn => write!(f, "gatedCheckIn"),
+                Self::BatchedGatedCheckIn => write!(f, "batchedGatedCheckIn"),
+                Self::PullRequest => write!(f, "pullRequest"),
+                Self::BuildCompletion => write!(f, "buildCompletion"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
 }
 #[doc = "Represents a Subversion mapping entry."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5605,6 +5992,19 @@ pub mod team_project_reference {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deleting => write!(f, "deleting"),
+                Self::New => write!(f, "new"),
+                Self::WellFormed => write!(f, "wellFormed"),
+                Self::CreatePending => write!(f, "createPending"),
+                Self::All => write!(f, "all"),
+                Self::Unchanged => write!(f, "unchanged"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
     #[doc = "Project visibility."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Visibility {
@@ -5616,6 +6016,16 @@ pub mod team_project_reference {
         Organization,
         #[serde(rename = "unchanged")]
         Unchanged,
+    }
+    impl std::fmt::Display for Visibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+                Self::Organization => write!(f, "organization"),
+                Self::Unchanged => write!(f, "unchanged"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5655,6 +6065,15 @@ pub mod test_results_context {
         Release,
         #[serde(rename = "pipeline")]
         Pipeline,
+    }
+    impl std::fmt::Display for ContextType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Build => write!(f, "build"),
+                Self::Release => write!(f, "release"),
+                Self::Pipeline => write!(f, "pipeline"),
+            }
+        }
     }
 }
 #[doc = "Represents the timeline of a build."]
@@ -5864,6 +6283,18 @@ pub mod timeline_record {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::SucceededWithIssues => write!(f, "succeededWithIssues"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
     #[doc = "The state of the record."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum State {
@@ -5873,6 +6304,15 @@ pub mod timeline_record {
         InProgress,
         #[serde(rename = "completed")]
         Completed,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Pending => write!(f, "pending"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5977,6 +6417,14 @@ pub mod update_stage_parameters {
         Cancel,
         #[serde(rename = "retry")]
         Retry,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Cancel => write!(f, "cancel"),
+                Self::Retry => write!(f, "retry"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6190,6 +6638,14 @@ pub mod workspace_mapping {
         #[serde(rename = "cloak")]
         Cloak,
     }
+    impl std::fmt::Display for MappingType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Map => write!(f, "map"),
+                Self::Cloak => write!(f, "cloak"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct WorkspaceTemplate {
@@ -6364,6 +6820,26 @@ pub mod xaml_build_definition {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for SupportedReasons {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::IndividualCi => write!(f, "individualCI"),
+                Self::BatchedCi => write!(f, "batchedCI"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::ScheduleForced => write!(f, "scheduleForced"),
+                Self::UserCreated => write!(f, "userCreated"),
+                Self::ValidateShelveset => write!(f, "validateShelveset"),
+                Self::CheckInShelveset => write!(f, "checkInShelveset"),
+                Self::PullRequest => write!(f, "pullRequest"),
+                Self::BuildCompletion => write!(f, "buildCompletion"),
+                Self::ResourceTrigger => write!(f, "resourceTrigger"),
+                Self::Triggered => write!(f, "triggered"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[doc = "How builds are triggered from this definition"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum TriggerType {
@@ -6385,6 +6861,21 @@ pub mod xaml_build_definition {
         BuildCompletion,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for TriggerType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::ContinuousIntegration => write!(f, "continuousIntegration"),
+                Self::BatchedContinuousIntegration => write!(f, "batchedContinuousIntegration"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::GatedCheckIn => write!(f, "gatedCheckIn"),
+                Self::BatchedGatedCheckIn => write!(f, "batchedGatedCheckIn"),
+                Self::PullRequest => write!(f, "pullRequest"),
+                Self::BuildCompletion => write!(f, "buildCompletion"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/build/models.rs
+++ b/azure_devops_rust_api/src/build/models.rs
@@ -2580,6 +2580,34 @@ pub mod build_process_template {
         }
     }
 }
+#[doc = "The order in which builds should be returned."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum BuildQueryOrder {
+    #[serde(rename = "finishTimeAscending")]
+    FinishTimeAscending,
+    #[serde(rename = "finishTimeDescending")]
+    FinishTimeDescending,
+    #[serde(rename = "queueTimeDescending")]
+    QueueTimeDescending,
+    #[serde(rename = "queueTimeAscending")]
+    QueueTimeAscending,
+    #[serde(rename = "startTimeDescending")]
+    StartTimeDescending,
+    #[serde(rename = "startTimeAscending")]
+    StartTimeAscending,
+}
+impl std::fmt::Display for BuildQueryOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FinishTimeAscending => write!(f, "finishTimeAscending"),
+            Self::FinishTimeDescending => write!(f, "finishTimeDescending"),
+            Self::QueueTimeDescending => write!(f, "queueTimeDescending"),
+            Self::QueueTimeAscending => write!(f, "queueTimeAscending"),
+            Self::StartTimeDescending => write!(f, "startTimeDescending"),
+            Self::StartTimeAscending => write!(f, "startTimeAscending"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BuildQueuedEvent {
     #[serde(flatten)]
@@ -2588,6 +2616,58 @@ pub struct BuildQueuedEvent {
 impl BuildQueuedEvent {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "If specified, filters to builds that match this reason."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum BuildReason {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "manual")]
+    Manual,
+    #[serde(rename = "individualCI")]
+    IndividualCi,
+    #[serde(rename = "batchedCI")]
+    BatchedCi,
+    #[serde(rename = "schedule")]
+    Schedule,
+    #[serde(rename = "scheduleForced")]
+    ScheduleForced,
+    #[serde(rename = "userCreated")]
+    UserCreated,
+    #[serde(rename = "validateShelveset")]
+    ValidateShelveset,
+    #[serde(rename = "checkInShelveset")]
+    CheckInShelveset,
+    #[serde(rename = "pullRequest")]
+    PullRequest,
+    #[serde(rename = "buildCompletion")]
+    BuildCompletion,
+    #[serde(rename = "resourceTrigger")]
+    ResourceTrigger,
+    #[serde(rename = "triggered")]
+    Triggered,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for BuildReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Manual => write!(f, "manual"),
+            Self::IndividualCi => write!(f, "individualCI"),
+            Self::BatchedCi => write!(f, "batchedCI"),
+            Self::Schedule => write!(f, "schedule"),
+            Self::ScheduleForced => write!(f, "scheduleForced"),
+            Self::UserCreated => write!(f, "userCreated"),
+            Self::ValidateShelveset => write!(f, "validateShelveset"),
+            Self::CheckInShelveset => write!(f, "checkInShelveset"),
+            Self::PullRequest => write!(f, "pullRequest"),
+            Self::BuildCompletion => write!(f, "buildCompletion"),
+            Self::ResourceTrigger => write!(f, "resourceTrigger"),
+            Self::Triggered => write!(f, "triggered"),
+            Self::All => write!(f, "all"),
+        }
     }
 }
 #[doc = "Represents a reference to a build."]
@@ -2858,6 +2938,31 @@ impl BuildResourceUsage {
         Self::default()
     }
 }
+#[doc = "If specified, filters to builds that match this result."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum BuildResult {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "succeeded")]
+    Succeeded,
+    #[serde(rename = "partiallySucceeded")]
+    PartiallySucceeded,
+    #[serde(rename = "failed")]
+    Failed,
+    #[serde(rename = "canceled")]
+    Canceled,
+}
+impl std::fmt::Display for BuildResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Succeeded => write!(f, "succeeded"),
+            Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+            Self::Failed => write!(f, "failed"),
+            Self::Canceled => write!(f, "canceled"),
+        }
+    }
+}
 #[doc = "A historical overview of build retention information. This includes a list of snapshots taken about build retention usage, and a list of builds that have exceeded the default 30 day retention policy."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BuildRetentionHistory {
@@ -2996,6 +3101,37 @@ pub struct BuildSettings {
 impl BuildSettings {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "If specified, filters to builds that match this status."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum BuildStatus {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "inProgress")]
+    InProgress,
+    #[serde(rename = "completed")]
+    Completed,
+    #[serde(rename = "cancelling")]
+    Cancelling,
+    #[serde(rename = "postponed")]
+    Postponed,
+    #[serde(rename = "notStarted")]
+    NotStarted,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for BuildStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::InProgress => write!(f, "inProgress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Cancelling => write!(f, "cancelling"),
+            Self::Postponed => write!(f, "postponed"),
+            Self::NotStarted => write!(f, "notStarted"),
+            Self::All => write!(f, "all"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3564,6 +3700,31 @@ impl DataSourceBindingBase {
         Self::default()
     }
 }
+#[doc = "Indicates the order in which definitions should be returned."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DefinitionQueryOrder {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "lastModifiedAscending")]
+    LastModifiedAscending,
+    #[serde(rename = "lastModifiedDescending")]
+    LastModifiedDescending,
+    #[serde(rename = "definitionNameAscending")]
+    DefinitionNameAscending,
+    #[serde(rename = "definitionNameDescending")]
+    DefinitionNameDescending,
+}
+impl std::fmt::Display for DefinitionQueryOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::LastModifiedAscending => write!(f, "lastModifiedAscending"),
+            Self::LastModifiedDescending => write!(f, "lastModifiedDescending"),
+            Self::DefinitionNameAscending => write!(f, "definitionNameAscending"),
+            Self::DefinitionNameDescending => write!(f, "definitionNameDescending"),
+        }
+    }
+}
 #[doc = "Represents a reference to a definition."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DefinitionReference {
@@ -3891,6 +4052,25 @@ pub struct FolderList {
 impl FolderList {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "The order in which folders should be returned."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum FolderQueryOrder {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "folderAscending")]
+    FolderAscending,
+    #[serde(rename = "folderDescending")]
+    FolderDescending,
+}
+impl std::fmt::Display for FolderQueryOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::FolderAscending => write!(f, "folderAscending"),
+            Self::FolderDescending => write!(f, "folderDescending"),
+        }
     }
 }
 #[doc = "Represents the ability to build forks of the selected repository."]
@@ -4870,6 +5050,25 @@ impl PullRequestTrigger {
         Self::default()
     }
 }
+#[doc = "Indicates whether to exclude, include, or only return deleted builds."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum QueryDeletedOption {
+    #[serde(rename = "excludeDeleted")]
+    ExcludeDeleted,
+    #[serde(rename = "includeDeleted")]
+    IncludeDeleted,
+    #[serde(rename = "onlyDeleted")]
+    OnlyDeleted,
+}
+impl std::fmt::Display for QueryDeletedOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExcludeDeleted => write!(f, "excludeDeleted"),
+            Self::IncludeDeleted => write!(f, "includeDeleted"),
+            Self::OnlyDeleted => write!(f, "onlyDeleted"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct RealtimeBuildEvent {
     #[serde(rename = "buildId", default, skip_serializing_if = "Option::is_none")]
@@ -5052,6 +5251,22 @@ pub struct ResourceReference {
 impl ResourceReference {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "'top' for the repositories most relevant for the endpoint. If not set, all repositories are returned. Ignored if 'repository' is set."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ResultSet {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "top")]
+    Top,
+}
+impl std::fmt::Display for ResultSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::All => write!(f, "all"),
+            Self::Top => write!(f, "top"),
+        }
     }
 }
 #[doc = "A valid retention lease prevents automated systems from deleting a pipeline run."]

--- a/azure_devops_rust_api/src/core/mod.rs
+++ b/azure_devops_rust_api/src/core/mod.rs
@@ -540,7 +540,7 @@ pub mod projects {
         pub struct RequestBuilder {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
-            pub(crate) state_filter: Option<String>,
+            pub(crate) state_filter: Option<models::ProjectState>,
             pub(crate) top: Option<i32>,
             pub(crate) skip: Option<i32>,
             pub(crate) continuation_token: Option<i32>,
@@ -548,7 +548,7 @@ pub mod projects {
         }
         impl RequestBuilder {
             #[doc = "Filter on team projects in a specific team project state (default: WellFormed)."]
-            pub fn state_filter(mut self, state_filter: impl Into<String>) -> Self {
+            pub fn state_filter(mut self, state_filter: impl Into<models::ProjectState>) -> Self {
                 self.state_filter = Some(state_filter.into());
                 self
             }
@@ -594,7 +594,7 @@ pub mod projects {
                         if let Some(state_filter) = &this.state_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("stateFilter", state_filter);
+                                .append_pair("stateFilter", &state_filter.to_string());
                         }
                         if let Some(top) = &this.top {
                             req.url_mut()

--- a/azure_devops_rust_api/src/core/models.rs
+++ b/azure_devops_rust_api/src/core/models.rs
@@ -643,6 +643,37 @@ impl ProjectPropertyList {
         Self::default()
     }
 }
+#[doc = "Filter on team projects in a specific team project state (default: WellFormed)."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ProjectState {
+    #[serde(rename = "deleting")]
+    Deleting,
+    #[serde(rename = "new")]
+    New,
+    #[serde(rename = "wellFormed")]
+    WellFormed,
+    #[serde(rename = "createPending")]
+    CreatePending,
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "unchanged")]
+    Unchanged,
+    #[serde(rename = "deleted")]
+    Deleted,
+}
+impl std::fmt::Display for ProjectState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Deleting => write!(f, "deleting"),
+            Self::New => write!(f, "new"),
+            Self::WellFormed => write!(f, "wellFormed"),
+            Self::CreatePending => write!(f, "createPending"),
+            Self::All => write!(f, "all"),
+            Self::Unchanged => write!(f, "unchanged"),
+            Self::Deleted => write!(f, "deleted"),
+        }
+    }
+}
 #[doc = "The class represents a property bag as a collection of key-value pairs. Values of all primitive types (any type with a `TypeCode != TypeCode.Object`) except for `DBNull` are accepted. Values of type Byte[], Int32, Double, DateType and String preserve their type, other primitives are retuned as a String. Byte[] expected as base64 encoded string."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct PropertiesCollection {

--- a/azure_devops_rust_api/src/core/models.rs
+++ b/azure_devops_rust_api/src/core/models.rs
@@ -298,6 +298,18 @@ pub mod json_patch_operation {
         #[serde(rename = "test")]
         Test,
     }
+    impl std::fmt::Display for Op {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Remove => write!(f, "remove"),
+                Self::Replace => write!(f, "replace"),
+                Self::Move => write!(f, "move"),
+                Self::Copy => write!(f, "copy"),
+                Self::Test => write!(f, "test"),
+            }
+        }
+    }
 }
 #[doc = "Reference for an async operation."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -338,6 +350,18 @@ pub mod operation_reference {
         #[serde(rename = "failed")]
         Failed,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NotSet => write!(f, "notSet"),
+                Self::Queued => write!(f, "queued"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Cancelled => write!(f, "cancelled"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct Process {
@@ -370,6 +394,15 @@ pub mod process {
         Custom,
         #[serde(rename = "inherited")]
         Inherited,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::System => write!(f, "system"),
+                Self::Custom => write!(f, "custom"),
+                Self::Inherited => write!(f, "inherited"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -487,6 +520,19 @@ pub mod project_info {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deleting => write!(f, "deleting"),
+                Self::New => write!(f, "new"),
+                Self::WellFormed => write!(f, "wellFormed"),
+                Self::CreatePending => write!(f, "createPending"),
+                Self::All => write!(f, "all"),
+                Self::Unchanged => write!(f, "unchanged"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
     #[doc = "Indicates whom the project is visible to."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Visibility {
@@ -494,6 +540,14 @@ pub mod project_info {
         Private,
         #[serde(rename = "public")]
         Public,
+    }
+    impl std::fmt::Display for Visibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -529,6 +583,15 @@ pub mod project_message {
         Deleted,
         #[serde(rename = "added")]
         Added,
+    }
+    impl std::fmt::Display for ProjectChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Modified => write!(f, "modified"),
+                Self::Deleted => write!(f, "deleted"),
+                Self::Added => write!(f, "added"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -825,6 +888,15 @@ pub mod team_project_collection {
         #[serde(rename = "inherited")]
         Inherited,
     }
+    impl std::fmt::Display for ProcessCustomizationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Xml => write!(f, "xml"),
+                Self::Inherited => write!(f, "inherited"),
+            }
+        }
+    }
 }
 #[doc = "Reference object for a TeamProjectCollection."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -924,6 +996,19 @@ pub mod team_project_reference {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deleting => write!(f, "deleting"),
+                Self::New => write!(f, "new"),
+                Self::WellFormed => write!(f, "wellFormed"),
+                Self::CreatePending => write!(f, "createPending"),
+                Self::All => write!(f, "all"),
+                Self::Unchanged => write!(f, "unchanged"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
     #[doc = "Project visibility."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Visibility {
@@ -935,6 +1020,16 @@ pub mod team_project_reference {
         Organization,
         #[serde(rename = "unchanged")]
         Unchanged,
+    }
+    impl std::fmt::Display for Visibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+                Self::Organization => write!(f, "organization"),
+                Self::Unchanged => write!(f, "unchanged"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/dashboard/mod.rs
+++ b/azure_devops_rust_api/src/dashboard/mod.rs
@@ -156,7 +156,7 @@ pub mod widget_types {
         pub fn get_widget_types(
             &self,
             organization: impl Into<String>,
-            scope: impl Into<String>,
+            scope: impl Into<models::WidgetScope>,
             project: impl Into<String>,
         ) -> get_widget_types::RequestBuilder {
             get_widget_types::RequestBuilder {
@@ -223,7 +223,7 @@ pub mod widget_types {
         pub struct RequestBuilder {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
-            pub(crate) scope: String,
+            pub(crate) scope: models::WidgetScope,
             pub(crate) project: String,
         }
         impl RequestBuilder {
@@ -250,7 +250,9 @@ pub mod widget_types {
                             );
                         }
                         let scope = &this.scope;
-                        req.url_mut().query_pairs_mut().append_pair("$scope", scope);
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair("$scope", &scope.to_string());
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))

--- a/azure_devops_rust_api/src/dashboard/models.rs
+++ b/azure_devops_rust_api/src/dashboard/models.rs
@@ -744,6 +744,21 @@ impl WidgetResponse {
         Self::default()
     }
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum WidgetScope {
+    #[serde(rename = "collection_User")]
+    CollectionUser,
+    #[serde(rename = "project_Team")]
+    ProjectTeam,
+}
+impl std::fmt::Display for WidgetScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CollectionUser => write!(f, "collection_User"),
+            Self::ProjectTeam => write!(f, "project_Team"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct WidgetSize {
     #[doc = "The Width of the widget, expressed in dashboard grid columns."]

--- a/azure_devops_rust_api/src/dashboard/models.rs
+++ b/azure_devops_rust_api/src/dashboard/models.rs
@@ -66,6 +66,15 @@ pub mod copy_dashboard_options {
         #[serde(rename = "project")]
         Project,
     }
+    impl std::fmt::Display for CopyDashboardScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::CollectionUser => write!(f, "collection_User"),
+                Self::ProjectTeam => write!(f, "project_Team"),
+                Self::Project => write!(f, "project"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct CopyDashboardResponse {
@@ -180,6 +189,15 @@ pub mod dashboard {
         #[serde(rename = "project")]
         Project,
     }
+    impl std::fmt::Display for DashboardScope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::CollectionUser => write!(f, "collection_User"),
+                Self::ProjectTeam => write!(f, "project_Team"),
+                Self::Project => write!(f, "project"),
+            }
+        }
+    }
 }
 #[doc = "Describes a list of dashboards associated to an owner. Currently, teams own dashboard groups."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -227,6 +245,16 @@ pub mod dashboard_group {
         #[serde(rename = "managePermissions")]
         ManagePermissions,
     }
+    impl std::fmt::Display for Permission {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Edit => write!(f, "edit"),
+                Self::Manage => write!(f, "manage"),
+                Self::ManagePermissions => write!(f, "managePermissions"),
+            }
+        }
+    }
     #[doc = "A permissions bit mask describing the security permissions of the current team for dashboards. When this permission is the value None, use GroupMemberPermission. Permissions are evaluated based on the presence of a value other than None, else the GroupMemberPermission will be saved."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum TeamDashboardPermission {
@@ -242,6 +270,18 @@ pub mod dashboard_group {
         Delete,
         #[serde(rename = "managePermissions")]
         ManagePermissions,
+    }
+    impl std::fmt::Display for TeamDashboardPermission {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Read => write!(f, "read"),
+                Self::Create => write!(f, "create"),
+                Self::Edit => write!(f, "edit"),
+                Self::Delete => write!(f, "delete"),
+                Self::ManagePermissions => write!(f, "managePermissions"),
+            }
+        }
     }
 }
 #[doc = "Dashboard group entry, wrapping around Dashboard (needed?)"]

--- a/azure_devops_rust_api/src/distributed_task/mod.rs
+++ b/azure_devops_rust_api/src/distributed_task/mod.rs
@@ -1038,8 +1038,8 @@ pub mod pools {
             pub(crate) organization: String,
             pub(crate) pool_name: Option<String>,
             pub(crate) properties: Option<String>,
-            pub(crate) pool_type: Option<String>,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) pool_type: Option<models::TaskAgentPoolType>,
+            pub(crate) action_filter: Option<models::TaskAgentPoolActionFilter>,
         }
         impl RequestBuilder {
             #[doc = "Filter by name"]
@@ -1053,12 +1053,15 @@ pub mod pools {
                 self
             }
             #[doc = "Filter by pool type"]
-            pub fn pool_type(mut self, pool_type: impl Into<String>) -> Self {
+            pub fn pool_type(mut self, pool_type: impl Into<models::TaskAgentPoolType>) -> Self {
                 self.pool_type = Some(pool_type.into());
                 self
             }
             #[doc = "Filter by whether the calling user has use or manage permissions"]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::TaskAgentPoolActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -1097,12 +1100,12 @@ pub mod pools {
                         if let Some(pool_type) = &this.pool_type {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("poolType", pool_type);
+                                .append_pair("poolType", &pool_type.to_string());
                         }
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1175,11 +1178,14 @@ pub mod pools {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) pool_ids: String,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) action_filter: Option<models::TaskAgentPoolActionFilter>,
         }
         impl RequestBuilder {
             #[doc = "Filter by whether the calling user has use or manage permissions"]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::TaskAgentPoolActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -1212,7 +1218,7 @@ pub mod pools {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1382,7 +1388,7 @@ pub mod pools {
             pub(crate) organization: String,
             pub(crate) pool_id: i32,
             pub(crate) properties: Option<String>,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) action_filter: Option<models::TaskAgentPoolActionFilter>,
         }
         impl RequestBuilder {
             #[doc = "Agent pool properties (comma-separated)"]
@@ -1391,7 +1397,10 @@ pub mod pools {
                 self
             }
             #[doc = "Filter by whether the calling user has use or manage permissions"]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::TaskAgentPoolActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -1425,7 +1434,7 @@ pub mod pools {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1839,11 +1848,14 @@ pub mod queues {
             pub(crate) organization: String,
             pub(crate) queue_names: String,
             pub(crate) project: String,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) action_filter: Option<models::TaskAgentQueueActionFilter>,
         }
         impl RequestBuilder {
             #[doc = "Filter by whether the calling user has use or manage permissions"]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::TaskAgentQueueActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -1876,7 +1888,7 @@ pub mod queues {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1952,11 +1964,14 @@ pub mod queues {
             pub(crate) organization: String,
             pub(crate) queue_ids: String,
             pub(crate) project: String,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) action_filter: Option<models::TaskAgentQueueActionFilter>,
         }
         impl RequestBuilder {
             #[doc = "Filter by whether the calling user has use or manage permissions"]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::TaskAgentQueueActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -1989,7 +2004,7 @@ pub mod queues {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -2065,7 +2080,7 @@ pub mod queues {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) queue_name: Option<String>,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) action_filter: Option<models::TaskAgentQueueActionFilter>,
         }
         impl RequestBuilder {
             #[doc = "Filter on the agent queue name"]
@@ -2074,7 +2089,10 @@ pub mod queues {
                 self
             }
             #[doc = "Filter by whether the calling user has use or manage permissions"]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::TaskAgentQueueActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -2108,7 +2126,7 @@ pub mod queues {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -2183,11 +2201,14 @@ pub mod queues {
             pub(crate) organization: String,
             pub(crate) pool_ids: String,
             pub(crate) project: String,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) action_filter: Option<models::TaskAgentQueueActionFilter>,
         }
         impl RequestBuilder {
             #[doc = "Filter by whether the calling user has use or manage permissions"]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::TaskAgentQueueActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -2220,7 +2241,7 @@ pub mod queues {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -2405,11 +2426,14 @@ pub mod queues {
             pub(crate) organization: String,
             pub(crate) queue_id: i32,
             pub(crate) project: String,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) action_filter: Option<models::TaskAgentQueueActionFilter>,
         }
         impl RequestBuilder {
             #[doc = "Filter by whether the calling user has use or manage permissions"]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::TaskAgentQueueActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -2438,7 +2462,7 @@ pub mod queues {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -2747,10 +2771,10 @@ pub mod variablegroups {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) group_name: Option<String>,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) action_filter: Option<models::VariableGroupActionFilter>,
             pub(crate) top: Option<i32>,
             pub(crate) continuation_token: Option<i32>,
-            pub(crate) query_order: Option<String>,
+            pub(crate) query_order: Option<models::VariableGroupQueryOrder>,
         }
         impl RequestBuilder {
             #[doc = "Name of variable group."]
@@ -2759,7 +2783,10 @@ pub mod variablegroups {
                 self
             }
             #[doc = "Action filter for the variable group. It specifies the action which can be performed on the variable groups."]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::VariableGroupActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -2774,7 +2801,10 @@ pub mod variablegroups {
                 self
             }
             #[doc = "Gets the results in the defined order. Default is 'IdDescending'."]
-            pub fn query_order(mut self, query_order: impl Into<String>) -> Self {
+            pub fn query_order(
+                mut self,
+                query_order: impl Into<models::VariableGroupQueryOrder>,
+            ) -> Self {
                 self.query_order = Some(query_order.into());
                 self
             }
@@ -2808,7 +2838,7 @@ pub mod variablegroups {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         if let Some(top) = &this.top {
                             req.url_mut()
@@ -2823,7 +2853,7 @@ pub mod variablegroups {
                         if let Some(query_order) = &this.query_order {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryOrder", query_order);
+                                .append_pair("queryOrder", &query_order.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -5368,8 +5398,8 @@ pub mod deploymentgroups {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) name: Option<String>,
-            pub(crate) action_filter: Option<String>,
-            pub(crate) expand: Option<String>,
+            pub(crate) action_filter: Option<models::DeploymentGroupActionFilter>,
+            pub(crate) expand: Option<models::DeploymentGroupExpands>,
             pub(crate) continuation_token: Option<String>,
             pub(crate) top: Option<i32>,
             pub(crate) ids: Option<String>,
@@ -5381,12 +5411,15 @@ pub mod deploymentgroups {
                 self
             }
             #[doc = "Get only deployment groups on which this action can be performed."]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::DeploymentGroupActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
             #[doc = "Include these additional details in the returned objects."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::DeploymentGroupExpands>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -5433,12 +5466,12 @@ pub mod deploymentgroups {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(continuation_token) = &this.continuation_token {
                             req.url_mut()
@@ -5624,17 +5657,20 @@ pub mod deploymentgroups {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) deployment_group_id: i32,
-            pub(crate) action_filter: Option<String>,
-            pub(crate) expand: Option<String>,
+            pub(crate) action_filter: Option<models::DeploymentGroupActionFilter>,
+            pub(crate) expand: Option<models::DeploymentGroupExpands>,
         }
         impl RequestBuilder {
             #[doc = "Get the deployment group only if this action can be performed on it."]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::DeploymentGroupActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
             #[doc = "Include these additional details in the returned object."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::DeploymentGroupExpands>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -5663,12 +5699,12 @@ pub mod deploymentgroups {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -6049,9 +6085,9 @@ pub mod targets {
             pub(crate) tags: Option<String>,
             pub(crate) name: Option<String>,
             pub(crate) partial_name_match: Option<bool>,
-            pub(crate) expand: Option<String>,
-            pub(crate) agent_status: Option<String>,
-            pub(crate) agent_job_result: Option<String>,
+            pub(crate) expand: Option<models::DeploymentTargetExpands>,
+            pub(crate) agent_status: Option<models::TaskAgentStatusFilter>,
+            pub(crate) agent_job_result: Option<models::TaskAgentJobResultFilter>,
             pub(crate) continuation_token: Option<String>,
             pub(crate) top: Option<i32>,
             pub(crate) enabled: Option<bool>,
@@ -6074,17 +6110,23 @@ pub mod targets {
                 self
             }
             #[doc = "Include these additional details in the returned objects."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::DeploymentTargetExpands>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
             #[doc = "Get only deployment targets that have this status."]
-            pub fn agent_status(mut self, agent_status: impl Into<String>) -> Self {
+            pub fn agent_status(
+                mut self,
+                agent_status: impl Into<models::TaskAgentStatusFilter>,
+            ) -> Self {
                 self.agent_status = Some(agent_status.into());
                 self
             }
             #[doc = "Get only deployment targets that have this last job result."]
-            pub fn agent_job_result(mut self, agent_job_result: impl Into<String>) -> Self {
+            pub fn agent_job_result(
+                mut self,
+                agent_job_result: impl Into<models::TaskAgentJobResultFilter>,
+            ) -> Self {
                 self.agent_job_result = Some(agent_job_result.into());
                 self
             }
@@ -6143,17 +6185,17 @@ pub mod targets {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(agent_status) = &this.agent_status {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("agentStatus", agent_status);
+                                .append_pair("agentStatus", &agent_status.to_string());
                         }
                         if let Some(agent_job_result) = &this.agent_job_result {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("agentJobResult", agent_job_result);
+                                .append_pair("agentJobResult", &agent_job_result.to_string());
                         }
                         if let Some(continuation_token) = &this.continuation_token {
                             req.url_mut()
@@ -6350,11 +6392,11 @@ pub mod targets {
             pub(crate) project: String,
             pub(crate) deployment_group_id: i32,
             pub(crate) target_id: i32,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::DeploymentTargetExpands>,
         }
         impl RequestBuilder {
             #[doc = "Include these additional details in the returned objects."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::DeploymentTargetExpands>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -6383,7 +6425,7 @@ pub mod targets {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -6893,11 +6935,11 @@ pub mod environments {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) environment_id: i32,
-            pub(crate) expands: Option<String>,
+            pub(crate) expands: Option<models::EnvironmentExpands>,
         }
         impl RequestBuilder {
             #[doc = "Include these additional details in the returned objects."]
-            pub fn expands(mut self, expands: impl Into<String>) -> Self {
+            pub fn expands(mut self, expands: impl Into<models::EnvironmentExpands>) -> Self {
                 self.expands = Some(expands.into());
                 self
             }
@@ -6926,7 +6968,7 @@ pub mod environments {
                         if let Some(expands) = &this.expands {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("expands", expands);
+                                .append_pair("expands", &expands.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -7915,7 +7957,7 @@ pub mod taskgroups {
             pub(crate) deleted: Option<bool>,
             pub(crate) top: Option<i32>,
             pub(crate) continuation_token: Option<time::OffsetDateTime>,
-            pub(crate) query_order: Option<String>,
+            pub(crate) query_order: Option<models::TaskGroupQueryOrder>,
         }
         impl RequestBuilder {
             #[doc = "'true' to recursively expand task groups. Default is 'false'."]
@@ -7947,7 +7989,10 @@ pub mod taskgroups {
                 self
             }
             #[doc = "Gets the results in the defined order. Default is 'CreatedOnDescending'."]
-            pub fn query_order(mut self, query_order: impl Into<String>) -> Self {
+            pub fn query_order(
+                mut self,
+                query_order: impl Into<models::TaskGroupQueryOrder>,
+            ) -> Self {
                 self.query_order = Some(query_order.into());
                 self
             }
@@ -8003,7 +8048,7 @@ pub mod taskgroups {
                         if let Some(query_order) = &this.query_order {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryOrder", query_order);
+                                .append_pair("queryOrder", &query_order.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -8962,11 +9007,11 @@ pub mod nodes {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) pool_id: i32,
-            pub(crate) state: Option<String>,
+            pub(crate) state: Option<models::ElasticNodeState>,
         }
         impl RequestBuilder {
             #[doc = "Optional: Filter to only retrieve ElasticNodes in the given ElasticNodeState"]
-            pub fn state(mut self, state: impl Into<String>) -> Self {
+            pub fn state(mut self, state: impl Into<models::ElasticNodeState>) -> Self {
                 self.state = Some(state.into());
                 self
             }
@@ -8993,7 +9038,9 @@ pub mod nodes {
                             );
                         }
                         if let Some(state) = &this.state {
-                            req.url_mut().query_pairs_mut().append_pair("$state", state);
+                            req.url_mut()
+                                .query_pairs_mut()
+                                .append_pair("$state", &state.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/distributed_task/models.rs
+++ b/azure_devops_rust_api/src/distributed_task/models.rs
@@ -678,6 +678,14 @@ pub mod demand_source {
         #[serde(rename = "feature")]
         Feature,
     }
+    impl std::fmt::Display for SourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Task => write!(f, "task"),
+                Self::Feature => write!(f, "feature"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DependencyBinding {
@@ -1181,6 +1189,16 @@ pub mod elastic_node {
         #[serde(rename = "assigned")]
         Assigned,
     }
+    impl std::fmt::Display for AgentState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Enabled => write!(f, "enabled"),
+                Self::Online => write!(f, "online"),
+                Self::Assigned => write!(f, "assigned"),
+            }
+        }
+    }
     #[doc = "State of the compute host"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum ComputeState {
@@ -1202,6 +1220,21 @@ pub mod elastic_node {
         UnhealthyVm,
         #[serde(rename = "unhealthyVmssVm")]
         UnhealthyVmssVm,
+    }
+    impl std::fmt::Display for ComputeState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Healthy => write!(f, "healthy"),
+                Self::Creating => write!(f, "creating"),
+                Self::Deleting => write!(f, "deleting"),
+                Self::Failed => write!(f, "failed"),
+                Self::Stopped => write!(f, "stopped"),
+                Self::Reimaging => write!(f, "reimaging"),
+                Self::UnhealthyVm => write!(f, "unhealthyVm"),
+                Self::UnhealthyVmssVm => write!(f, "unhealthyVmssVm"),
+            }
+        }
     }
     #[doc = "Users can force state changes to specific states (ToReimage, ToDelete, Save)"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1251,6 +1284,34 @@ pub mod elastic_node {
         #[serde(rename = "unhealthyVmPendingDelete")]
         UnhealthyVmPendingDelete,
     }
+    impl std::fmt::Display for DesiredState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::New => write!(f, "new"),
+                Self::CreatingCompute => write!(f, "creatingCompute"),
+                Self::StartingAgent => write!(f, "startingAgent"),
+                Self::Idle => write!(f, "idle"),
+                Self::Assigned => write!(f, "assigned"),
+                Self::Offline => write!(f, "offline"),
+                Self::PendingReimage => write!(f, "pendingReimage"),
+                Self::PendingDelete => write!(f, "pendingDelete"),
+                Self::Saved => write!(f, "saved"),
+                Self::DeletingCompute => write!(f, "deletingCompute"),
+                Self::Deleted => write!(f, "deleted"),
+                Self::Lost => write!(f, "lost"),
+                Self::ReimagingCompute => write!(f, "reimagingCompute"),
+                Self::RestartingAgent => write!(f, "restartingAgent"),
+                Self::FailedToStartPendingDelete => write!(f, "failedToStartPendingDelete"),
+                Self::FailedToRestartPendingDelete => write!(f, "failedToRestartPendingDelete"),
+                Self::FailedVmPendingDelete => write!(f, "failedVMPendingDelete"),
+                Self::AssignedPendingDelete => write!(f, "assignedPendingDelete"),
+                Self::RetryDelete => write!(f, "retryDelete"),
+                Self::UnhealthyVm => write!(f, "unhealthyVm"),
+                Self::UnhealthyVmPendingDelete => write!(f, "unhealthyVmPendingDelete"),
+            }
+        }
+    }
     #[doc = "State of the ElasticNode"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum State {
@@ -1298,6 +1359,34 @@ pub mod elastic_node {
         UnhealthyVm,
         #[serde(rename = "unhealthyVmPendingDelete")]
         UnhealthyVmPendingDelete,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::New => write!(f, "new"),
+                Self::CreatingCompute => write!(f, "creatingCompute"),
+                Self::StartingAgent => write!(f, "startingAgent"),
+                Self::Idle => write!(f, "idle"),
+                Self::Assigned => write!(f, "assigned"),
+                Self::Offline => write!(f, "offline"),
+                Self::PendingReimage => write!(f, "pendingReimage"),
+                Self::PendingDelete => write!(f, "pendingDelete"),
+                Self::Saved => write!(f, "saved"),
+                Self::DeletingCompute => write!(f, "deletingCompute"),
+                Self::Deleted => write!(f, "deleted"),
+                Self::Lost => write!(f, "lost"),
+                Self::ReimagingCompute => write!(f, "reimagingCompute"),
+                Self::RestartingAgent => write!(f, "restartingAgent"),
+                Self::FailedToStartPendingDelete => write!(f, "failedToStartPendingDelete"),
+                Self::FailedToRestartPendingDelete => write!(f, "failedToRestartPendingDelete"),
+                Self::FailedVmPendingDelete => write!(f, "failedVMPendingDelete"),
+                Self::AssignedPendingDelete => write!(f, "assignedPendingDelete"),
+                Self::RetryDelete => write!(f, "retryDelete"),
+                Self::UnhealthyVm => write!(f, "unhealthyVm"),
+                Self::UnhealthyVmPendingDelete => write!(f, "unhealthyVmPendingDelete"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1377,6 +1466,34 @@ pub mod elastic_node_settings {
         UnhealthyVm,
         #[serde(rename = "unhealthyVmPendingDelete")]
         UnhealthyVmPendingDelete,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::New => write!(f, "new"),
+                Self::CreatingCompute => write!(f, "creatingCompute"),
+                Self::StartingAgent => write!(f, "startingAgent"),
+                Self::Idle => write!(f, "idle"),
+                Self::Assigned => write!(f, "assigned"),
+                Self::Offline => write!(f, "offline"),
+                Self::PendingReimage => write!(f, "pendingReimage"),
+                Self::PendingDelete => write!(f, "pendingDelete"),
+                Self::Saved => write!(f, "saved"),
+                Self::DeletingCompute => write!(f, "deletingCompute"),
+                Self::Deleted => write!(f, "deleted"),
+                Self::Lost => write!(f, "lost"),
+                Self::ReimagingCompute => write!(f, "reimagingCompute"),
+                Self::RestartingAgent => write!(f, "restartingAgent"),
+                Self::FailedToStartPendingDelete => write!(f, "failedToStartPendingDelete"),
+                Self::FailedToRestartPendingDelete => write!(f, "failedToRestartPendingDelete"),
+                Self::FailedVmPendingDelete => write!(f, "failedVMPendingDelete"),
+                Self::AssignedPendingDelete => write!(f, "assignedPendingDelete"),
+                Self::RetryDelete => write!(f, "retryDelete"),
+                Self::UnhealthyVm => write!(f, "unhealthyVm"),
+                Self::UnhealthyVmPendingDelete => write!(f, "unhealthyVmPendingDelete"),
+            }
+        }
     }
 }
 #[doc = "Data and settings for an elastic pool"]
@@ -1495,6 +1612,14 @@ pub mod elastic_pool {
         #[serde(rename = "flexible")]
         Flexible,
     }
+    impl std::fmt::Display for OrchestrationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Uniform => write!(f, "uniform"),
+                Self::Flexible => write!(f, "flexible"),
+            }
+        }
+    }
     #[doc = "Operating system type of the nodes in the pool"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum OsType {
@@ -1502,6 +1627,14 @@ pub mod elastic_pool {
         Windows,
         #[serde(rename = "linux")]
         Linux,
+    }
+    impl std::fmt::Display for OsType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Windows => write!(f, "windows"),
+                Self::Linux => write!(f, "linux"),
+            }
+        }
     }
     #[doc = "State of the pool"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1514,6 +1647,16 @@ pub mod elastic_pool {
         Unhealthy,
         #[serde(rename = "new")]
         New,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Online => write!(f, "online"),
+                Self::Offline => write!(f, "offline"),
+                Self::Unhealthy => write!(f, "unhealthy"),
+                Self::New => write!(f, "new"),
+            }
+        }
     }
 }
 #[doc = "Returned result from creating a new elastic pool"]
@@ -1601,6 +1744,15 @@ pub mod elastic_pool_log {
         #[serde(rename = "info")]
         Info,
     }
+    impl std::fmt::Display for Level {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Error => write!(f, "error"),
+                Self::Warning => write!(f, "warning"),
+                Self::Info => write!(f, "info"),
+            }
+        }
+    }
     #[doc = "Operation that triggered the message being logged"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Operation {
@@ -1614,6 +1766,17 @@ pub mod elastic_pool_log {
         Reimage,
         #[serde(rename = "deleteVMs")]
         DeleteVMs,
+    }
+    impl std::fmt::Display for Operation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ConfigurationJob => write!(f, "configurationJob"),
+                Self::SizingJob => write!(f, "sizingJob"),
+                Self::IncreaseCapacity => write!(f, "increaseCapacity"),
+                Self::Reimage => write!(f, "reimage"),
+                Self::DeleteVMs => write!(f, "deleteVMs"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1720,6 +1883,14 @@ pub mod elastic_pool_settings {
         #[serde(rename = "flexible")]
         Flexible,
     }
+    impl std::fmt::Display for OrchestrationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Uniform => write!(f, "uniform"),
+                Self::Flexible => write!(f, "flexible"),
+            }
+        }
+    }
     #[doc = "Operating system type of the machines in the pool"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum OsType {
@@ -1727,6 +1898,14 @@ pub mod elastic_pool_settings {
         Windows,
         #[serde(rename = "linux")]
         Linux,
+    }
+    impl std::fmt::Display for OsType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Windows => write!(f, "windows"),
+                Self::Linux => write!(f, "linux"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1903,6 +2082,18 @@ pub mod environment_deployment_execution_record {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::SucceededWithIssues => write!(f, "succeededWithIssues"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct EnvironmentDeploymentExecutionRecordList {
@@ -2077,6 +2268,16 @@ pub mod environment_resource {
         #[serde(rename = "kubernetes")]
         Kubernetes,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Generic => write!(f, "generic"),
+                Self::VirtualMachine => write!(f, "virtualMachine"),
+                Self::Kubernetes => write!(f, "kubernetes"),
+            }
+        }
+    }
 }
 #[doc = "EnvironmentResourceDeploymentExecutionRecord."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2141,6 +2342,18 @@ pub mod environment_resource_deployment_execution_record {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::SucceededWithIssues => write!(f, "succeededWithIssues"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
 }
 #[doc = "EnvironmentResourceReference."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2180,6 +2393,16 @@ pub mod environment_resource_reference {
         VirtualMachine,
         #[serde(rename = "kubernetes")]
         Kubernetes,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Generic => write!(f, "generic"),
+                Self::VirtualMachine => write!(f, "virtualMachine"),
+                Self::Kubernetes => write!(f, "kubernetes"),
+            }
+        }
     }
 }
 #[doc = "Properties to update Environment."]
@@ -2408,6 +2631,19 @@ pub mod input_descriptor {
         #[serde(rename = "textArea")]
         TextArea,
     }
+    impl std::fmt::Display for InputMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::TextBox => write!(f, "textBox"),
+                Self::PasswordBox => write!(f, "passwordBox"),
+                Self::Combo => write!(f, "combo"),
+                Self::RadioButtons => write!(f, "radioButtons"),
+                Self::CheckBox => write!(f, "checkBox"),
+                Self::TextArea => write!(f, "textArea"),
+            }
+        }
+    }
 }
 #[doc = "Describes what values are valid for a subscription input"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2467,6 +2703,18 @@ pub mod input_validation {
         Guid,
         #[serde(rename = "uri")]
         Uri,
+    }
+    impl std::fmt::Display for DataType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::String => write!(f, "string"),
+                Self::Number => write!(f, "number"),
+                Self::Boolean => write!(f, "boolean"),
+                Self::Guid => write!(f, "guid"),
+                Self::Uri => write!(f, "uri"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2607,6 +2855,14 @@ pub mod issue {
         #[serde(rename = "warning")]
         Warning,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Error => write!(f, "error"),
+                Self::Warning => write!(f, "warning"),
+            }
+        }
+    }
 }
 #[doc = "Represents a JSON object."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2742,6 +2998,18 @@ pub mod job_completed_event {
         Skipped,
         #[serde(rename = "abandoned")]
         Abandoned,
+    }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::SucceededWithIssues => write!(f, "succeededWithIssues"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
     }
 }
 #[doc = "Represents the context of variables and vectors for a job request."]
@@ -3077,6 +3345,14 @@ pub mod mask_hint {
         Variable,
         #[serde(rename = "regex")]
         Regex,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Variable => write!(f, "variable"),
+                Self::Regex => write!(f, "regex"),
+            }
+        }
     }
 }
 #[doc = "Meta data for a metrics column."]
@@ -3528,6 +3804,14 @@ pub mod resource_lock_request {
         #[serde(rename = "sequential")]
         Sequential,
     }
+    impl std::fmt::Display for LockType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::RunLatest => write!(f, "runLatest"),
+                Self::Sequential => write!(f, "sequential"),
+            }
+        }
+    }
     #[doc = "The result of this request."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -3545,6 +3829,19 @@ pub mod resource_lock_request {
         Abandoned,
         #[serde(rename = "waitingOnChecks")]
         WaitingOnChecks,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Queued => write!(f, "queued"),
+                Self::InUse => write!(f, "inUse"),
+                Self::Finished => write!(f, "finished"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Abandoned => write!(f, "abandoned"),
+                Self::WaitingOnChecks => write!(f, "waitingOnChecks"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3914,6 +4211,18 @@ pub mod service_endpoint_execution_data {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::SucceededWithIssues => write!(f, "succeededWithIssues"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ServiceEndpointExecutionRecord {
@@ -4098,6 +4407,59 @@ pub mod service_endpoint_request_result {
         GatewayTimeout,
         #[serde(rename = "httpVersionNotSupported")]
         HttpVersionNotSupported,
+    }
+    impl std::fmt::Display for StatusCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Continue => write!(f, "continue"),
+                Self::SwitchingProtocols => write!(f, "switchingProtocols"),
+                Self::Ok => write!(f, "ok"),
+                Self::Created => write!(f, "created"),
+                Self::Accepted => write!(f, "accepted"),
+                Self::NonAuthoritativeInformation => write!(f, "nonAuthoritativeInformation"),
+                Self::NoContent => write!(f, "noContent"),
+                Self::ResetContent => write!(f, "resetContent"),
+                Self::PartialContent => write!(f, "partialContent"),
+                Self::MultipleChoices => write!(f, "multipleChoices"),
+                Self::Ambiguous => write!(f, "ambiguous"),
+                Self::MovedPermanently => write!(f, "movedPermanently"),
+                Self::Moved => write!(f, "moved"),
+                Self::Found => write!(f, "found"),
+                Self::Redirect => write!(f, "redirect"),
+                Self::SeeOther => write!(f, "seeOther"),
+                Self::RedirectMethod => write!(f, "redirectMethod"),
+                Self::NotModified => write!(f, "notModified"),
+                Self::UseProxy => write!(f, "useProxy"),
+                Self::Unused => write!(f, "unused"),
+                Self::TemporaryRedirect => write!(f, "temporaryRedirect"),
+                Self::RedirectKeepVerb => write!(f, "redirectKeepVerb"),
+                Self::BadRequest => write!(f, "badRequest"),
+                Self::Unauthorized => write!(f, "unauthorized"),
+                Self::PaymentRequired => write!(f, "paymentRequired"),
+                Self::Forbidden => write!(f, "forbidden"),
+                Self::NotFound => write!(f, "notFound"),
+                Self::MethodNotAllowed => write!(f, "methodNotAllowed"),
+                Self::NotAcceptable => write!(f, "notAcceptable"),
+                Self::ProxyAuthenticationRequired => write!(f, "proxyAuthenticationRequired"),
+                Self::RequestTimeout => write!(f, "requestTimeout"),
+                Self::Conflict => write!(f, "conflict"),
+                Self::Gone => write!(f, "gone"),
+                Self::LengthRequired => write!(f, "lengthRequired"),
+                Self::PreconditionFailed => write!(f, "preconditionFailed"),
+                Self::RequestEntityTooLarge => write!(f, "requestEntityTooLarge"),
+                Self::RequestUriTooLong => write!(f, "requestUriTooLong"),
+                Self::UnsupportedMediaType => write!(f, "unsupportedMediaType"),
+                Self::RequestedRangeNotSatisfiable => write!(f, "requestedRangeNotSatisfiable"),
+                Self::ExpectationFailed => write!(f, "expectationFailed"),
+                Self::UpgradeRequired => write!(f, "upgradeRequired"),
+                Self::InternalServerError => write!(f, "internalServerError"),
+                Self::NotImplemented => write!(f, "notImplemented"),
+                Self::BadGateway => write!(f, "badGateway"),
+                Self::ServiceUnavailable => write!(f, "serviceUnavailable"),
+                Self::GatewayTimeout => write!(f, "gatewayTimeout"),
+                Self::HttpVersionNotSupported => write!(f, "httpVersionNotSupported"),
+            }
+        }
     }
 }
 #[doc = "Represents type of the service endpoint."]
@@ -4702,6 +5064,18 @@ pub mod task_agent_job_request {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::SucceededWithIssues => write!(f, "succeededWithIssues"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TaskAgentJobStep {
@@ -4753,6 +5127,14 @@ pub mod task_agent_job_step {
         Task,
         #[serde(rename = "action")]
         Action,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Task => write!(f, "task"),
+                Self::Action => write!(f, "action"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5082,6 +5464,15 @@ pub mod task_agent_pool_maintenance_job {
         #[serde(rename = "canceled")]
         Canceled,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+            }
+        }
+    }
     #[doc = "Status of the maintenance job"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -5093,6 +5484,16 @@ pub mod task_agent_pool_maintenance_job {
         Cancelling,
         #[serde(rename = "queued")]
         Queued,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Cancelling => write!(f, "cancelling"),
+                Self::Queued => write!(f, "queued"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5123,6 +5524,15 @@ pub mod task_agent_pool_maintenance_job_target_agent {
         #[serde(rename = "canceled")]
         Canceled,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
         #[serde(rename = "inProgress")]
@@ -5133,6 +5543,16 @@ pub mod task_agent_pool_maintenance_job_target_agent {
         Cancelling,
         #[serde(rename = "queued")]
         Queued,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Cancelling => write!(f, "cancelling"),
+                Self::Queued => write!(f, "queued"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5232,6 +5652,21 @@ pub mod task_agent_pool_maintenance_schedule {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for DaysToBuild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Monday => write!(f, "monday"),
+                Self::Tuesday => write!(f, "tuesday"),
+                Self::Wednesday => write!(f, "wednesday"),
+                Self::Thursday => write!(f, "thursday"),
+                Self::Friday => write!(f, "friday"),
+                Self::Saturday => write!(f, "saturday"),
+                Self::Sunday => write!(f, "sunday"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TaskAgentPoolReference {
@@ -5276,6 +5711,16 @@ pub mod task_agent_pool_reference {
         #[serde(rename = "preserveAgentOnJobFailure")]
         PreserveAgentOnJobFailure,
     }
+    impl std::fmt::Display for Options {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::ElasticPool => write!(f, "elasticPool"),
+                Self::SingleUseAgents => write!(f, "singleUseAgents"),
+                Self::PreserveAgentOnJobFailure => write!(f, "preserveAgentOnJobFailure"),
+            }
+        }
+    }
     #[doc = "Gets or sets the type of the pool"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum PoolType {
@@ -5283,6 +5728,14 @@ pub mod task_agent_pool_reference {
         Automation,
         #[serde(rename = "deployment")]
         Deployment,
+    }
+    impl std::fmt::Display for PoolType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Automation => write!(f, "automation"),
+                Self::Deployment => write!(f, "deployment"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5469,6 +5922,14 @@ pub mod task_agent_reference {
         #[serde(rename = "online")]
         Online,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Offline => write!(f, "offline"),
+                Self::Online => write!(f, "online"),
+            }
+        }
+    }
 }
 #[doc = "Represents a session for performing message exchanges from an agent."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5585,6 +6046,15 @@ pub mod task_agent_update_reason {
         #[serde(rename = "downgrade")]
         Downgrade,
     }
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Manual => write!(f, "manual"),
+                Self::MinAgentVersionRequired => write!(f, "minAgentVersionRequired"),
+                Self::Downgrade => write!(f, "downgrade"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TaskAssignedEvent {
@@ -5658,6 +6128,14 @@ pub mod task_command_restrictions {
         #[serde(rename = "restricted")]
         Restricted,
     }
+    impl std::fmt::Display for Mode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Any => write!(f, "any"),
+                Self::Restricted => write!(f, "restricted"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TaskCompletedEvent {
@@ -5696,6 +6174,18 @@ pub mod task_completed_event {
         Skipped,
         #[serde(rename = "abandoned")]
         Abandoned,
+    }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::SucceededWithIssues => write!(f, "succeededWithIssues"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6254,6 +6744,16 @@ pub mod task_group_revision {
         #[serde(rename = "undelete")]
         Undelete,
     }
+    impl std::fmt::Display for ChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Update => write!(f, "update"),
+                Self::Delete => write!(f, "delete"),
+                Self::Undelete => write!(f, "undelete"),
+            }
+        }
+    }
 }
 #[doc = "Represents tasks in the task group."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6731,6 +7231,14 @@ pub mod task_orchestration_item {
         #[serde(rename = "job")]
         Job,
     }
+    impl std::fmt::Display for ItemType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Container => write!(f, "container"),
+                Self::Job => write!(f, "job"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TaskOrchestrationJob {
@@ -6879,6 +7387,18 @@ pub mod task_orchestration_plan {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::SucceededWithIssues => write!(f, "succeededWithIssues"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum State {
         #[serde(rename = "inProgress")]
@@ -6889,6 +7409,16 @@ pub mod task_orchestration_plan {
         Completed,
         #[serde(rename = "throttled")]
         Throttled,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Queued => write!(f, "queued"),
+                Self::Completed => write!(f, "completed"),
+                Self::Throttled => write!(f, "throttled"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6932,6 +7462,15 @@ pub mod task_orchestration_plan_groups_queue_metrics {
         Queued,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Running => write!(f, "running"),
+                Self::Queued => write!(f, "queued"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -7402,6 +7941,18 @@ pub mod timeline_record {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::SucceededWithIssues => write!(f, "succeededWithIssues"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
     #[doc = "The state of the record."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum State {
@@ -7411,6 +7962,15 @@ pub mod timeline_record {
         InProgress,
         #[serde(rename = "completed")]
         Completed,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Pending => write!(f, "pending"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/distributed_task/models.rs
+++ b/azure_devops_rust_api/src/distributed_task/models.rs
@@ -782,6 +782,25 @@ impl DeploymentGroup {
         Self::default()
     }
 }
+#[doc = "Get only deployment groups on which this action can be performed."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DeploymentGroupActionFilter {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "manage")]
+    Manage,
+    #[serde(rename = "use")]
+    Use,
+}
+impl std::fmt::Display for DeploymentGroupActionFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Manage => write!(f, "manage"),
+            Self::Use => write!(f, "use"),
+        }
+    }
+}
 #[doc = "Properties to create Deployment group."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DeploymentGroupCreateParameter {
@@ -810,6 +829,25 @@ pub struct DeploymentGroupCreateParameterPoolProperty {
 impl DeploymentGroupCreateParameterPoolProperty {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Include these additional details in the returned objects."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DeploymentGroupExpands {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "machines")]
+    Machines,
+    #[serde(rename = "tags")]
+    Tags,
+}
+impl std::fmt::Display for DeploymentGroupExpands {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Machines => write!(f, "machines"),
+            Self::Tags => write!(f, "tags"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1046,6 +1084,28 @@ pub struct DeploymentPoolSummary {
 impl DeploymentPoolSummary {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Include these additional details in the returned objects."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DeploymentTargetExpands {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "capabilities")]
+    Capabilities,
+    #[serde(rename = "assignedRequest")]
+    AssignedRequest,
+    #[serde(rename = "lastCompletedRequest")]
+    LastCompletedRequest,
+}
+impl std::fmt::Display for DeploymentTargetExpands {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Capabilities => write!(f, "capabilities"),
+            Self::AssignedRequest => write!(f, "assignedRequest"),
+            Self::LastCompletedRequest => write!(f, "lastCompletedRequest"),
+        }
     }
 }
 #[doc = "Deployment target update parameter."]
@@ -1493,6 +1553,82 @@ pub mod elastic_node_settings {
                 Self::UnhealthyVm => write!(f, "unhealthyVm"),
                 Self::UnhealthyVmPendingDelete => write!(f, "unhealthyVmPendingDelete"),
             }
+        }
+    }
+}
+#[doc = "Optional: Filter to only retrieve ElasticNodes in the given ElasticNodeState"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ElasticNodeState {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "new")]
+    New,
+    #[serde(rename = "creatingCompute")]
+    CreatingCompute,
+    #[serde(rename = "startingAgent")]
+    StartingAgent,
+    #[serde(rename = "idle")]
+    Idle,
+    #[serde(rename = "assigned")]
+    Assigned,
+    #[serde(rename = "offline")]
+    Offline,
+    #[serde(rename = "pendingReimage")]
+    PendingReimage,
+    #[serde(rename = "pendingDelete")]
+    PendingDelete,
+    #[serde(rename = "saved")]
+    Saved,
+    #[serde(rename = "deletingCompute")]
+    DeletingCompute,
+    #[serde(rename = "deleted")]
+    Deleted,
+    #[serde(rename = "lost")]
+    Lost,
+    #[serde(rename = "reimagingCompute")]
+    ReimagingCompute,
+    #[serde(rename = "restartingAgent")]
+    RestartingAgent,
+    #[serde(rename = "failedToStartPendingDelete")]
+    FailedToStartPendingDelete,
+    #[serde(rename = "failedToRestartPendingDelete")]
+    FailedToRestartPendingDelete,
+    #[serde(rename = "failedVMPendingDelete")]
+    FailedVmPendingDelete,
+    #[serde(rename = "assignedPendingDelete")]
+    AssignedPendingDelete,
+    #[serde(rename = "retryDelete")]
+    RetryDelete,
+    #[serde(rename = "unhealthyVm")]
+    UnhealthyVm,
+    #[serde(rename = "unhealthyVmPendingDelete")]
+    UnhealthyVmPendingDelete,
+}
+impl std::fmt::Display for ElasticNodeState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::New => write!(f, "new"),
+            Self::CreatingCompute => write!(f, "creatingCompute"),
+            Self::StartingAgent => write!(f, "startingAgent"),
+            Self::Idle => write!(f, "idle"),
+            Self::Assigned => write!(f, "assigned"),
+            Self::Offline => write!(f, "offline"),
+            Self::PendingReimage => write!(f, "pendingReimage"),
+            Self::PendingDelete => write!(f, "pendingDelete"),
+            Self::Saved => write!(f, "saved"),
+            Self::DeletingCompute => write!(f, "deletingCompute"),
+            Self::Deleted => write!(f, "deleted"),
+            Self::Lost => write!(f, "lost"),
+            Self::ReimagingCompute => write!(f, "reimagingCompute"),
+            Self::RestartingAgent => write!(f, "restartingAgent"),
+            Self::FailedToStartPendingDelete => write!(f, "failedToStartPendingDelete"),
+            Self::FailedToRestartPendingDelete => write!(f, "failedToRestartPendingDelete"),
+            Self::FailedVmPendingDelete => write!(f, "failedVMPendingDelete"),
+            Self::AssignedPendingDelete => write!(f, "assignedPendingDelete"),
+            Self::RetryDelete => write!(f, "retryDelete"),
+            Self::UnhealthyVm => write!(f, "unhealthyVm"),
+            Self::UnhealthyVmPendingDelete => write!(f, "unhealthyVmPendingDelete"),
         }
     }
 }
@@ -2109,6 +2245,22 @@ pub struct EnvironmentDeploymentExecutionRecordList {
 impl EnvironmentDeploymentExecutionRecordList {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Include these additional details in the returned objects."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum EnvironmentExpands {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "resourceReferences")]
+    ResourceReferences,
+}
+impl std::fmt::Display for EnvironmentExpands {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::ResourceReferences => write!(f, "resourceReferences"),
+        }
     }
 }
 #[doc = "Environment."]
@@ -5077,6 +5229,28 @@ pub mod task_agent_job_request {
         }
     }
 }
+#[doc = "Get only deployment targets that have this last job result."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TaskAgentJobResultFilter {
+    #[serde(rename = "failed")]
+    Failed,
+    #[serde(rename = "passed")]
+    Passed,
+    #[serde(rename = "neverDeployed")]
+    NeverDeployed,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for TaskAgentJobResultFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Failed => write!(f, "failed"),
+            Self::Passed => write!(f, "passed"),
+            Self::NeverDeployed => write!(f, "neverDeployed"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TaskAgentJobStep {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -5299,6 +5473,25 @@ pub struct TaskAgentPool {
 impl TaskAgentPool {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Filter by whether the calling user has use or manage permissions"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TaskAgentPoolActionFilter {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "manage")]
+    Manage,
+    #[serde(rename = "use")]
+    Use,
+}
+impl std::fmt::Display for TaskAgentPoolActionFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Manage => write!(f, "manage"),
+            Self::Use => write!(f, "use"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5805,6 +5998,22 @@ impl TaskAgentPoolSummary {
         Self::default()
     }
 }
+#[doc = "Filter by pool type"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TaskAgentPoolType {
+    #[serde(rename = "automation")]
+    Automation,
+    #[serde(rename = "deployment")]
+    Deployment,
+}
+impl std::fmt::Display for TaskAgentPoolType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Automation => write!(f, "automation"),
+            Self::Deployment => write!(f, "deployment"),
+        }
+    }
+}
 #[doc = "Represents the public key portion of an RSA asymmetric key."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TaskAgentPublicKey {
@@ -5846,6 +6055,25 @@ pub struct TaskAgentQueue {
 impl TaskAgentQueue {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Filter by whether the calling user has use or manage permissions"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TaskAgentQueueActionFilter {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "manage")]
+    Manage,
+    #[serde(rename = "use")]
+    Use,
+}
+impl std::fmt::Display for TaskAgentQueueActionFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Manage => write!(f, "manage"),
+            Self::Use => write!(f, "use"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5979,6 +6207,25 @@ pub struct TaskAgentSessionKey {
 impl TaskAgentSessionKey {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Get only deployment targets that have this status."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TaskAgentStatusFilter {
+    #[serde(rename = "offline")]
+    Offline,
+    #[serde(rename = "online")]
+    Online,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for TaskAgentStatusFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Offline => write!(f, "offline"),
+            Self::Online => write!(f, "online"),
+            Self::All => write!(f, "all"),
+        }
     }
 }
 #[doc = "Details about an agent update."]
@@ -6675,6 +6922,22 @@ pub struct TaskGroupPublishPreviewParameter {
 impl TaskGroupPublishPreviewParameter {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Gets the results in the defined order. Default is 'CreatedOnDescending'."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TaskGroupQueryOrder {
+    #[serde(rename = "createdOnAscending")]
+    CreatedOnAscending,
+    #[serde(rename = "createdOnDescending")]
+    CreatedOnDescending,
+}
+impl std::fmt::Display for TaskGroupQueryOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CreatedOnAscending => write!(f, "createdOnAscending"),
+            Self::CreatedOnDescending => write!(f, "createdOnDescending"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -8115,6 +8378,25 @@ impl VariableGroup {
         Self::default()
     }
 }
+#[doc = "Action filter for the variable group. It specifies the action which can be performed on the variable groups."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum VariableGroupActionFilter {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "manage")]
+    Manage,
+    #[serde(rename = "use")]
+    Use,
+}
+impl std::fmt::Display for VariableGroupActionFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Manage => write!(f, "manage"),
+            Self::Use => write!(f, "use"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct VariableGroupList {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -8192,6 +8474,22 @@ pub struct VariableGroupProviderData {}
 impl VariableGroupProviderData {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Gets the results in the defined order. Default is 'IdDescending'."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum VariableGroupQueryOrder {
+    #[serde(rename = "idAscending")]
+    IdAscending,
+    #[serde(rename = "idDescending")]
+    IdDescending,
+}
+impl std::fmt::Display for VariableGroupQueryOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IdAscending => write!(f, "idAscending"),
+            Self::IdDescending => write!(f, "idDescending"),
+        }
     }
 }
 #[doc = "A wrapper class for a generic variable."]

--- a/azure_devops_rust_api/src/extension_management/models.rs
+++ b/azure_devops_rust_api/src/extension_management/models.rs
@@ -49,6 +49,15 @@ pub mod acquisition_operation {
         #[serde(rename = "completed")]
         Completed,
     }
+    impl std::fmt::Display for OperationState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Disallow => write!(f, "disallow"),
+                Self::Allow => write!(f, "allow"),
+                Self::Completed => write!(f, "completed"),
+            }
+        }
+    }
     #[doc = "AcquisitionOperationType: install, request, buy, etc..."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum OperationType {
@@ -66,6 +75,19 @@ pub mod acquisition_operation {
         None,
         #[serde(rename = "purchaseRequest")]
         PurchaseRequest,
+    }
+    impl std::fmt::Display for OperationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Get => write!(f, "get"),
+                Self::Install => write!(f, "install"),
+                Self::Buy => write!(f, "buy"),
+                Self::Try => write!(f, "try"),
+                Self::Request => write!(f, "request"),
+                Self::None => write!(f, "none"),
+                Self::PurchaseRequest => write!(f, "purchaseRequest"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -372,6 +394,18 @@ pub mod contribution_node_query {
         #[serde(rename = "ignoreConstraints")]
         IgnoreConstraints,
     }
+    impl std::fmt::Display for QueryOptions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::IncludeSelf => write!(f, "includeSelf"),
+                Self::IncludeChildren => write!(f, "includeChildren"),
+                Self::IncludeSubTree => write!(f, "includeSubTree"),
+                Self::IncludeAll => write!(f, "includeAll"),
+                Self::IgnoreConstraints => write!(f, "ignoreConstraints"),
+            }
+        }
+    }
 }
 #[doc = "Result of a contribution node query.  Wraps the resulting contribution nodes and provider details."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -440,6 +474,23 @@ pub mod contribution_property_description {
         Array,
         #[serde(rename = "object")]
         Object,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::String => write!(f, "string"),
+                Self::Uri => write!(f, "uri"),
+                Self::Guid => write!(f, "guid"),
+                Self::Boolean => write!(f, "boolean"),
+                Self::Integer => write!(f, "integer"),
+                Self::Double => write!(f, "double"),
+                Self::DateTime => write!(f, "dateTime"),
+                Self::Dictionary => write!(f, "dictionary"),
+                Self::Array => write!(f, "array"),
+                Self::Object => write!(f, "object"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -645,6 +696,15 @@ pub mod extension_acquisition_request {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for AssignmentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Me => write!(f, "me"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[doc = "The type of operation, such as install, request, purchase"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum OperationType {
@@ -662,6 +722,19 @@ pub mod extension_acquisition_request {
         None,
         #[serde(rename = "purchaseRequest")]
         PurchaseRequest,
+    }
+    impl std::fmt::Display for OperationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Get => write!(f, "get"),
+                Self::Install => write!(f, "install"),
+                Self::Buy => write!(f, "buy"),
+                Self::Try => write!(f, "try"),
+                Self::Request => write!(f, "request"),
+                Self::None => write!(f, "none"),
+                Self::PurchaseRequest => write!(f, "purchaseRequest"),
+            }
+        }
     }
 }
 #[doc = "Audit log for an extension"]
@@ -855,6 +928,19 @@ pub mod extension_event {
         ActionRequired,
         #[serde(rename = "actionResolved")]
         ActionResolved,
+    }
+    impl std::fmt::Display for UpdateType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Installed => write!(f, "installed"),
+                Self::Uninstalled => write!(f, "uninstalled"),
+                Self::Enabled => write!(f, "enabled"),
+                Self::Disabled => write!(f, "disabled"),
+                Self::VersionUpdated => write!(f, "versionUpdated"),
+                Self::ActionRequired => write!(f, "actionRequired"),
+                Self::ActionResolved => write!(f, "actionResolved"),
+            }
+        }
     }
 }
 #[doc = "Base class for an event callback for an extension"]
@@ -1134,6 +1220,19 @@ pub mod extension_policy {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for Install {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+                Self::Preview => write!(f, "preview"),
+                Self::Released => write!(f, "released"),
+                Self::FirstParty => write!(f, "firstParty"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[doc = "Permission on 'Request' operation"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Request {
@@ -1151,6 +1250,19 @@ pub mod extension_policy {
         FirstParty,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Request {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+                Self::Preview => write!(f, "preview"),
+                Self::Released => write!(f, "released"),
+                Self::FirstParty => write!(f, "firstParty"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[doc = "A request for an extension (to be installed or have a license assigned)"]
@@ -1223,6 +1335,15 @@ pub mod extension_request {
         #[serde(rename = "rejected")]
         Rejected,
     }
+    impl std::fmt::Display for RequestState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Open => write!(f, "open"),
+                Self::Accepted => write!(f, "accepted"),
+                Self::Rejected => write!(f, "rejected"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ExtensionRequestEvent {
@@ -1264,6 +1385,16 @@ pub mod extension_request_event {
         Rejected,
         #[serde(rename = "deleted")]
         Deleted,
+    }
+    impl std::fmt::Display for UpdateType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Created => write!(f, "created"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1324,6 +1455,16 @@ pub mod extension_requests_event {
         Rejected,
         #[serde(rename = "deleted")]
         Deleted,
+    }
+    impl std::fmt::Display for UpdateType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Created => write!(f, "created"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1760,6 +1901,14 @@ pub mod installed_extension_state_issue {
         #[serde(rename = "error")]
         Error,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+            }
+        }
+    }
 }
 #[doc = "Represents a JSON object."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1801,6 +1950,15 @@ pub mod licensing_override {
         OnlyIfUnlicensed,
         #[serde(rename = "alwaysInclude")]
         AlwaysInclude,
+    }
+    impl std::fmt::Display for Behavior {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::OnlyIfLicensed => write!(f, "onlyIfLicensed"),
+                Self::OnlyIfUnlicensed => write!(f, "onlyIfUnlicensed"),
+                Self::AlwaysInclude => write!(f, "alwaysInclude"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1932,6 +2090,16 @@ pub mod published_extension {
         Vsix,
         #[serde(rename = "referralLink")]
         ReferralLink,
+    }
+    impl std::fmt::Display for DeploymentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Exe => write!(f, "exe"),
+                Self::Msi => write!(f, "msi"),
+                Self::Vsix => write!(f, "vsix"),
+                Self::ReferralLink => write!(f, "referralLink"),
+            }
+        }
     }
 }
 #[doc = "High-level information about the publisher, like id's and names"]

--- a/azure_devops_rust_api/src/git/mod.rs
+++ b/azure_devops_rust_api/src/git/mod.rs
@@ -1667,12 +1667,13 @@ pub mod commits {
             pub(crate) search_criteria_top: Option<i32>,
             pub(crate) search_criteria_author: Option<String>,
             pub(crate) search_criteria_compare_version_version: Option<String>,
-            pub(crate) search_criteria_compare_version_version_options: Option<String>,
-            pub(crate) search_criteria_compare_version_version_type: Option<String>,
+            pub(crate) search_criteria_compare_version_version_options:
+                Option<models::GitVersionOptions>,
+            pub(crate) search_criteria_compare_version_version_type: Option<models::GitVersionType>,
             pub(crate) search_criteria_exclude_deletes: Option<bool>,
             pub(crate) search_criteria_from_commit_id: Option<String>,
             pub(crate) search_criteria_from_date: Option<String>,
-            pub(crate) search_criteria_history_mode: Option<String>,
+            pub(crate) search_criteria_history_mode: Option<models::GitHistoryMode>,
             pub(crate) search_criteria_ids: Vec<String>,
             pub(crate) search_criteria_include_links: Option<bool>,
             pub(crate) search_criteria_include_push_data: Option<bool>,
@@ -1680,8 +1681,9 @@ pub mod commits {
             pub(crate) search_criteria_include_work_items: Option<bool>,
             pub(crate) search_criteria_item_path: Option<String>,
             pub(crate) search_criteria_item_version_version: Option<String>,
-            pub(crate) search_criteria_item_version_version_options: Option<String>,
-            pub(crate) search_criteria_item_version_version_type: Option<String>,
+            pub(crate) search_criteria_item_version_version_options:
+                Option<models::GitVersionOptions>,
+            pub(crate) search_criteria_item_version_version_type: Option<models::GitVersionType>,
             pub(crate) search_criteria_show_oldest_commits_first: Option<bool>,
             pub(crate) search_criteria_to_commit_id: Option<String>,
             pub(crate) search_criteria_to_date: Option<String>,
@@ -1718,7 +1720,7 @@ pub mod commits {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn search_criteria_compare_version_version_options(
                 mut self,
-                search_criteria_compare_version_version_options: impl Into<String>,
+                search_criteria_compare_version_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.search_criteria_compare_version_version_options =
                     Some(search_criteria_compare_version_version_options.into());
@@ -1727,7 +1729,7 @@ pub mod commits {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn search_criteria_compare_version_version_type(
                 mut self,
-                search_criteria_compare_version_version_type: impl Into<String>,
+                search_criteria_compare_version_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.search_criteria_compare_version_version_type =
                     Some(search_criteria_compare_version_version_type.into());
@@ -1760,7 +1762,7 @@ pub mod commits {
             #[doc = "What Git history mode should be used. This only applies to the search criteria when Ids = null and an itemPath is specified."]
             pub fn search_criteria_history_mode(
                 mut self,
-                search_criteria_history_mode: impl Into<String>,
+                search_criteria_history_mode: impl Into<models::GitHistoryMode>,
             ) -> Self {
                 self.search_criteria_history_mode = Some(search_criteria_history_mode.into());
                 self
@@ -1823,7 +1825,7 @@ pub mod commits {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn search_criteria_item_version_version_options(
                 mut self,
-                search_criteria_item_version_version_options: impl Into<String>,
+                search_criteria_item_version_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.search_criteria_item_version_version_options =
                     Some(search_criteria_item_version_version_options.into());
@@ -1832,7 +1834,7 @@ pub mod commits {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn search_criteria_item_version_version_type(
                 mut self,
-                search_criteria_item_version_version_type: impl Into<String>,
+                search_criteria_item_version_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.search_criteria_item_version_version_type =
                     Some(search_criteria_item_version_version_type.into());
@@ -1920,7 +1922,7 @@ pub mod commits {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "searchCriteria.compareVersion.versionOptions",
-                                search_criteria_compare_version_version_options,
+                                &search_criteria_compare_version_version_options.to_string(),
                             );
                         }
                         if let Some(search_criteria_compare_version_version_type) =
@@ -1928,7 +1930,7 @@ pub mod commits {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "searchCriteria.compareVersion.versionType",
-                                search_criteria_compare_version_version_type,
+                                &search_criteria_compare_version_version_type.to_string(),
                             );
                         }
                         if let Some(search_criteria_exclude_deletes) =
@@ -1957,7 +1959,7 @@ pub mod commits {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "searchCriteria.historyMode",
-                                search_criteria_history_mode,
+                                &search_criteria_history_mode.to_string(),
                             );
                         }
                         if let Some(search_criteria_include_links) =
@@ -2010,7 +2012,7 @@ pub mod commits {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "searchCriteria.itemVersion.versionOptions",
-                                search_criteria_item_version_version_options,
+                                &search_criteria_item_version_version_options.to_string(),
                             );
                         }
                         if let Some(search_criteria_item_version_version_type) =
@@ -2018,7 +2020,7 @@ pub mod commits {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "searchCriteria.itemVersion.versionType",
-                                search_criteria_item_version_version_type,
+                                &search_criteria_item_version_version_type.to_string(),
                             );
                         }
                         if let Some(search_criteria_show_oldest_commits_first) =
@@ -2727,8 +2729,8 @@ pub mod items {
             pub(crate) download: Option<bool>,
             pub(crate) format: Option<String>,
             pub(crate) version_descriptor_version: Option<String>,
-            pub(crate) version_descriptor_version_options: Option<String>,
-            pub(crate) version_descriptor_version_type: Option<String>,
+            pub(crate) version_descriptor_version_options: Option<models::GitVersionOptions>,
+            pub(crate) version_descriptor_version_type: Option<models::GitVersionType>,
             pub(crate) include_content: Option<bool>,
             pub(crate) resolve_lfs: Option<bool>,
             pub(crate) sanitize: Option<bool>,
@@ -2778,7 +2780,7 @@ pub mod items {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn version_descriptor_version_options(
                 mut self,
-                version_descriptor_version_options: impl Into<String>,
+                version_descriptor_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.version_descriptor_version_options =
                     Some(version_descriptor_version_options.into());
@@ -2787,7 +2789,7 @@ pub mod items {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn version_descriptor_version_type(
                 mut self,
-                version_descriptor_version_type: impl Into<String>,
+                version_descriptor_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.version_descriptor_version_type = Some(version_descriptor_version_type.into());
                 self
@@ -2874,7 +2876,7 @@ pub mod items {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionOptions",
-                                version_descriptor_version_options,
+                                &version_descriptor_version_options.to_string(),
                             );
                         }
                         if let Some(version_descriptor_version_type) =
@@ -2882,7 +2884,7 @@ pub mod items {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionType",
-                                version_descriptor_version_type,
+                                &version_descriptor_version_type.to_string(),
                             );
                         }
                         if let Some(include_content) = &this.include_content {
@@ -2983,8 +2985,8 @@ pub mod items {
             pub(crate) include_links: Option<bool>,
             pub(crate) format: Option<String>,
             pub(crate) version_descriptor_version: Option<String>,
-            pub(crate) version_descriptor_version_options: Option<String>,
-            pub(crate) version_descriptor_version_type: Option<String>,
+            pub(crate) version_descriptor_version_options: Option<models::GitVersionOptions>,
+            pub(crate) version_descriptor_version_type: Option<models::GitVersionType>,
             pub(crate) zip_for_unix: Option<bool>,
         }
         impl RequestBuilder {
@@ -3037,7 +3039,7 @@ pub mod items {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn version_descriptor_version_options(
                 mut self,
-                version_descriptor_version_options: impl Into<String>,
+                version_descriptor_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.version_descriptor_version_options =
                     Some(version_descriptor_version_options.into());
@@ -3046,7 +3048,7 @@ pub mod items {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn version_descriptor_version_type(
                 mut self,
-                version_descriptor_version_type: impl Into<String>,
+                version_descriptor_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.version_descriptor_version_type = Some(version_descriptor_version_type.into());
                 self
@@ -3126,7 +3128,7 @@ pub mod items {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionOptions",
-                                version_descriptor_version_options,
+                                &version_descriptor_version_options.to_string(),
                             );
                         }
                         if let Some(version_descriptor_version_type) =
@@ -3134,7 +3136,7 @@ pub mod items {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionType",
-                                version_descriptor_version_type,
+                                &version_descriptor_version_type.to_string(),
                             );
                         }
                         if let Some(zip_for_unix) = &this.zip_for_unix {
@@ -3375,8 +3377,8 @@ pub mod stats {
             pub(crate) name: String,
             pub(crate) project: String,
             pub(crate) base_version_descriptor_version: Option<String>,
-            pub(crate) base_version_descriptor_version_options: Option<String>,
-            pub(crate) base_version_descriptor_version_type: Option<String>,
+            pub(crate) base_version_descriptor_version_options: Option<models::GitVersionOptions>,
+            pub(crate) base_version_descriptor_version_type: Option<models::GitVersionType>,
         }
         impl RequestBuilder {
             #[doc = "Version string identifier (name of tag/branch, SHA1 of commit)"]
@@ -3390,7 +3392,7 @@ pub mod stats {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn base_version_descriptor_version_options(
                 mut self,
-                base_version_descriptor_version_options: impl Into<String>,
+                base_version_descriptor_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.base_version_descriptor_version_options =
                     Some(base_version_descriptor_version_options.into());
@@ -3399,7 +3401,7 @@ pub mod stats {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn base_version_descriptor_version_type(
                 mut self,
-                base_version_descriptor_version_type: impl Into<String>,
+                base_version_descriptor_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.base_version_descriptor_version_type =
                     Some(base_version_descriptor_version_type.into());
@@ -3442,7 +3444,7 @@ pub mod stats {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "baseVersionDescriptor.versionOptions",
-                                base_version_descriptor_version_options,
+                                &base_version_descriptor_version_options.to_string(),
                             );
                         }
                         if let Some(base_version_descriptor_version_type) =
@@ -3450,7 +3452,7 @@ pub mod stats {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "baseVersionDescriptor.versionType",
-                                base_version_descriptor_version_type,
+                                &base_version_descriptor_version_type.to_string(),
                             );
                         }
                         let req_body = azure_core::Bytes::new();
@@ -3529,8 +3531,8 @@ pub mod stats {
             pub(crate) repository_id: String,
             pub(crate) project: String,
             pub(crate) base_version_descriptor_version: Option<String>,
-            pub(crate) base_version_descriptor_version_options: Option<String>,
-            pub(crate) base_version_descriptor_version_type: Option<String>,
+            pub(crate) base_version_descriptor_version_options: Option<models::GitVersionOptions>,
+            pub(crate) base_version_descriptor_version_type: Option<models::GitVersionType>,
         }
         impl RequestBuilder {
             #[doc = "Version string identifier (name of tag/branch, SHA1 of commit)"]
@@ -3544,7 +3546,7 @@ pub mod stats {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn base_version_descriptor_version_options(
                 mut self,
-                base_version_descriptor_version_options: impl Into<String>,
+                base_version_descriptor_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.base_version_descriptor_version_options =
                     Some(base_version_descriptor_version_options.into());
@@ -3553,7 +3555,7 @@ pub mod stats {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn base_version_descriptor_version_type(
                 mut self,
-                base_version_descriptor_version_type: impl Into<String>,
+                base_version_descriptor_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.base_version_descriptor_version_type =
                     Some(base_version_descriptor_version_type.into());
@@ -3594,7 +3596,7 @@ pub mod stats {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "baseVersionDescriptor.versionOptions",
-                                base_version_descriptor_version_options,
+                                &base_version_descriptor_version_options.to_string(),
                             );
                         }
                         if let Some(base_version_descriptor_version_type) =
@@ -3602,7 +3604,7 @@ pub mod stats {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "baseVersionDescriptor.versionType",
-                                base_version_descriptor_version_type,
+                                &base_version_descriptor_version_type.to_string(),
                             );
                         }
                         let req_body = azure_core::Bytes::new();
@@ -4544,12 +4546,13 @@ pub mod pull_requests {
             pub(crate) search_criteria_include_links: Option<bool>,
             pub(crate) search_criteria_max_time: Option<time::OffsetDateTime>,
             pub(crate) search_criteria_min_time: Option<time::OffsetDateTime>,
-            pub(crate) search_criteria_query_time_range_type: Option<String>,
+            pub(crate) search_criteria_query_time_range_type:
+                Option<models::PullRequestTimeRangeType>,
             pub(crate) search_criteria_repository_id: Option<String>,
             pub(crate) search_criteria_reviewer_id: Option<String>,
             pub(crate) search_criteria_source_ref_name: Option<String>,
             pub(crate) search_criteria_source_repository_id: Option<String>,
-            pub(crate) search_criteria_status: Option<String>,
+            pub(crate) search_criteria_status: Option<models::PullRequestStatus>,
             pub(crate) search_criteria_target_ref_name: Option<String>,
             pub(crate) max_comment_length: Option<i32>,
             pub(crate) skip: Option<i32>,
@@ -4591,7 +4594,7 @@ pub mod pull_requests {
             #[doc = "The type of time range which should be used for minTime and maxTime. Defaults to Created if unset."]
             pub fn search_criteria_query_time_range_type(
                 mut self,
-                search_criteria_query_time_range_type: impl Into<String>,
+                search_criteria_query_time_range_type: impl Into<models::PullRequestTimeRangeType>,
             ) -> Self {
                 self.search_criteria_query_time_range_type =
                     Some(search_criteria_query_time_range_type.into());
@@ -4633,7 +4636,7 @@ pub mod pull_requests {
             #[doc = "If set, search for pull requests that are in this state. Defaults to Active if unset."]
             pub fn search_criteria_status(
                 mut self,
-                search_criteria_status: impl Into<String>,
+                search_criteria_status: impl Into<models::PullRequestStatus>,
             ) -> Self {
                 self.search_criteria_status = Some(search_criteria_status.into());
                 self
@@ -4716,7 +4719,7 @@ pub mod pull_requests {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "searchCriteria.queryTimeRangeType",
-                                search_criteria_query_time_range_type,
+                                &search_criteria_query_time_range_type.to_string(),
                             );
                         }
                         if let Some(search_criteria_repository_id) =
@@ -4751,9 +4754,10 @@ pub mod pull_requests {
                             );
                         }
                         if let Some(search_criteria_status) = &this.search_criteria_status {
-                            req.url_mut()
-                                .query_pairs_mut()
-                                .append_pair("searchCriteria.status", search_criteria_status);
+                            req.url_mut().query_pairs_mut().append_pair(
+                                "searchCriteria.status",
+                                &search_criteria_status.to_string(),
+                            );
                         }
                         if let Some(search_criteria_target_ref_name) =
                             &this.search_criteria_target_ref_name
@@ -4953,12 +4957,13 @@ pub mod pull_requests {
             pub(crate) search_criteria_include_links: Option<bool>,
             pub(crate) search_criteria_max_time: Option<time::OffsetDateTime>,
             pub(crate) search_criteria_min_time: Option<time::OffsetDateTime>,
-            pub(crate) search_criteria_query_time_range_type: Option<String>,
+            pub(crate) search_criteria_query_time_range_type:
+                Option<models::PullRequestTimeRangeType>,
             pub(crate) search_criteria_repository_id: Option<String>,
             pub(crate) search_criteria_reviewer_id: Option<String>,
             pub(crate) search_criteria_source_ref_name: Option<String>,
             pub(crate) search_criteria_source_repository_id: Option<String>,
-            pub(crate) search_criteria_status: Option<String>,
+            pub(crate) search_criteria_status: Option<models::PullRequestStatus>,
             pub(crate) search_criteria_target_ref_name: Option<String>,
             pub(crate) max_comment_length: Option<i32>,
             pub(crate) skip: Option<i32>,
@@ -5000,7 +5005,7 @@ pub mod pull_requests {
             #[doc = "The type of time range which should be used for minTime and maxTime. Defaults to Created if unset."]
             pub fn search_criteria_query_time_range_type(
                 mut self,
-                search_criteria_query_time_range_type: impl Into<String>,
+                search_criteria_query_time_range_type: impl Into<models::PullRequestTimeRangeType>,
             ) -> Self {
                 self.search_criteria_query_time_range_type =
                     Some(search_criteria_query_time_range_type.into());
@@ -5042,7 +5047,7 @@ pub mod pull_requests {
             #[doc = "If set, search for pull requests that are in this state. Defaults to Active if unset."]
             pub fn search_criteria_status(
                 mut self,
-                search_criteria_status: impl Into<String>,
+                search_criteria_status: impl Into<models::PullRequestStatus>,
             ) -> Self {
                 self.search_criteria_status = Some(search_criteria_status.into());
                 self
@@ -5125,7 +5130,7 @@ pub mod pull_requests {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "searchCriteria.queryTimeRangeType",
-                                search_criteria_query_time_range_type,
+                                &search_criteria_query_time_range_type.to_string(),
                             );
                         }
                         if let Some(search_criteria_repository_id) =
@@ -5160,9 +5165,10 @@ pub mod pull_requests {
                             );
                         }
                         if let Some(search_criteria_status) = &this.search_criteria_status {
-                            req.url_mut()
-                                .query_pairs_mut()
-                                .append_pair("searchCriteria.status", search_criteria_status);
+                            req.url_mut().query_pairs_mut().append_pair(
+                                "searchCriteria.status",
+                                &search_criteria_status.to_string(),
+                            );
                         }
                         if let Some(search_criteria_target_ref_name) =
                             &this.search_criteria_target_ref_name
@@ -6934,11 +6940,11 @@ pub mod diffs {
             pub(crate) top: Option<i32>,
             pub(crate) skip: Option<i32>,
             pub(crate) base_version: Option<String>,
-            pub(crate) base_version_options: Option<String>,
-            pub(crate) base_version_type: Option<String>,
+            pub(crate) base_version_options: Option<models::GitVersionOptions>,
+            pub(crate) base_version_type: Option<models::GitVersionType>,
             pub(crate) target_version: Option<String>,
-            pub(crate) target_version_options: Option<String>,
-            pub(crate) target_version_type: Option<String>,
+            pub(crate) target_version_options: Option<models::GitVersionOptions>,
+            pub(crate) target_version_type: Option<models::GitVersionType>,
         }
         impl RequestBuilder {
             #[doc = "If true, diff between common and target commits. If false, diff between base and target commits."]
@@ -6962,12 +6968,18 @@ pub mod diffs {
                 self
             }
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
-            pub fn base_version_options(mut self, base_version_options: impl Into<String>) -> Self {
+            pub fn base_version_options(
+                mut self,
+                base_version_options: impl Into<models::GitVersionOptions>,
+            ) -> Self {
                 self.base_version_options = Some(base_version_options.into());
                 self
             }
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
-            pub fn base_version_type(mut self, base_version_type: impl Into<String>) -> Self {
+            pub fn base_version_type(
+                mut self,
+                base_version_type: impl Into<models::GitVersionType>,
+            ) -> Self {
                 self.base_version_type = Some(base_version_type.into());
                 self
             }
@@ -6979,13 +6991,16 @@ pub mod diffs {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn target_version_options(
                 mut self,
-                target_version_options: impl Into<String>,
+                target_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.target_version_options = Some(target_version_options.into());
                 self
             }
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
-            pub fn target_version_type(mut self, target_version_type: impl Into<String>) -> Self {
+            pub fn target_version_type(
+                mut self,
+                target_version_type: impl Into<models::GitVersionType>,
+            ) -> Self {
                 self.target_version_type = Some(target_version_type.into());
                 self
             }
@@ -7032,14 +7047,15 @@ pub mod diffs {
                                 .append_pair("baseVersion", base_version);
                         }
                         if let Some(base_version_options) = &this.base_version_options {
-                            req.url_mut()
-                                .query_pairs_mut()
-                                .append_pair("baseVersionOptions", base_version_options);
+                            req.url_mut().query_pairs_mut().append_pair(
+                                "baseVersionOptions",
+                                &base_version_options.to_string(),
+                            );
                         }
                         if let Some(base_version_type) = &this.base_version_type {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("baseVersionType", base_version_type);
+                                .append_pair("baseVersionType", &base_version_type.to_string());
                         }
                         if let Some(target_version) = &this.target_version {
                             req.url_mut()
@@ -7047,14 +7063,15 @@ pub mod diffs {
                                 .append_pair("targetVersion", target_version);
                         }
                         if let Some(target_version_options) = &this.target_version_options {
-                            req.url_mut()
-                                .query_pairs_mut()
-                                .append_pair("targetVersionOptions", target_version_options);
+                            req.url_mut().query_pairs_mut().append_pair(
+                                "targetVersionOptions",
+                                &target_version_options.to_string(),
+                            );
                         }
                         if let Some(target_version_type) = &this.target_version_type {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("targetVersionType", target_version_type);
+                                .append_pair("targetVersionType", &target_version_type.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/git/mod.rs
+++ b/azure_devops_rust_api/src/git/mod.rs
@@ -2721,7 +2721,7 @@ pub mod items {
             pub(crate) path: String,
             pub(crate) project: String,
             pub(crate) scope_path: Option<String>,
-            pub(crate) recursion_level: Option<String>,
+            pub(crate) recursion_level: Option<models::VersionControlRecursionType>,
             pub(crate) include_content_metadata: Option<bool>,
             pub(crate) latest_processed_change: Option<bool>,
             pub(crate) download: Option<bool>,
@@ -2740,7 +2740,10 @@ pub mod items {
                 self
             }
             #[doc = "The recursion level of this request. The default is 'none', no recursion."]
-            pub fn recursion_level(mut self, recursion_level: impl Into<String>) -> Self {
+            pub fn recursion_level(
+                mut self,
+                recursion_level: impl Into<models::VersionControlRecursionType>,
+            ) -> Self {
                 self.recursion_level = Some(recursion_level.into());
                 self
             }
@@ -2836,7 +2839,7 @@ pub mod items {
                         if let Some(recursion_level) = &this.recursion_level {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("recursionLevel", recursion_level);
+                                .append_pair("recursionLevel", &recursion_level.to_string());
                         }
                         if let Some(include_content_metadata) = &this.include_content_metadata {
                             req.url_mut().query_pairs_mut().append_pair(
@@ -2973,7 +2976,7 @@ pub mod items {
             pub(crate) repository_id: String,
             pub(crate) project: String,
             pub(crate) scope_path: Option<String>,
-            pub(crate) recursion_level: Option<String>,
+            pub(crate) recursion_level: Option<models::VersionControlRecursionType>,
             pub(crate) include_content_metadata: Option<bool>,
             pub(crate) latest_processed_change: Option<bool>,
             pub(crate) download: Option<bool>,
@@ -2991,7 +2994,10 @@ pub mod items {
                 self
             }
             #[doc = "The recursion level of this request. The default is 'none', no recursion."]
-            pub fn recursion_level(mut self, recursion_level: impl Into<String>) -> Self {
+            pub fn recursion_level(
+                mut self,
+                recursion_level: impl Into<models::VersionControlRecursionType>,
+            ) -> Self {
                 self.recursion_level = Some(recursion_level.into());
                 self
             }
@@ -3080,7 +3086,7 @@ pub mod items {
                         if let Some(recursion_level) = &this.recursion_level {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("recursionLevel", recursion_level);
+                                .append_pair("recursionLevel", &recursion_level.to_string());
                         }
                         if let Some(include_content_metadata) = &this.include_content_metadata {
                             req.url_mut().query_pairs_mut().append_pair(

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -2536,6 +2536,28 @@ impl GitForkTeamProjectReference {
         }
     }
 }
+#[doc = "What Git history mode should be used. This only applies to the search criteria when Ids = null and an itemPath is specified."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GitHistoryMode {
+    #[serde(rename = "simplifiedHistory")]
+    SimplifiedHistory,
+    #[serde(rename = "firstParent")]
+    FirstParent,
+    #[serde(rename = "fullHistory")]
+    FullHistory,
+    #[serde(rename = "fullHistorySimplifyMerges")]
+    FullHistorySimplifyMerges,
+}
+impl std::fmt::Display for GitHistoryMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SimplifiedHistory => write!(f, "simplifiedHistory"),
+            Self::FirstParent => write!(f, "firstParent"),
+            Self::FullHistory => write!(f, "fullHistory"),
+            Self::FullHistorySimplifyMerges => write!(f, "fullHistorySimplifyMerges"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitImportFailedEvent {
     #[serde(
@@ -6000,6 +6022,44 @@ pub mod git_version_descriptor {
         }
     }
 }
+#[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GitVersionOptions {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "previousChange")]
+    PreviousChange,
+    #[serde(rename = "firstParent")]
+    FirstParent,
+}
+impl std::fmt::Display for GitVersionOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::PreviousChange => write!(f, "previousChange"),
+            Self::FirstParent => write!(f, "firstParent"),
+        }
+    }
+}
+#[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GitVersionType {
+    #[serde(rename = "branch")]
+    Branch,
+    #[serde(rename = "tag")]
+    Tag,
+    #[serde(rename = "commit")]
+    Commit,
+}
+impl std::fmt::Display for GitVersionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Branch => write!(f, "branch"),
+            Self::Tag => write!(f, "tag"),
+            Self::Commit => write!(f, "commit"),
+        }
+    }
+}
 #[doc = "Globally unique key for a repository."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GlobalGitRepositoryKey {
@@ -6835,6 +6895,22 @@ pub struct PullRequestTabExtensionConfig {
 impl PullRequestTabExtensionConfig {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "The type of time range which should be used for minTime and maxTime. Defaults to Created if unset."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum PullRequestTimeRangeType {
+    #[serde(rename = "created")]
+    Created,
+    #[serde(rename = "closed")]
+    Closed,
+}
+impl std::fmt::Display for PullRequestTimeRangeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Created => write!(f, "created"),
+            Self::Closed => write!(f, "closed"),
+        }
     }
 }
 #[doc = "Base contract for a real time pull request event (SignalR)"]
@@ -8337,7 +8413,7 @@ pub mod version_control_project_info {
         }
     }
 }
-#[doc = "The recursion level for a request."]
+#[doc = "The recursion level of this request. The default is 'none', no recursion."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum VersionControlRecursionType {
     #[serde(rename = "none")]

--- a/azure_devops_rust_api/src/git/models.rs
+++ b/azure_devops_rust_api/src/git/models.rs
@@ -423,6 +423,29 @@ pub mod change {
         #[serde(rename = "edit, rename")]
         EditRename,
     }
+    impl std::fmt::Display for ChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Add => write!(f, "add"),
+                Self::Edit => write!(f, "edit"),
+                Self::Encoding => write!(f, "encoding"),
+                Self::Rename => write!(f, "rename"),
+                Self::Delete => write!(f, "delete"),
+                Self::Undelete => write!(f, "undelete"),
+                Self::Branch => write!(f, "branch"),
+                Self::Merge => write!(f, "merge"),
+                Self::Lock => write!(f, "lock"),
+                Self::Rollback => write!(f, "rollback"),
+                Self::SourceRename => write!(f, "sourceRename"),
+                Self::TargetRename => write!(f, "targetRename"),
+                Self::Property => write!(f, "property"),
+                Self::All => write!(f, "all"),
+                Self::DeleteSourceRename => write!(f, "delete, sourceRename"),
+                Self::EditRename => write!(f, "edit, rename"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ChangeCountDictionary {}
@@ -665,6 +688,16 @@ pub mod comment {
         #[serde(rename = "system")]
         System,
     }
+    impl std::fmt::Display for CommentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Text => write!(f, "text"),
+                Self::CodeChange => write!(f, "codeChange"),
+                Self::System => write!(f, "system"),
+            }
+        }
+    }
 }
 #[doc = "Comment iteration context is used to identify which diff was being viewed when the thread was created."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -794,6 +827,19 @@ pub mod comment_thread {
         ByDesign,
         #[serde(rename = "pending")]
         Pending,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Active => write!(f, "active"),
+                Self::Fixed => write!(f, "fixed"),
+                Self::WontFix => write!(f, "wontFix"),
+                Self::Closed => write!(f, "closed"),
+                Self::ByDesign => write!(f, "byDesign"),
+                Self::Pending => write!(f, "pending"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1088,6 +1134,17 @@ pub mod git_async_ref_operation {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Queued => write!(f, "queued"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
 }
 #[doc = "Information about the progress of a cherry pick or revert operation."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1151,6 +1208,23 @@ pub mod git_async_ref_operation_detail {
         Other,
         #[serde(rename = "emptyCommitterSignature")]
         EmptyCommitterSignature,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::InvalidRefName => write!(f, "invalidRefName"),
+                Self::RefNameConflict => write!(f, "refNameConflict"),
+                Self::CreateBranchPermissionRequired => write!(f, "createBranchPermissionRequired"),
+                Self::WritePermissionRequired => write!(f, "writePermissionRequired"),
+                Self::TargetBranchDeleted => write!(f, "targetBranchDeleted"),
+                Self::GitObjectTooLarge => write!(f, "gitObjectTooLarge"),
+                Self::OperationIndentityNotFound => write!(f, "operationIndentityNotFound"),
+                Self::AsyncOperationNotFound => write!(f, "asyncOperationNotFound"),
+                Self::Other => write!(f, "other"),
+                Self::EmptyCommitterSignature => write!(f, "emptyCommitterSignature"),
+            }
+        }
     }
 }
 #[doc = "Parameters that are provided in the request body when requesting to cherry pick or revert."]
@@ -1248,6 +1322,15 @@ pub mod git_base_version_descriptor {
         #[serde(rename = "firstParent")]
         FirstParent,
     }
+    impl std::fmt::Display for BaseVersionOptions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::PreviousChange => write!(f, "previousChange"),
+                Self::FirstParent => write!(f, "firstParent"),
+            }
+        }
+    }
     #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum BaseVersionType {
@@ -1257,6 +1340,15 @@ pub mod git_base_version_descriptor {
         Tag,
         #[serde(rename = "commit")]
         Commit,
+    }
+    impl std::fmt::Display for BaseVersionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Branch => write!(f, "branch"),
+                Self::Tag => write!(f, "tag"),
+                Self::Commit => write!(f, "commit"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1700,6 +1792,27 @@ pub mod git_conflict {
         #[serde(rename = "renameRename")]
         RenameRename,
     }
+    impl std::fmt::Display for ConflictType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::AddAdd => write!(f, "addAdd"),
+                Self::AddRename => write!(f, "addRename"),
+                Self::DeleteEdit => write!(f, "deleteEdit"),
+                Self::DeleteRename => write!(f, "deleteRename"),
+                Self::DirectoryFile => write!(f, "directoryFile"),
+                Self::DirectoryChild => write!(f, "directoryChild"),
+                Self::EditDelete => write!(f, "editDelete"),
+                Self::EditEdit => write!(f, "editEdit"),
+                Self::FileDirectory => write!(f, "fileDirectory"),
+                Self::Rename1to2 => write!(f, "rename1to2"),
+                Self::Rename2to1 => write!(f, "rename2to1"),
+                Self::RenameAdd => write!(f, "renameAdd"),
+                Self::RenameDelete => write!(f, "renameDelete"),
+                Self::RenameRename => write!(f, "renameRename"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum ResolutionError {
         #[serde(rename = "none")]
@@ -1717,6 +1830,19 @@ pub mod git_conflict {
         #[serde(rename = "otherError")]
         OtherError,
     }
+    impl std::fmt::Display for ResolutionError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::MergeContentNotFound => write!(f, "mergeContentNotFound"),
+                Self::PathInUse => write!(f, "pathInUse"),
+                Self::InvalidPath => write!(f, "invalidPath"),
+                Self::UnknownAction => write!(f, "unknownAction"),
+                Self::UnknownMergeType => write!(f, "unknownMergeType"),
+                Self::OtherError => write!(f, "otherError"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum ResolutionStatus {
         #[serde(rename = "unresolved")]
@@ -1725,6 +1851,15 @@ pub mod git_conflict {
         PartiallyResolved,
         #[serde(rename = "resolved")]
         Resolved,
+    }
+    impl std::fmt::Display for ResolutionStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unresolved => write!(f, "unresolved"),
+                Self::PartiallyResolved => write!(f, "partiallyResolved"),
+                Self::Resolved => write!(f, "resolved"),
+            }
+        }
     }
 }
 #[doc = "Data object for AddAdd conflict"]
@@ -2163,6 +2298,17 @@ pub mod git_conflict_update_result {
         #[serde(rename = "notFound")]
         NotFound,
     }
+    impl std::fmt::Display for UpdateStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::BadRequest => write!(f, "badRequest"),
+                Self::InvalidResolution => write!(f, "invalidResolution"),
+                Self::UnsupportedConflictType => write!(f, "unsupportedConflictType"),
+                Self::NotFound => write!(f, "notFound"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitDeletedRepository {
@@ -2330,6 +2476,17 @@ pub mod git_fork_sync_request {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Queued => write!(f, "queued"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitForkSyncRequestList {
@@ -2466,6 +2623,17 @@ pub mod git_import_request {
         Failed,
         #[serde(rename = "abandoned")]
         Abandoned,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Queued => write!(f, "queued"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2653,6 +2821,20 @@ pub mod git_item {
         #[serde(rename = "refDelta")]
         RefDelta,
     }
+    impl std::fmt::Display for GitObjectType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Bad => write!(f, "bad"),
+                Self::Commit => write!(f, "commit"),
+                Self::Tree => write!(f, "tree"),
+                Self::Blob => write!(f, "blob"),
+                Self::Tag => write!(f, "tag"),
+                Self::Ext2 => write!(f, "ext2"),
+                Self::OfsDelta => write!(f, "ofsDelta"),
+                Self::RefDelta => write!(f, "refDelta"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitItemDescriptor {
@@ -2703,6 +2885,16 @@ pub mod git_item_descriptor {
         #[serde(rename = "full")]
         Full,
     }
+    impl std::fmt::Display for RecursionLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::OneLevel => write!(f, "oneLevel"),
+                Self::OneLevelPlusNestedEmptyFolders => write!(f, "oneLevelPlusNestedEmptyFolders"),
+                Self::Full => write!(f, "full"),
+            }
+        }
+    }
     #[doc = "Version modifiers (e.g. previous)"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum VersionOptions {
@@ -2713,6 +2905,15 @@ pub mod git_item_descriptor {
         #[serde(rename = "firstParent")]
         FirstParent,
     }
+    impl std::fmt::Display for VersionOptions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::PreviousChange => write!(f, "previousChange"),
+                Self::FirstParent => write!(f, "firstParent"),
+            }
+        }
+    }
     #[doc = "How to interpret version (branch,tag,commit)"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum VersionType {
@@ -2722,6 +2923,15 @@ pub mod git_item_descriptor {
         Tag,
         #[serde(rename = "commit")]
         Commit,
+    }
+    impl std::fmt::Display for VersionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Branch => write!(f, "branch"),
+                Self::Tag => write!(f, "tag"),
+                Self::Commit => write!(f, "commit"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2884,6 +3094,17 @@ pub mod git_merge {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Queued => write!(f, "queued"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
 }
 #[doc = "Status information about a requested merge operation."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2990,6 +3211,20 @@ pub mod git_object {
         #[serde(rename = "refDelta")]
         RefDelta,
     }
+    impl std::fmt::Display for ObjectType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Bad => write!(f, "bad"),
+                Self::Commit => write!(f, "commit"),
+                Self::Tree => write!(f, "tree"),
+                Self::Blob => write!(f, "blob"),
+                Self::Tag => write!(f, "tag"),
+                Self::Ext2 => write!(f, "ext2"),
+                Self::OfsDelta => write!(f, "ofsDelta"),
+                Self::RefDelta => write!(f, "refDelta"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitPathAction {
@@ -3035,6 +3270,17 @@ pub mod git_path_action {
         Add,
         #[serde(rename = "rename")]
         Rename,
+    }
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Edit => write!(f, "edit"),
+                Self::Delete => write!(f, "delete"),
+                Self::Add => write!(f, "add"),
+                Self::Rename => write!(f, "rename"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3319,6 +3565,16 @@ pub mod git_pull_request {
         #[serde(rename = "objectTooLarge")]
         ObjectTooLarge,
     }
+    impl std::fmt::Display for MergeFailureType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Unknown => write!(f, "unknown"),
+                Self::CaseSensitive => write!(f, "caseSensitive"),
+                Self::ObjectTooLarge => write!(f, "objectTooLarge"),
+            }
+        }
+    }
     #[doc = "The current status of the pull request merge."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum MergeStatus {
@@ -3335,6 +3591,18 @@ pub mod git_pull_request {
         #[serde(rename = "failure")]
         Failure,
     }
+    impl std::fmt::Display for MergeStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NotSet => write!(f, "notSet"),
+                Self::Queued => write!(f, "queued"),
+                Self::Conflicts => write!(f, "conflicts"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::RejectedByPolicy => write!(f, "rejectedByPolicy"),
+                Self::Failure => write!(f, "failure"),
+            }
+        }
+    }
     #[doc = "The status of the pull request."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -3348,6 +3616,17 @@ pub mod git_pull_request {
         Completed,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NotSet => write!(f, "notSet"),
+                Self::Active => write!(f, "active"),
+                Self::Abandoned => write!(f, "abandoned"),
+                Self::Completed => write!(f, "completed"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[doc = "Change made in a pull request."]
@@ -3521,6 +3800,16 @@ pub mod git_pull_request_completion_options {
         Rebase,
         #[serde(rename = "rebaseMerge")]
         RebaseMerge,
+    }
+    impl std::fmt::Display for MergeStrategy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NoFastForward => write!(f, "noFastForward"),
+                Self::Squash => write!(f, "squash"),
+                Self::Rebase => write!(f, "rebase"),
+                Self::RebaseMerge => write!(f, "rebaseMerge"),
+            }
+        }
     }
 }
 #[doc = "Pull Request create options"]
@@ -3711,6 +4000,19 @@ pub mod git_pull_request_iteration {
         #[serde(rename = "resolveConflicts")]
         ResolveConflicts,
     }
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Push => write!(f, "push"),
+                Self::ForcePush => write!(f, "forcePush"),
+                Self::Create => write!(f, "create"),
+                Self::Rebase => write!(f, "rebase"),
+                Self::Unknown => write!(f, "unknown"),
+                Self::Retarget => write!(f, "retarget"),
+                Self::ResolveConflicts => write!(f, "resolveConflicts"),
+            }
+        }
+    }
 }
 #[doc = "Collection of changes made in a pull request."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3850,6 +4152,15 @@ pub mod git_pull_request_query_input {
         #[serde(rename = "commit")]
         Commit,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NotSet => write!(f, "notSet"),
+                Self::LastMergeCommit => write!(f, "lastMergeCommit"),
+                Self::Commit => write!(f, "commit"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitPullRequestReviewFileContentInfo {
@@ -3958,6 +4269,14 @@ pub mod git_pull_request_search_criteria {
         #[serde(rename = "closed")]
         Closed,
     }
+    impl std::fmt::Display for QueryTimeRangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Created => write!(f, "created"),
+                Self::Closed => write!(f, "closed"),
+            }
+        }
+    }
     #[doc = "If set, search for pull requests that are in this state. Defaults to Active if unset."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -3971,6 +4290,17 @@ pub mod git_pull_request_search_criteria {
         Completed,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NotSet => write!(f, "notSet"),
+                Self::Active => write!(f, "active"),
+                Self::Abandoned => write!(f, "abandoned"),
+                Self::Completed => write!(f, "completed"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[doc = "This class contains the metadata of a service/extension posting pull request status. Status can be associated with a pull request or an iteration."]
@@ -4326,6 +4656,16 @@ pub mod git_query_commits_criteria {
         #[serde(rename = "fullHistorySimplifyMerges")]
         FullHistorySimplifyMerges,
     }
+    impl std::fmt::Display for HistoryMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::SimplifiedHistory => write!(f, "simplifiedHistory"),
+                Self::FirstParent => write!(f, "firstParent"),
+                Self::FullHistory => write!(f, "fullHistory"),
+                Self::FullHistorySimplifyMerges => write!(f, "fullHistorySimplifyMerges"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitQueryRefsCriteria {
@@ -4369,6 +4709,15 @@ pub mod git_query_refs_criteria {
         StartsWith,
         #[serde(rename = "contains")]
         Contains,
+    }
+    impl std::fmt::Display for SearchType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Exact => write!(f, "exact"),
+                Self::StartsWith => write!(f, "startsWith"),
+                Self::Contains => write!(f, "contains"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4471,6 +4820,15 @@ pub mod git_ref_favorite {
         Folder,
         #[serde(rename = "ref")]
         Ref,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Invalid => write!(f, "invalid"),
+                Self::Folder => write!(f, "folder"),
+                Self::Ref => write!(f, "ref"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4631,6 +4989,28 @@ pub mod git_ref_update_result {
         SucceededNonExistentRef,
         #[serde(rename = "succeededCorruptRef")]
         SucceededCorruptRef,
+    }
+    impl std::fmt::Display for UpdateStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::ForcePushRequired => write!(f, "forcePushRequired"),
+                Self::StaleOldObjectId => write!(f, "staleOldObjectId"),
+                Self::InvalidRefName => write!(f, "invalidRefName"),
+                Self::Unprocessed => write!(f, "unprocessed"),
+                Self::UnresolvableToCommit => write!(f, "unresolvableToCommit"),
+                Self::WritePermissionRequired => write!(f, "writePermissionRequired"),
+                Self::ManageNotePermissionRequired => write!(f, "manageNotePermissionRequired"),
+                Self::CreateBranchPermissionRequired => write!(f, "createBranchPermissionRequired"),
+                Self::CreateTagPermissionRequired => write!(f, "createTagPermissionRequired"),
+                Self::RejectedByPlugin => write!(f, "rejectedByPlugin"),
+                Self::Locked => write!(f, "locked"),
+                Self::RefNameConflict => write!(f, "refNameConflict"),
+                Self::RejectedByPolicy => write!(f, "rejectedByPolicy"),
+                Self::SucceededNonExistentRef => write!(f, "succeededNonExistentRef"),
+                Self::SucceededCorruptRef => write!(f, "succeededCorruptRef"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4886,6 +5266,17 @@ pub mod git_resolution_merge_content {
         #[serde(rename = "userMerged")]
         UserMerged,
     }
+    impl std::fmt::Display for MergeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undecided => write!(f, "undecided"),
+                Self::TakeSourceContent => write!(f, "takeSourceContent"),
+                Self::TakeTargetContent => write!(f, "takeTargetContent"),
+                Self::AutoMerged => write!(f, "autoMerged"),
+                Self::UserMerged => write!(f, "userMerged"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitResolutionPathConflict {
@@ -4920,6 +5311,17 @@ pub mod git_resolution_path_conflict {
         #[serde(rename = "keepTargetDeleteSource")]
         KeepTargetDeleteSource,
     }
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undecided => write!(f, "undecided"),
+                Self::KeepSourceRenameTarget => write!(f, "keepSourceRenameTarget"),
+                Self::KeepSourceDeleteTarget => write!(f, "keepSourceDeleteTarget"),
+                Self::KeepTargetRenameSource => write!(f, "keepTargetRenameSource"),
+                Self::KeepTargetDeleteSource => write!(f, "keepTargetDeleteSource"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GitResolutionPickOneAction {
@@ -4943,6 +5345,15 @@ pub mod git_resolution_pick_one_action {
         PickSourceAction,
         #[serde(rename = "pickTargetAction")]
         PickTargetAction,
+    }
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undecided => write!(f, "undecided"),
+                Self::PickSourceAction => write!(f, "pickSourceAction"),
+                Self::PickTargetAction => write!(f, "pickTargetAction"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4969,6 +5380,16 @@ pub mod git_resolution_rename1to2 {
         KeepTargetPath,
         #[serde(rename = "keepBothFiles")]
         KeepBothFiles,
+    }
+    impl std::fmt::Display for Action {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undecided => write!(f, "undecided"),
+                Self::KeepSourcePath => write!(f, "keepSourcePath"),
+                Self::KeepTargetPath => write!(f, "keepTargetPath"),
+                Self::KeepBothFiles => write!(f, "keepBothFiles"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5045,6 +5466,18 @@ pub mod git_status {
         Error,
         #[serde(rename = "notApplicable")]
         NotApplicable,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NotSet => write!(f, "notSet"),
+                Self::Pending => write!(f, "pending"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Error => write!(f, "error"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+            }
+        }
     }
 }
 #[doc = "Status context that uniquely identifies the status."]
@@ -5152,6 +5585,15 @@ pub mod git_target_version_descriptor {
         #[serde(rename = "firstParent")]
         FirstParent,
     }
+    impl std::fmt::Display for TargetVersionOptions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::PreviousChange => write!(f, "previousChange"),
+                Self::FirstParent => write!(f, "firstParent"),
+            }
+        }
+    }
     #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum TargetVersionType {
@@ -5161,6 +5603,15 @@ pub mod git_target_version_descriptor {
         Tag,
         #[serde(rename = "commit")]
         Commit,
+    }
+    impl std::fmt::Display for TargetVersionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Branch => write!(f, "branch"),
+                Self::Tag => write!(f, "tag"),
+                Self::Commit => write!(f, "commit"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5285,6 +5736,27 @@ pub mod git_tree_diff_entry {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for ChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Add => write!(f, "add"),
+                Self::Edit => write!(f, "edit"),
+                Self::Encoding => write!(f, "encoding"),
+                Self::Rename => write!(f, "rename"),
+                Self::Delete => write!(f, "delete"),
+                Self::Undelete => write!(f, "undelete"),
+                Self::Branch => write!(f, "branch"),
+                Self::Merge => write!(f, "merge"),
+                Self::Lock => write!(f, "lock"),
+                Self::Rollback => write!(f, "rollback"),
+                Self::SourceRename => write!(f, "sourceRename"),
+                Self::TargetRename => write!(f, "targetRename"),
+                Self::Property => write!(f, "property"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[doc = "Object type of the tree entry. Blob, Tree or Commit(\"submodule\")"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum ObjectType {
@@ -5304,6 +5776,20 @@ pub mod git_tree_diff_entry {
         OfsDelta,
         #[serde(rename = "refDelta")]
         RefDelta,
+    }
+    impl std::fmt::Display for ObjectType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Bad => write!(f, "bad"),
+                Self::Commit => write!(f, "commit"),
+                Self::Tree => write!(f, "tree"),
+                Self::Blob => write!(f, "blob"),
+                Self::Tag => write!(f, "tag"),
+                Self::Ext2 => write!(f, "ext2"),
+                Self::OfsDelta => write!(f, "ofsDelta"),
+                Self::RefDelta => write!(f, "refDelta"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5379,6 +5865,20 @@ pub mod git_tree_entry_ref {
         OfsDelta,
         #[serde(rename = "refDelta")]
         RefDelta,
+    }
+    impl std::fmt::Display for GitObjectType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Bad => write!(f, "bad"),
+                Self::Commit => write!(f, "commit"),
+                Self::Tree => write!(f, "tree"),
+                Self::Blob => write!(f, "blob"),
+                Self::Tag => write!(f, "tag"),
+                Self::Ext2 => write!(f, "ext2"),
+                Self::OfsDelta => write!(f, "ofsDelta"),
+                Self::RefDelta => write!(f, "refDelta"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5471,6 +5971,15 @@ pub mod git_version_descriptor {
         #[serde(rename = "firstParent")]
         FirstParent,
     }
+    impl std::fmt::Display for VersionOptions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::PreviousChange => write!(f, "previousChange"),
+                Self::FirstParent => write!(f, "firstParent"),
+            }
+        }
+    }
     #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum VersionType {
@@ -5480,6 +5989,15 @@ pub mod git_version_descriptor {
         Tag,
         #[serde(rename = "commit")]
         Commit,
+    }
+    impl std::fmt::Display for VersionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Branch => write!(f, "branch"),
+                Self::Tag => write!(f, "tag"),
+                Self::Commit => write!(f, "commit"),
+            }
+        }
     }
 }
 #[doc = "Globally unique key for a repository."]
@@ -5595,6 +6113,27 @@ pub mod history_entry {
         Property,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for ItemChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Add => write!(f, "add"),
+                Self::Edit => write!(f, "edit"),
+                Self::Encoding => write!(f, "encoding"),
+                Self::Rename => write!(f, "rename"),
+                Self::Delete => write!(f, "delete"),
+                Self::Undelete => write!(f, "undelete"),
+                Self::Branch => write!(f, "branch"),
+                Self::Merge => write!(f, "merge"),
+                Self::Lock => write!(f, "lock"),
+                Self::Rollback => write!(f, "rollback"),
+                Self::SourceRename => write!(f, "sourceRename"),
+                Self::TargetRename => write!(f, "targetRename"),
+                Self::Property => write!(f, "property"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[doc = "Identity id"]
@@ -5857,6 +6396,14 @@ pub mod item_content {
         #[serde(rename = "base64Encoded")]
         Base64Encoded,
     }
+    impl std::fmt::Display for ContentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::RawText => write!(f, "rawText"),
+                Self::Base64Encoded => write!(f, "base64Encoded"),
+            }
+        }
+    }
 }
 #[doc = "Optional details to include when returning an item model"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5894,6 +6441,16 @@ pub mod item_details_options {
         OneLevelPlusNestedEmptyFolders,
         #[serde(rename = "full")]
         Full,
+    }
+    impl std::fmt::Display for RecursionLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::OneLevel => write!(f, "oneLevel"),
+                Self::OneLevelPlusNestedEmptyFolders => write!(f, "oneLevelPlusNestedEmptyFolders"),
+                Self::Full => write!(f, "full"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5970,6 +6527,18 @@ pub mod json_patch_operation {
         #[serde(rename = "test")]
         Test,
     }
+    impl std::fmt::Display for Op {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Remove => write!(f, "remove"),
+                Self::Replace => write!(f, "replace"),
+                Self::Move => write!(f, "move"),
+                Self::Copy => write!(f, "copy"),
+                Self::Test => write!(f, "test"),
+            }
+        }
+    }
 }
 #[doc = "Real time event (SignalR) for updated labels on a pull request"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6039,6 +6608,16 @@ pub mod line_diff_block {
         Delete,
         #[serde(rename = "edit")]
         Edit,
+    }
+    impl std::fmt::Display for ChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Add => write!(f, "add"),
+                Self::Delete => write!(f, "delete"),
+                Self::Edit => write!(f, "edit"),
+            }
+        }
     }
 }
 #[doc = "Link URL"]
@@ -6226,6 +6805,16 @@ pub enum PullRequestStatus {
     Abandoned,
     #[serde(rename = "completed")]
     Completed,
+}
+impl std::fmt::Display for PullRequestStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotSet => write!(f, "notSet"),
+            Self::Active => write!(f, "active"),
+            Self::Abandoned => write!(f, "abandoned"),
+            Self::Completed => write!(f, "completed"),
+        }
+    }
 }
 #[doc = "Initial config contract sent to extensions creating tabs on the pull request page"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6518,6 +7107,27 @@ pub mod supported_ide {
         #[serde(rename = "webStorm")]
         WebStorm,
     }
+    impl std::fmt::Display for IdeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::AndroidStudio => write!(f, "androidStudio"),
+                Self::AppCode => write!(f, "appCode"),
+                Self::CLion => write!(f, "cLion"),
+                Self::DataGrip => write!(f, "dataGrip"),
+                Self::Eclipse => write!(f, "eclipse"),
+                Self::IntelliJ => write!(f, "intelliJ"),
+                Self::Mps => write!(f, "mps"),
+                Self::PhpStorm => write!(f, "phpStorm"),
+                Self::PyCharm => write!(f, "pyCharm"),
+                Self::RubyMine => write!(f, "rubyMine"),
+                Self::Tower => write!(f, "tower"),
+                Self::VisualStudio => write!(f, "visualStudio"),
+                Self::VsCode => write!(f, "vsCode"),
+                Self::WebStorm => write!(f, "webStorm"),
+            }
+        }
+    }
 }
 #[doc = "Reference object for a TeamProjectCollection."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6617,6 +7227,19 @@ pub mod team_project_reference {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deleting => write!(f, "deleting"),
+                Self::New => write!(f, "new"),
+                Self::WellFormed => write!(f, "wellFormed"),
+                Self::CreatePending => write!(f, "createPending"),
+                Self::All => write!(f, "all"),
+                Self::Unchanged => write!(f, "unchanged"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
     #[doc = "Project visibility."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Visibility {
@@ -6628,6 +7251,16 @@ pub mod team_project_reference {
         Organization,
         #[serde(rename = "unchanged")]
         Unchanged,
+    }
+    impl std::fmt::Display for Visibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+                Self::Organization => write!(f, "organization"),
+                Self::Unchanged => write!(f, "unchanged"),
+            }
+        }
     }
 }
 #[doc = "Class representing a branch object."]
@@ -7071,6 +7704,16 @@ pub mod tfvc_item_descriptor {
         #[serde(rename = "full")]
         Full,
     }
+    impl std::fmt::Display for RecursionLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::OneLevel => write!(f, "oneLevel"),
+                Self::OneLevelPlusNestedEmptyFolders => write!(f, "oneLevelPlusNestedEmptyFolders"),
+                Self::Full => write!(f, "full"),
+            }
+        }
+    }
     #[doc = "Defaults to None."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum VersionOption {
@@ -7080,6 +7723,15 @@ pub mod tfvc_item_descriptor {
         Previous,
         #[serde(rename = "useRename")]
         UseRename,
+    }
+    impl std::fmt::Display for VersionOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Previous => write!(f, "previous"),
+                Self::UseRename => write!(f, "useRename"),
+            }
+        }
     }
     #[doc = "Defaults to Latest."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -7100,6 +7752,20 @@ pub mod tfvc_item_descriptor {
         Tip,
         #[serde(rename = "mergeSource")]
         MergeSource,
+    }
+    impl std::fmt::Display for VersionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Changeset => write!(f, "changeset"),
+                Self::Shelveset => write!(f, "shelveset"),
+                Self::Change => write!(f, "change"),
+                Self::Date => write!(f, "date"),
+                Self::Latest => write!(f, "latest"),
+                Self::Tip => write!(f, "tip"),
+                Self::MergeSource => write!(f, "mergeSource"),
+            }
+        }
     }
 }
 #[doc = "Metadata for an item including the previous hash value for files."]
@@ -7531,6 +8197,15 @@ pub mod tfvc_version_descriptor {
         #[serde(rename = "useRename")]
         UseRename,
     }
+    impl std::fmt::Display for VersionOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Previous => write!(f, "previous"),
+                Self::UseRename => write!(f, "useRename"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum VersionType {
         #[serde(rename = "none")]
@@ -7549,6 +8224,20 @@ pub mod tfvc_version_descriptor {
         Tip,
         #[serde(rename = "mergeSource")]
         MergeSource,
+    }
+    impl std::fmt::Display for VersionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Changeset => write!(f, "changeset"),
+                Self::Shelveset => write!(f, "shelveset"),
+                Self::Change => write!(f, "change"),
+                Self::Date => write!(f, "date"),
+                Self::Latest => write!(f, "latest"),
+                Self::Tip => write!(f, "tip"),
+                Self::MergeSource => write!(f, "mergeSource"),
+            }
+        }
     }
 }
 #[doc = "Real time event (SignalR) for a title/description update on a pull request"]
@@ -7592,6 +8281,14 @@ pub mod update_refs_request {
         #[serde(rename = "allOrNone")]
         AllOrNone,
     }
+    impl std::fmt::Display for UpdateMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::BestEffort => write!(f, "bestEffort"),
+                Self::AllOrNone => write!(f, "allOrNone"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct VersionControlProjectInfo {
@@ -7630,6 +8327,36 @@ pub mod version_control_project_info {
         Tfvc,
         #[serde(rename = "git")]
         Git,
+    }
+    impl std::fmt::Display for DefaultSourceControlType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Tfvc => write!(f, "tfvc"),
+                Self::Git => write!(f, "git"),
+            }
+        }
+    }
+}
+#[doc = "The recursion level for a request."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum VersionControlRecursionType {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "oneLevel")]
+    OneLevel,
+    #[serde(rename = "oneLevelPlusNestedEmptyFolders")]
+    OneLevelPlusNestedEmptyFolders,
+    #[serde(rename = "full")]
+    Full,
+}
+impl std::fmt::Display for VersionControlRecursionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::OneLevel => write!(f, "oneLevel"),
+            Self::OneLevelPlusNestedEmptyFolders => write!(f, "oneLevelPlusNestedEmptyFolders"),
+            Self::Full => write!(f, "full"),
+        }
     }
 }
 #[doc = "A particular revision for a policy configuration."]

--- a/azure_devops_rust_api/src/graph/mod.rs
+++ b/azure_devops_rust_api/src/graph/mod.rs
@@ -1067,12 +1067,15 @@ pub mod memberships {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) subject_descriptor: String,
-            pub(crate) direction: Option<String>,
+            pub(crate) direction: Option<models::GraphTraversalDirection>,
             pub(crate) depth: Option<i32>,
         }
         impl RequestBuilder {
             #[doc = "Defaults to Up."]
-            pub fn direction(mut self, direction: impl Into<String>) -> Self {
+            pub fn direction(
+                mut self,
+                direction: impl Into<models::GraphTraversalDirection>,
+            ) -> Self {
                 self.direction = Some(direction.into());
                 self
             }
@@ -1106,7 +1109,7 @@ pub mod memberships {
                         if let Some(direction) = &this.direction {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("direction", direction);
+                                .append_pair("direction", &direction.to_string());
                         }
                         if let Some(depth) = &this.depth {
                             req.url_mut()
@@ -2730,11 +2733,11 @@ pub mod avatars {
             pub(crate) client: super::super::Client,
             pub(crate) subject_descriptor: String,
             pub(crate) organization: String,
-            pub(crate) size: Option<String>,
+            pub(crate) size: Option<models::AvatarSize>,
             pub(crate) format: Option<String>,
         }
         impl RequestBuilder {
-            pub fn size(mut self, size: impl Into<String>) -> Self {
+            pub fn size(mut self, size: impl Into<models::AvatarSize>) -> Self {
                 self.size = Some(size.into());
                 self
             }
@@ -2765,7 +2768,9 @@ pub mod avatars {
                             );
                         }
                         if let Some(size) = &this.size {
-                            req.url_mut().query_pairs_mut().append_pair("size", size);
+                            req.url_mut()
+                                .query_pairs_mut()
+                                .append_pair("size", &size.to_string());
                         }
                         if let Some(format) = &this.format {
                             req.url_mut()

--- a/azure_devops_rust_api/src/graph/models.rs
+++ b/azure_devops_rust_api/src/graph/models.rs
@@ -82,6 +82,24 @@ pub mod avatar {
         }
     }
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum AvatarSize {
+    #[serde(rename = "small")]
+    Small,
+    #[serde(rename = "medium")]
+    Medium,
+    #[serde(rename = "large")]
+    Large,
+}
+impl std::fmt::Display for AvatarSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Small => write!(f, "small"),
+            Self::Medium => write!(f, "medium"),
+            Self::Large => write!(f, "large"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GraphCachePolicies {
     #[doc = "Size of the cache"]
@@ -781,6 +799,25 @@ pub struct GraphSystemSubject {
 impl GraphSystemSubject {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Defaults to Up."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GraphTraversalDirection {
+    #[serde(rename = "unknown")]
+    Unknown,
+    #[serde(rename = "down")]
+    Down,
+    #[serde(rename = "up")]
+    Up,
+}
+impl std::fmt::Display for GraphTraversalDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unknown => write!(f, "unknown"),
+            Self::Down => write!(f, "down"),
+            Self::Up => write!(f, "up"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/graph/models.rs
+++ b/azure_devops_rust_api/src/graph/models.rs
@@ -72,6 +72,15 @@ pub mod avatar {
         #[serde(rename = "large")]
         Large,
     }
+    impl std::fmt::Display for Size {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Small => write!(f, "small"),
+                Self::Medium => write!(f, "medium"),
+                Self::Large => write!(f, "large"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GraphCachePolicies {
@@ -473,6 +482,15 @@ pub mod graph_scope {
         #[serde(rename = "teamProject")]
         TeamProject,
     }
+    impl std::fmt::Display for ScopeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Generic => write!(f, "generic"),
+                Self::ServiceHost => write!(f, "serviceHost"),
+                Self::TeamProject => write!(f, "teamProject"),
+            }
+        }
+    }
 }
 #[doc = "This type is the subset of fields that can be provided by the user to create a Vsts scope. Scope creation is currently limited to internal back-compat scenarios. End users that attempt to create a scope with this API will fail."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -524,6 +542,15 @@ pub mod graph_scope_creation_context {
         ServiceHost,
         #[serde(rename = "teamProject")]
         TeamProject,
+    }
+    impl std::fmt::Display for ScopeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Generic => write!(f, "generic"),
+                Self::ServiceHost => write!(f, "serviceHost"),
+                Self::TeamProject => write!(f, "teamProject"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -998,6 +1025,18 @@ pub mod json_patch_operation {
         Copy,
         #[serde(rename = "test")]
         Test,
+    }
+    impl std::fmt::Display for Op {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Remove => write!(f, "remove"),
+                Self::Replace => write!(f, "replace"),
+                Self::Move => write!(f, "move"),
+                Self::Copy => write!(f, "copy"),
+                Self::Test => write!(f, "test"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/hooks/mod.rs
+++ b/azure_devops_rust_api/src/hooks/mod.rs
@@ -857,8 +857,8 @@ pub mod notifications {
             pub(crate) organization: String,
             pub(crate) subscription_id: String,
             pub(crate) max_results: Option<i32>,
-            pub(crate) status: Option<String>,
-            pub(crate) result: Option<String>,
+            pub(crate) status: Option<models::NotificationStatus>,
+            pub(crate) result: Option<models::NotificationResult>,
         }
         impl RequestBuilder {
             #[doc = "Maximum number of notifications to return. Default is **100**."]
@@ -867,12 +867,12 @@ pub mod notifications {
                 self
             }
             #[doc = "Get only notifications with this status."]
-            pub fn status(mut self, status: impl Into<String>) -> Self {
+            pub fn status(mut self, status: impl Into<models::NotificationStatus>) -> Self {
                 self.status = Some(status.into());
                 self
             }
             #[doc = "Get only notifications with this result type."]
-            pub fn result(mut self, result: impl Into<String>) -> Self {
+            pub fn result(mut self, result: impl Into<models::NotificationResult>) -> Self {
                 self.result = Some(result.into());
                 self
             }
@@ -906,12 +906,12 @@ pub mod notifications {
                         if let Some(status) = &this.status {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("status", status);
+                                .append_pair("status", &status.to_string());
                         }
                         if let Some(result) = &this.result {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("result", result);
+                                .append_pair("result", &result.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/hooks/models.rs
+++ b/azure_devops_rust_api/src/hooks/models.rs
@@ -1019,6 +1019,28 @@ impl NotificationList {
         Self::default()
     }
 }
+#[doc = "Get only notifications with this result type."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum NotificationResult {
+    #[serde(rename = "pending")]
+    Pending,
+    #[serde(rename = "succeeded")]
+    Succeeded,
+    #[serde(rename = "failed")]
+    Failed,
+    #[serde(rename = "filtered")]
+    Filtered,
+}
+impl std::fmt::Display for NotificationResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(f, "pending"),
+            Self::Succeeded => write!(f, "succeeded"),
+            Self::Failed => write!(f, "failed"),
+            Self::Filtered => write!(f, "filtered"),
+        }
+    }
+}
 #[doc = "Summary of a particular result and count."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct NotificationResultsSummaryDetail {
@@ -1060,6 +1082,28 @@ pub mod notification_results_summary_detail {
                 Self::Failed => write!(f, "failed"),
                 Self::Filtered => write!(f, "filtered"),
             }
+        }
+    }
+}
+#[doc = "Get only notifications with this status."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum NotificationStatus {
+    #[serde(rename = "queued")]
+    Queued,
+    #[serde(rename = "processing")]
+    Processing,
+    #[serde(rename = "requestInProgress")]
+    RequestInProgress,
+    #[serde(rename = "completed")]
+    Completed,
+}
+impl std::fmt::Display for NotificationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Queued => write!(f, "queued"),
+            Self::Processing => write!(f, "processing"),
+            Self::RequestInProgress => write!(f, "requestInProgress"),
+            Self::Completed => write!(f, "completed"),
         }
     }
 }

--- a/azure_devops_rust_api/src/hooks/models.rs
+++ b/azure_devops_rust_api/src/hooks/models.rs
@@ -80,6 +80,15 @@ pub mod consumer {
         #[serde(rename = "external")]
         External,
     }
+    impl std::fmt::Display for AuthenticationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::OAuth => write!(f, "oAuth"),
+                Self::External => write!(f, "external"),
+            }
+        }
+    }
 }
 #[doc = "Defines the data contract of a consumer action."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -517,6 +526,19 @@ pub mod input_descriptor {
         #[serde(rename = "textArea")]
         TextArea,
     }
+    impl std::fmt::Display for InputMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::TextBox => write!(f, "textBox"),
+                Self::PasswordBox => write!(f, "passwordBox"),
+                Self::Combo => write!(f, "combo"),
+                Self::RadioButtons => write!(f, "radioButtons"),
+                Self::CheckBox => write!(f, "checkBox"),
+                Self::TextArea => write!(f, "textArea"),
+            }
+        }
+    }
 }
 #[doc = "Defines a filter for subscription inputs. The filter matches a set of inputs if any (one or more) of the groups evaluates to true."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -572,6 +594,14 @@ pub mod input_filter_condition {
         Equals,
         #[serde(rename = "notEquals")]
         NotEquals,
+    }
+    impl std::fmt::Display for Operator {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Equals => write!(f, "equals"),
+                Self::NotEquals => write!(f, "notEquals"),
+            }
+        }
     }
 }
 #[doc = "Describes what values are valid for a subscription input"]
@@ -632,6 +662,18 @@ pub mod input_validation {
         Guid,
         #[serde(rename = "uri")]
         Uri,
+    }
+    impl std::fmt::Display for DataType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::String => write!(f, "string"),
+                Self::Number => write!(f, "number"),
+                Self::Boolean => write!(f, "boolean"),
+                Self::Guid => write!(f, "guid"),
+                Self::Uri => write!(f, "uri"),
+            }
+        }
     }
 }
 #[doc = "Information about a single value for an input"]
@@ -812,6 +854,16 @@ pub mod notification {
         #[serde(rename = "filtered")]
         Filtered,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Pending => write!(f, "pending"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Filtered => write!(f, "filtered"),
+            }
+        }
+    }
     #[doc = "Status of the notification"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -823,6 +875,16 @@ pub mod notification {
         RequestInProgress,
         #[serde(rename = "completed")]
         Completed,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Queued => write!(f, "queued"),
+                Self::Processing => write!(f, "processing"),
+                Self::RequestInProgress => write!(f, "requestInProgress"),
+                Self::Completed => write!(f, "completed"),
+            }
+        }
     }
 }
 #[doc = "Defines the data contract of notification details."]
@@ -990,6 +1052,16 @@ pub mod notification_results_summary_detail {
         #[serde(rename = "filtered")]
         Filtered,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Pending => write!(f, "pending"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Filtered => write!(f, "filtered"),
+            }
+        }
+    }
 }
 #[doc = "Summary of the notifications for a subscription."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1121,6 +1193,16 @@ pub mod notifications_query {
         #[serde(rename = "filtered")]
         Filtered,
     }
+    impl std::fmt::Display for ResultType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Pending => write!(f, "pending"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Filtered => write!(f, "filtered"),
+            }
+        }
+    }
     #[doc = "Optional notification status to filter results to"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -1132,6 +1214,16 @@ pub mod notifications_query {
         RequestInProgress,
         #[serde(rename = "completed")]
         Completed,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Queued => write!(f, "queued"),
+                Self::Processing => write!(f, "processing"),
+                Self::RequestInProgress => write!(f, "requestInProgress"),
+                Self::Completed => write!(f, "completed"),
+            }
+        }
     }
 }
 #[doc = "Defines the data contract of an event publisher."]
@@ -1454,6 +1546,17 @@ pub mod subscription {
         #[serde(rename = "disabledByInactiveIdentity")]
         DisabledByInactiveIdentity,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Enabled => write!(f, "enabled"),
+                Self::OnProbation => write!(f, "onProbation"),
+                Self::DisabledByUser => write!(f, "disabledByUser"),
+                Self::DisabledBySystem => write!(f, "disabledBySystem"),
+                Self::DisabledByInactiveIdentity => write!(f, "disabledByInactiveIdentity"),
+            }
+        }
+    }
 }
 #[doc = "Contains all the diagnostics settings for a subscription."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1517,6 +1620,14 @@ pub mod subscription_input_values_query {
         Publisher,
         #[serde(rename = "consumer")]
         Consumer,
+    }
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Publisher => write!(f, "publisher"),
+                Self::Consumer => write!(f, "consumer"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/ims/mod.rs
+++ b/azure_devops_rust_api/src/ims/mod.rs
@@ -204,7 +204,7 @@ pub mod identities {
             pub(crate) subject_descriptors: Option<String>,
             pub(crate) search_filter: Option<String>,
             pub(crate) filter_value: Option<String>,
-            pub(crate) query_membership: Option<String>,
+            pub(crate) query_membership: Option<models::QueryMembership>,
         }
         impl RequestBuilder {
             #[doc = "A comma separated list of identity descriptors to resolve"]
@@ -233,7 +233,10 @@ pub mod identities {
                 self
             }
             #[doc = "The membership information to include with the identities. Values can be None for no membership data or Direct to include the groups that the identity is a member of and the identities that are a member of this identity (groups only)"]
-            pub fn query_membership(mut self, query_membership: impl Into<String>) -> Self {
+            pub fn query_membership(
+                mut self,
+                query_membership: impl Into<models::QueryMembership>,
+            ) -> Self {
                 self.query_membership = Some(query_membership.into());
                 self
             }
@@ -287,7 +290,7 @@ pub mod identities {
                         if let Some(query_membership) = &this.query_membership {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryMembership", query_membership);
+                                .append_pair("queryMembership", &query_membership.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/ims/models.rs
+++ b/azure_devops_rust_api/src/ims/models.rs
@@ -929,6 +929,31 @@ impl PropertiesCollection {
         Self::default()
     }
 }
+#[doc = "The membership information to include with the identities. Values can be None for no membership data or Direct to include the groups that the identity is a member of and the identities that are a member of this identity (groups only)"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum QueryMembership {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "direct")]
+    Direct,
+    #[serde(rename = "expanded")]
+    Expanded,
+    #[serde(rename = "expandedUp")]
+    ExpandedUp,
+    #[serde(rename = "expandedDown")]
+    ExpandedDown,
+}
+impl std::fmt::Display for QueryMembership {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Direct => write!(f, "direct"),
+            Self::Expanded => write!(f, "expanded"),
+            Self::ExpandedUp => write!(f, "expandedUp"),
+            Self::ExpandedDown => write!(f, "expandedDown"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct RefreshTokenGrant {
     #[serde(flatten)]

--- a/azure_devops_rust_api/src/ims/models.rs
+++ b/azure_devops_rust_api/src/ims/models.rs
@@ -137,6 +137,47 @@ pub mod access_token_result {
         #[serde(rename = "invalidScope")]
         InvalidScope,
     }
+    impl std::fmt::Display for AccessTokenError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::GrantTypeRequired => write!(f, "grantTypeRequired"),
+                Self::AuthorizationGrantRequired => write!(f, "authorizationGrantRequired"),
+                Self::ClientSecretRequired => write!(f, "clientSecretRequired"),
+                Self::RedirectUriRequired => write!(f, "redirectUriRequired"),
+                Self::InvalidAuthorizationGrant => write!(f, "invalidAuthorizationGrant"),
+                Self::InvalidAuthorizationScopes => write!(f, "invalidAuthorizationScopes"),
+                Self::InvalidRefreshToken => write!(f, "invalidRefreshToken"),
+                Self::AuthorizationNotFound => write!(f, "authorizationNotFound"),
+                Self::AuthorizationGrantExpired => write!(f, "authorizationGrantExpired"),
+                Self::AccessAlreadyIssued => write!(f, "accessAlreadyIssued"),
+                Self::InvalidRedirectUri => write!(f, "invalidRedirectUri"),
+                Self::AccessTokenNotFound => write!(f, "accessTokenNotFound"),
+                Self::InvalidAccessToken => write!(f, "invalidAccessToken"),
+                Self::AccessTokenAlreadyRefreshed => write!(f, "accessTokenAlreadyRefreshed"),
+                Self::InvalidClientSecret => write!(f, "invalidClientSecret"),
+                Self::ClientSecretExpired => write!(f, "clientSecretExpired"),
+                Self::ServerError => write!(f, "serverError"),
+                Self::AccessDenied => write!(f, "accessDenied"),
+                Self::AccessTokenKeyRequired => write!(f, "accessTokenKeyRequired"),
+                Self::InvalidAccessTokenKey => write!(f, "invalidAccessTokenKey"),
+                Self::FailedToGetAccessToken => write!(f, "failedToGetAccessToken"),
+                Self::InvalidClientId => write!(f, "invalidClientId"),
+                Self::InvalidClient => write!(f, "invalidClient"),
+                Self::InvalidValidTo => write!(f, "invalidValidTo"),
+                Self::InvalidUserId => write!(f, "invalidUserId"),
+                Self::FailedToIssueAccessToken => write!(f, "failedToIssueAccessToken"),
+                Self::AuthorizationGrantScopeMissing => write!(f, "authorizationGrantScopeMissing"),
+                Self::InvalidPublicAccessTokenKey => write!(f, "invalidPublicAccessTokenKey"),
+                Self::InvalidPublicAccessToken => write!(f, "invalidPublicAccessToken"),
+                Self::PublicFeatureFlagNotEnabled => write!(f, "publicFeatureFlagNotEnabled"),
+                Self::SshPolicyDisabled => write!(f, "sshPolicyDisabled"),
+                Self::HostAuthorizationNotFound => write!(f, "hostAuthorizationNotFound"),
+                Self::HostAuthorizationIsNotValid => write!(f, "hostAuthorizationIsNotValid"),
+                Self::InvalidScope => write!(f, "invalidScope"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AuthorizationGrant {
@@ -162,6 +203,17 @@ pub mod authorization_grant {
         Implicit,
         #[serde(rename = "clientCredentials")]
         ClientCredentials,
+    }
+    impl std::fmt::Display for GrantType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::JwtBearer => write!(f, "jwtBearer"),
+                Self::RefreshToken => write!(f, "refreshToken"),
+                Self::Implicit => write!(f, "implicit"),
+                Self::ClientCredentials => write!(f, "clientCredentials"),
+            }
+        }
     }
 }
 #[doc = "Container class for changed identities"]
@@ -266,6 +318,15 @@ pub mod create_scope_info {
         #[serde(rename = "teamProject")]
         TeamProject,
     }
+    impl std::fmt::Display for ScopeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Generic => write!(f, "generic"),
+                Self::ServiceHost => write!(f, "serviceHost"),
+                Self::TeamProject => write!(f, "teamProject"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct FrameworkIdentityInfo {
@@ -303,6 +364,16 @@ pub mod framework_identity_info {
         AggregateIdentity,
         #[serde(rename = "importedIdentity")]
         ImportedIdentity,
+    }
+    impl std::fmt::Display for IdentityType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::ServiceIdentity => write!(f, "serviceIdentity"),
+                Self::AggregateIdentity => write!(f, "aggregateIdentity"),
+                Self::ImportedIdentity => write!(f, "importedIdentity"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -496,6 +567,17 @@ pub mod identity_batch_info {
         #[serde(rename = "expandedDown")]
         ExpandedDown,
     }
+    impl std::fmt::Display for QueryMembership {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Direct => write!(f, "direct"),
+                Self::Expanded => write!(f, "expanded"),
+                Self::ExpandedUp => write!(f, "expandedUp"),
+                Self::ExpandedDown => write!(f, "expandedDown"),
+            }
+        }
+    }
 }
 #[doc = "An Identity descriptor is a wrapper for the identity type (Windows SID, Passport) along with a unique identifier such as the SID or PUID."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -596,6 +678,15 @@ pub mod identity_scope {
         ServiceHost,
         #[serde(rename = "teamProject")]
         TeamProject,
+    }
+    impl std::fmt::Display for ScopeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Generic => write!(f, "generic"),
+                Self::ServiceHost => write!(f, "serviceHost"),
+                Self::TeamProject => write!(f, "teamProject"),
+            }
+        }
     }
 }
 #[doc = "Identity information."]
@@ -765,6 +856,18 @@ pub mod json_patch_operation {
         Copy,
         #[serde(rename = "test")]
         Test,
+    }
+    impl std::fmt::Display for Op {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Remove => write!(f, "remove"),
+                Self::Replace => write!(f, "replace"),
+                Self::Move => write!(f, "move"),
+                Self::Copy => write!(f, "copy"),
+                Self::Test => write!(f, "test"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/member_entitlement_management/mod.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/mod.rs
@@ -376,11 +376,11 @@ pub mod group_entitlements {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) body: models::GroupEntitlement,
-            pub(crate) rule_option: Option<String>,
+            pub(crate) rule_option: Option<models::RuleOption>,
         }
         impl RequestBuilder {
             #[doc = "RuleOption [ApplyGroupRule/TestApplyGroupRule] - specifies if the rules defined in group entitlement should be created and applied to it’s members (default option) or just be tested"]
-            pub fn rule_option(mut self, rule_option: impl Into<String>) -> Self {
+            pub fn rule_option(mut self, rule_option: impl Into<models::RuleOption>) -> Self {
                 self.rule_option = Some(rule_option.into());
                 self
             }
@@ -411,7 +411,7 @@ pub mod group_entitlements {
                         if let Some(rule_option) = &this.rule_option {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("ruleOption", rule_option);
+                                .append_pair("ruleOption", &rule_option.to_string());
                         }
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))
@@ -586,11 +586,11 @@ pub mod group_entitlements {
             pub(crate) organization: String,
             pub(crate) body: models::JsonPatchDocument,
             pub(crate) group_id: String,
-            pub(crate) rule_option: Option<String>,
+            pub(crate) rule_option: Option<models::RuleOption>,
         }
         impl RequestBuilder {
             #[doc = "RuleOption [ApplyGroupRule/TestApplyGroupRule] - specifies if the rules defined in group entitlement should be updated and the changes are applied to it’s members (default option) or just be tested"]
-            pub fn rule_option(mut self, rule_option: impl Into<String>) -> Self {
+            pub fn rule_option(mut self, rule_option: impl Into<models::RuleOption>) -> Self {
                 self.rule_option = Some(rule_option.into());
                 self
             }
@@ -621,7 +621,7 @@ pub mod group_entitlements {
                         if let Some(rule_option) = &this.rule_option {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("ruleOption", rule_option);
+                                .append_pair("ruleOption", &rule_option.to_string());
                         }
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))
@@ -700,12 +700,12 @@ pub mod group_entitlements {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) group_id: String,
-            pub(crate) rule_option: Option<String>,
+            pub(crate) rule_option: Option<models::RuleOption>,
             pub(crate) remove_group_membership: Option<bool>,
         }
         impl RequestBuilder {
             #[doc = "RuleOption [ApplyGroupRule/TestApplyGroupRule] - specifies if the rules defined in group entitlement should be deleted and the changes are applied to it’s members (default option) or just be tested"]
-            pub fn rule_option(mut self, rule_option: impl Into<String>) -> Self {
+            pub fn rule_option(mut self, rule_option: impl Into<models::RuleOption>) -> Self {
                 self.rule_option = Some(rule_option.into());
                 self
             }
@@ -739,7 +739,7 @@ pub mod group_entitlements {
                         if let Some(rule_option) = &this.rule_option {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("ruleOption", rule_option);
+                                .append_pair("ruleOption", &rule_option.to_string());
                         }
                         if let Some(remove_group_membership) = &this.remove_group_membership {
                             req.url_mut().query_pairs_mut().append_pair(
@@ -1221,7 +1221,7 @@ pub mod member_entitlements {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) continuation_token: Option<String>,
-            pub(crate) select: Option<String>,
+            pub(crate) select: Option<models::UserEntitlementProperty>,
             pub(crate) filter: Option<String>,
             pub(crate) order_by: Option<String>,
         }
@@ -1230,7 +1230,7 @@ pub mod member_entitlements {
                 self.continuation_token = Some(continuation_token.into());
                 self
             }
-            pub fn select(mut self, select: impl Into<String>) -> Self {
+            pub fn select(mut self, select: impl Into<models::UserEntitlementProperty>) -> Self {
                 self.select = Some(select.into());
                 self
             }
@@ -1272,7 +1272,7 @@ pub mod member_entitlements {
                         if let Some(select) = &this.select {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("select", select);
+                                .append_pair("select", &select.to_string());
                         }
                         if let Some(filter) = &this.filter {
                             req.url_mut()
@@ -2071,7 +2071,7 @@ pub mod user_entitlements {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) continuation_token: Option<String>,
-            pub(crate) select: Option<String>,
+            pub(crate) select: Option<models::UserEntitlementProperty>,
             pub(crate) filter: Option<String>,
             pub(crate) order_by: Option<String>,
         }
@@ -2082,7 +2082,7 @@ pub mod user_entitlements {
                 self
             }
             #[doc = "Comma (\",\") separated list of properties to select in the result entitlements. names of the properties are - 'Projects, 'Extensions' and 'Grouprules'."]
-            pub fn select(mut self, select: impl Into<String>) -> Self {
+            pub fn select(mut self, select: impl Into<models::UserEntitlementProperty>) -> Self {
                 self.select = Some(select.into());
                 self
             }
@@ -2126,7 +2126,7 @@ pub mod user_entitlements {
                         if let Some(select) = &this.select {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("select", select);
+                                .append_pair("select", &select.to_string());
                         }
                         if let Some(filter) = &this.filter {
                             req.url_mut()

--- a/azure_devops_rust_api/src/member_entitlement_management/models.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/models.rs
@@ -1460,6 +1460,22 @@ impl ReferenceLinks {
         Self::default()
     }
 }
+#[doc = "RuleOption [ApplyGroupRule/TestApplyGroupRule] - specifies if the rules defined in group entitlement should be created and applied to it’s members (default option) or just be tested"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum RuleOption {
+    #[serde(rename = "applyGroupRule")]
+    ApplyGroupRule,
+    #[serde(rename = "testApplyGroupRule")]
+    TestApplyGroupRule,
+}
+impl std::fmt::Display for RuleOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ApplyGroupRule => write!(f, "applyGroupRule"),
+            Self::TestApplyGroupRule => write!(f, "testApplyGroupRule"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ServicePrincipalEntitlement {
     #[serde(flatten)]
@@ -1659,6 +1675,30 @@ pub struct UserEntitlementOperationResult {
 impl UserEntitlementOperationResult {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum UserEntitlementProperty {
+    #[serde(rename = "license")]
+    License,
+    #[serde(rename = "extensions")]
+    Extensions,
+    #[serde(rename = "projects")]
+    Projects,
+    #[serde(rename = "groupRules")]
+    GroupRules,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for UserEntitlementProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::License => write!(f, "license"),
+            Self::Extensions => write!(f, "extensions"),
+            Self::Projects => write!(f, "projects"),
+            Self::GroupRules => write!(f, "groupRules"),
+            Self::All => write!(f, "all"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/member_entitlement_management/models.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/models.rs
@@ -104,6 +104,18 @@ pub mod access_level {
         #[serde(rename = "stakeholder")]
         Stakeholder,
     }
+    impl std::fmt::Display for AccountLicenseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::EarlyAdopter => write!(f, "earlyAdopter"),
+                Self::Express => write!(f, "express"),
+                Self::Professional => write!(f, "professional"),
+                Self::Advanced => write!(f, "advanced"),
+                Self::Stakeholder => write!(f, "stakeholder"),
+            }
+        }
+    }
     #[doc = "Assignment Source of the License (e.g. Group, Unknown etc."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum AssignmentSource {
@@ -113,6 +125,15 @@ pub mod access_level {
         Unknown,
         #[serde(rename = "groupRule")]
         GroupRule,
+    }
+    impl std::fmt::Display for AssignmentSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Unknown => write!(f, "unknown"),
+                Self::GroupRule => write!(f, "groupRule"),
+            }
+        }
     }
     #[doc = "Licensing Source (e.g. Account. MSDN etc.)"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -129,6 +150,18 @@ pub mod access_level {
         Auto,
         #[serde(rename = "trial")]
         Trial,
+    }
+    impl std::fmt::Display for LicensingSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Account => write!(f, "account"),
+                Self::Msdn => write!(f, "msdn"),
+                Self::Profile => write!(f, "profile"),
+                Self::Auto => write!(f, "auto"),
+                Self::Trial => write!(f, "trial"),
+            }
+        }
     }
     #[doc = "Type of MSDN License (e.g. Visual Studio Professional, Visual Studio Enterprise etc.). To use the MsdnLicenseType, LicensingSource should be defined as 'msdn' in the request body."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -150,6 +183,20 @@ pub mod access_level {
         #[serde(rename = "enterprise")]
         Enterprise,
     }
+    impl std::fmt::Display for MsdnLicenseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Eligible => write!(f, "eligible"),
+                Self::Professional => write!(f, "professional"),
+                Self::Platforms => write!(f, "platforms"),
+                Self::TestProfessional => write!(f, "testProfessional"),
+                Self::Premium => write!(f, "premium"),
+                Self::Ultimate => write!(f, "ultimate"),
+                Self::Enterprise => write!(f, "enterprise"),
+            }
+        }
+    }
     #[doc = "User status in the account"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -167,6 +214,19 @@ pub mod access_level {
         Expired,
         #[serde(rename = "pendingDisabled")]
         PendingDisabled,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Active => write!(f, "active"),
+                Self::Disabled => write!(f, "disabled"),
+                Self::Deleted => write!(f, "deleted"),
+                Self::Pending => write!(f, "pending"),
+                Self::Expired => write!(f, "expired"),
+                Self::PendingDisabled => write!(f, "pendingDisabled"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -295,6 +355,15 @@ pub mod extension {
         #[serde(rename = "groupRule")]
         GroupRule,
     }
+    impl std::fmt::Display for AssignmentSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Unknown => write!(f, "unknown"),
+                Self::GroupRule => write!(f, "groupRule"),
+            }
+        }
+    }
     #[doc = "Source of this extension assignment. Ex: msdn, account, none, etc."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Source {
@@ -310,6 +379,18 @@ pub mod extension {
         Auto,
         #[serde(rename = "trial")]
         Trial,
+    }
+    impl std::fmt::Display for Source {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Account => write!(f, "account"),
+                Self::Msdn => write!(f, "msdn"),
+                Self::Profile => write!(f, "profile"),
+                Self::Auto => write!(f, "auto"),
+                Self::Trial => write!(f, "trial"),
+            }
+        }
     }
 }
 #[doc = "Summary of Extensions in the organization."]
@@ -388,6 +469,17 @@ pub mod extension_summary_data {
         AdvancedPlus,
         #[serde(rename = "stakeholder")]
         Stakeholder,
+    }
+    impl std::fmt::Display for MinimumLicenseRequired {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Express => write!(f, "express"),
+                Self::Advanced => write!(f, "advanced"),
+                Self::AdvancedPlus => write!(f, "advancedPlus"),
+                Self::Stakeholder => write!(f, "stakeholder"),
+            }
+        }
     }
 }
 #[doc = "Graph group entity"]
@@ -547,6 +639,17 @@ pub mod group {
         #[serde(rename = "custom")]
         Custom,
     }
+    impl std::fmt::Display for GroupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ProjectStakeholder => write!(f, "projectStakeholder"),
+                Self::ProjectReader => write!(f, "projectReader"),
+                Self::ProjectContributor => write!(f, "projectContributor"),
+                Self::ProjectAdministrator => write!(f, "projectAdministrator"),
+                Self::Custom => write!(f, "custom"),
+            }
+        }
+    }
 }
 #[doc = "A group entity with additional properties including its license, extensions, and project membership"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -609,6 +712,16 @@ pub mod group_entitlement {
         Incompatible,
         #[serde(rename = "unableToApply")]
         UnableToApply,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ApplyPending => write!(f, "applyPending"),
+                Self::Applied => write!(f, "applied"),
+                Self::Incompatible => write!(f, "incompatible"),
+                Self::UnableToApply => write!(f, "unableToApply"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -736,6 +849,18 @@ pub mod json_patch_operation {
         #[serde(rename = "test")]
         Test,
     }
+    impl std::fmt::Display for Op {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Remove => write!(f, "remove"),
+                Self::Replace => write!(f, "replace"),
+                Self::Move => write!(f, "move"),
+                Self::Copy => write!(f, "copy"),
+                Self::Test => write!(f, "test"),
+            }
+        }
+    }
 }
 #[doc = "Summary of Licenses in the organization."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -815,6 +940,18 @@ pub mod license_summary_data {
         #[serde(rename = "stakeholder")]
         Stakeholder,
     }
+    impl std::fmt::Display for AccountLicenseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::EarlyAdopter => write!(f, "earlyAdopter"),
+                Self::Express => write!(f, "express"),
+                Self::Professional => write!(f, "professional"),
+                Self::Advanced => write!(f, "advanced"),
+                Self::Stakeholder => write!(f, "stakeholder"),
+            }
+        }
+    }
     #[doc = "Type of MSDN License. To use the MsdnLicenseType, LicensingSource should be defined as 'msdn' in the request body."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum MsdnLicenseType {
@@ -835,6 +972,20 @@ pub mod license_summary_data {
         #[serde(rename = "enterprise")]
         Enterprise,
     }
+    impl std::fmt::Display for MsdnLicenseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Eligible => write!(f, "eligible"),
+                Self::Professional => write!(f, "professional"),
+                Self::Platforms => write!(f, "platforms"),
+                Self::TestProfessional => write!(f, "testProfessional"),
+                Self::Premium => write!(f, "premium"),
+                Self::Ultimate => write!(f, "ultimate"),
+                Self::Enterprise => write!(f, "enterprise"),
+            }
+        }
+    }
     #[doc = "Source of the License."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Source {
@@ -850,6 +1001,18 @@ pub mod license_summary_data {
         Auto,
         #[serde(rename = "trial")]
         Trial,
+    }
+    impl std::fmt::Display for Source {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Account => write!(f, "account"),
+                Self::Msdn => write!(f, "msdn"),
+                Self::Profile => write!(f, "profile"),
+                Self::Auto => write!(f, "auto"),
+                Self::Trial => write!(f, "trial"),
+            }
+        }
     }
 }
 #[doc = "Deprecated: Use UserEntitlement instead"]
@@ -1088,6 +1251,18 @@ pub mod operation_reference {
         #[serde(rename = "failed")]
         Failed,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NotSet => write!(f, "notSet"),
+                Self::Queued => write!(f, "queued"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Cancelled => write!(f, "cancelled"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct OperationResult {
@@ -1229,6 +1404,15 @@ pub mod project_entitlement {
         #[serde(rename = "groupRule")]
         GroupRule,
     }
+    impl std::fmt::Display for AssignmentSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Unknown => write!(f, "unknown"),
+                Self::GroupRule => write!(f, "groupRule"),
+            }
+        }
+    }
     #[doc = "Whether the user is inheriting permissions to a project through a Azure DevOps or AAD group membership."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum ProjectPermissionInherited {
@@ -1238,6 +1422,15 @@ pub mod project_entitlement {
         NotInherited,
         #[serde(rename = "inherited")]
         Inherited,
+    }
+    impl std::fmt::Display for ProjectPermissionInherited {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NotSet => write!(f, "notSet"),
+                Self::NotInherited => write!(f, "notInherited"),
+                Self::Inherited => write!(f, "inherited"),
+            }
+        }
     }
 }
 #[doc = "A reference to a project"]

--- a/azure_devops_rust_api/src/operations/models.rs
+++ b/azure_devops_rust_api/src/operations/models.rs
@@ -74,6 +74,18 @@ pub mod operation_reference {
         #[serde(rename = "failed")]
         Failed,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::NotSet => write!(f, "notSet"),
+                Self::Queued => write!(f, "queued"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Cancelled => write!(f, "cancelled"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct OperationResultReference {

--- a/azure_devops_rust_api/src/permissions_report/models.rs
+++ b/azure_devops_rust_api/src/permissions_report/models.rs
@@ -64,6 +64,17 @@ pub mod permissions_report {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for ReportStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Created => write!(f, "created"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::CompletedWithErrors => write!(f, "completedWithErrors"),
+                Self::CompletedSuccessfully => write!(f, "completedSuccessfully"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct PermissionsReportList {
@@ -156,6 +167,17 @@ pub mod permissions_report_resource {
         Release,
         #[serde(rename = "tfvc")]
         Tfvc,
+    }
+    impl std::fmt::Display for ResourceType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Repo => write!(f, "repo"),
+                Self::Ref => write!(f, "ref"),
+                Self::ProjectGit => write!(f, "projectGit"),
+                Self::Release => write!(f, "release"),
+                Self::Tfvc => write!(f, "tfvc"),
+            }
+        }
     }
 }
 #[doc = "The class to represent a collection of REST reference links."]

--- a/azure_devops_rust_api/src/pipelines/mod.rs
+++ b/azure_devops_rust_api/src/pipelines/mod.rs
@@ -1149,11 +1149,11 @@ pub mod artifacts {
             pub(crate) pipeline_id: i32,
             pub(crate) run_id: i32,
             pub(crate) artifact_name: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::GetArtifactExpandOptions>,
         }
         impl RequestBuilder {
             #[doc = "Expand options. Default is None."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::GetArtifactExpandOptions>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1186,7 +1186,7 @@ pub mod artifacts {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1323,11 +1323,11 @@ pub mod logs {
             pub(crate) project: String,
             pub(crate) pipeline_id: i32,
             pub(crate) run_id: i32,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::GetLogExpandOptions>,
         }
         impl RequestBuilder {
             #[doc = "Expand options. Default is None."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::GetLogExpandOptions>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1356,7 +1356,7 @@ pub mod logs {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1433,11 +1433,11 @@ pub mod logs {
             pub(crate) pipeline_id: i32,
             pub(crate) run_id: i32,
             pub(crate) log_id: i32,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::GetLogExpandOptions>,
         }
         impl RequestBuilder {
             #[doc = "Expand options. Default is None."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::GetLogExpandOptions>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1466,7 +1466,7 @@ pub mod logs {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/pipelines/models.rs
+++ b/azure_devops_rust_api/src/pipelines/models.rs
@@ -147,6 +147,38 @@ impl CreatePipelineParameters {
         Self::default()
     }
 }
+#[doc = "Expand options. Default is None."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GetArtifactExpandOptions {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "signedContent")]
+    SignedContent,
+}
+impl std::fmt::Display for GetArtifactExpandOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::SignedContent => write!(f, "signedContent"),
+        }
+    }
+}
+#[doc = "Expand options. Default is None."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GetLogExpandOptions {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "signedContent")]
+    SignedContent,
+}
+impl std::fmt::Display for GetLogExpandOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::SignedContent => write!(f, "signedContent"),
+        }
+    }
+}
 #[doc = "Link URL"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Link {

--- a/azure_devops_rust_api/src/pipelines/models.rs
+++ b/azure_devops_rust_api/src/pipelines/models.rs
@@ -117,6 +117,17 @@ pub mod create_pipeline_configuration_parameters {
         #[serde(rename = "designerHyphenJson")]
         DesignerHyphenJson,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Yaml => write!(f, "yaml"),
+                Self::DesignerJson => write!(f, "designerJson"),
+                Self::JustInTime => write!(f, "justInTime"),
+                Self::DesignerHyphenJson => write!(f, "designerHyphenJson"),
+            }
+        }
+    }
 }
 #[doc = "Parameters to create a pipeline."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -317,6 +328,17 @@ pub mod pipeline_configuration {
         #[serde(rename = "designerHyphenJson")]
         DesignerHyphenJson,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Yaml => write!(f, "yaml"),
+                Self::DesignerJson => write!(f, "designerJson"),
+                Self::JustInTime => write!(f, "justInTime"),
+                Self::DesignerHyphenJson => write!(f, "designerHyphenJson"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
     pub struct Repository {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -435,6 +457,17 @@ pub mod repository {
         #[serde(rename = "azureReposGitHyphenated")]
         AzureReposGitHyphenated,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::GitHub => write!(f, "gitHub"),
+                Self::AzureReposGit => write!(f, "azureReposGit"),
+                Self::GitHubEnterprise => write!(f, "gitHubEnterprise"),
+                Self::AzureReposGitHyphenated => write!(f, "azureReposGitHyphenated"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct RepositoryResource {
@@ -541,6 +574,16 @@ pub mod run {
         #[serde(rename = "canceled")]
         Canceled,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum State {
         #[serde(rename = "unknown")]
@@ -551,6 +594,16 @@ pub mod run {
         Canceling,
         #[serde(rename = "completed")]
         Completed,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Canceling => write!(f, "canceling"),
+                Self::Completed => write!(f, "completed"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/policy/models.rs
+++ b/azure_devops_rust_api/src/policy/models.rs
@@ -252,6 +252,18 @@ pub mod policy_evaluation_record {
         #[serde(rename = "broken")]
         Broken,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Queued => write!(f, "queued"),
+                Self::Running => write!(f, "running"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Broken => write!(f, "broken"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct PolicyEvaluationRecordList {

--- a/azure_devops_rust_api/src/processadmin/models.rs
+++ b/azure_devops_rust_api/src/processadmin/models.rs
@@ -221,6 +221,14 @@ pub mod validation_issue {
         #[serde(rename = "error")]
         Error,
     }
+    impl std::fmt::Display for IssueType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+            }
+        }
+    }
 }
 #[doc = "This class is used to serialize collections as a single JSON object on the wire."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/processes/mod.rs
+++ b/azure_devops_rust_api/src/processes/mod.rs
@@ -954,10 +954,10 @@ pub mod processes {
         pub struct RequestBuilder {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::GetProcessExpandLevel>,
         }
         impl RequestBuilder {
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::GetProcessExpandLevel>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -986,7 +986,7 @@ pub mod processes {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1155,10 +1155,10 @@ pub mod processes {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) process_type_id: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::GetProcessExpandLevel>,
         }
         impl RequestBuilder {
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::GetProcessExpandLevel>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1187,7 +1187,7 @@ pub mod processes {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1558,10 +1558,10 @@ pub mod behaviors {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) process_id: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::GetBehaviorsExpand>,
         }
         impl RequestBuilder {
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::GetBehaviorsExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1590,7 +1590,7 @@ pub mod behaviors {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1763,10 +1763,10 @@ pub mod behaviors {
             pub(crate) organization: String,
             pub(crate) process_id: String,
             pub(crate) behavior_ref_name: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::GetBehaviorsExpand>,
         }
         impl RequestBuilder {
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::GetBehaviorsExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1795,7 +1795,7 @@ pub mod behaviors {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -2174,11 +2174,11 @@ pub mod work_item_types {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) process_id: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::GetWorkItemTypeExpand>,
         }
         impl RequestBuilder {
             #[doc = "Flag to determine what properties of work item type to return"]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::GetWorkItemTypeExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -2207,7 +2207,7 @@ pub mod work_item_types {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -2381,11 +2381,11 @@ pub mod work_item_types {
             pub(crate) organization: String,
             pub(crate) process_id: String,
             pub(crate) wit_ref_name: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::GetWorkItemTypeExpand>,
         }
         impl RequestBuilder {
             #[doc = "Flag to determine what properties of work item type to return"]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::GetWorkItemTypeExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -2414,7 +2414,7 @@ pub mod work_item_types {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -3015,10 +3015,13 @@ pub mod fields {
             pub(crate) process_id: String,
             pub(crate) wit_ref_name: String,
             pub(crate) field_ref_name: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::ProcessWorkItemTypeFieldsExpandLevel>,
         }
         impl RequestBuilder {
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(
+                mut self,
+                expand: impl Into<models::ProcessWorkItemTypeFieldsExpandLevel>,
+            ) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -3047,7 +3050,7 @@ pub mod fields {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/processes/models.rs
+++ b/azure_devops_rust_api/src/processes/models.rs
@@ -377,6 +377,61 @@ impl FormLayout {
         Self::default()
     }
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GetBehaviorsExpand {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "fields")]
+    Fields,
+    #[serde(rename = "combinedFields")]
+    CombinedFields,
+}
+impl std::fmt::Display for GetBehaviorsExpand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Fields => write!(f, "fields"),
+            Self::CombinedFields => write!(f, "combinedFields"),
+        }
+    }
+}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GetProcessExpandLevel {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "projects")]
+    Projects,
+}
+impl std::fmt::Display for GetProcessExpandLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Projects => write!(f, "projects"),
+        }
+    }
+}
+#[doc = "Flag to determine what properties of work item type to return"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GetWorkItemTypeExpand {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "states")]
+    States,
+    #[serde(rename = "behaviors")]
+    Behaviors,
+    #[serde(rename = "layout")]
+    Layout,
+}
+impl std::fmt::Display for GetWorkItemTypeExpand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::States => write!(f, "states"),
+            Self::Behaviors => write!(f, "behaviors"),
+            Self::Layout => write!(f, "layout"),
+        }
+    }
+}
 #[doc = "Represent a group in the form that holds controls in it."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct Group {
@@ -1203,6 +1258,24 @@ pub struct ProcessWorkItemTypeFieldList {
 impl ProcessWorkItemTypeFieldList {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ProcessWorkItemTypeFieldsExpandLevel {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "allowedValues")]
+    AllowedValues,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for ProcessWorkItemTypeFieldsExpandLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::AllowedValues => write!(f, "allowedValues"),
+            Self::All => write!(f, "all"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/processes/models.rs
+++ b/azure_devops_rust_api/src/processes/models.rs
@@ -289,6 +289,26 @@ pub mod field_model {
         #[serde(rename = "picklistDouble")]
         PicklistDouble,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::String => write!(f, "string"),
+                Self::Integer => write!(f, "integer"),
+                Self::DateTime => write!(f, "dateTime"),
+                Self::PlainText => write!(f, "plainText"),
+                Self::Html => write!(f, "html"),
+                Self::TreePath => write!(f, "treePath"),
+                Self::History => write!(f, "history"),
+                Self::Double => write!(f, "double"),
+                Self::Guid => write!(f, "guid"),
+                Self::Boolean => write!(f, "boolean"),
+                Self::Identity => write!(f, "identity"),
+                Self::PicklistInteger => write!(f, "picklistInteger"),
+                Self::PicklistString => write!(f, "picklistString"),
+                Self::PicklistDouble => write!(f, "picklistDouble"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct FieldRuleModel {
@@ -480,6 +500,16 @@ pub mod page {
         #[serde(rename = "attachments")]
         Attachments,
     }
+    impl std::fmt::Display for PageType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Custom => write!(f, "custom"),
+                Self::History => write!(f, "history"),
+                Self::Links => write!(f, "links"),
+                Self::Attachments => write!(f, "attachments"),
+            }
+        }
+    }
 }
 #[doc = "Picklist."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -598,6 +628,15 @@ pub mod process_behavior {
         Inherited,
         #[serde(rename = "custom")]
         Custom,
+    }
+    impl std::fmt::Display for Customization {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::System => write!(f, "system"),
+                Self::Inherited => write!(f, "inherited"),
+                Self::Custom => write!(f, "custom"),
+            }
+        }
     }
 }
 #[doc = "Process Behavior Create Payload."]
@@ -761,6 +800,15 @@ pub mod process_info {
         #[serde(rename = "custom")]
         Custom,
     }
+    impl std::fmt::Display for CustomizationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::System => write!(f, "system"),
+                Self::Inherited => write!(f, "inherited"),
+                Self::Custom => write!(f, "custom"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ProcessInfoList {
@@ -852,6 +900,15 @@ pub mod process_properties {
         #[serde(rename = "custom")]
         Custom,
     }
+    impl std::fmt::Display for Class {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::System => write!(f, "system"),
+                Self::Derived => write!(f, "derived"),
+                Self::Custom => write!(f, "custom"),
+            }
+        }
+    }
 }
 #[doc = "Process Rule Response."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -888,6 +945,15 @@ pub mod process_rule {
         Inherited,
         #[serde(rename = "custom")]
         Custom,
+    }
+    impl std::fmt::Display for CustomizationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::System => write!(f, "system"),
+                Self::Inherited => write!(f, "inherited"),
+                Self::Custom => write!(f, "custom"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -977,6 +1043,15 @@ pub mod process_work_item_type {
         #[serde(rename = "custom")]
         Custom,
     }
+    impl std::fmt::Display for Customization {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::System => write!(f, "system"),
+                Self::Inherited => write!(f, "inherited"),
+                Self::Custom => write!(f, "custom"),
+            }
+        }
+    }
 }
 #[doc = "Class that describes a field in a work item type and its properties."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1052,6 +1127,15 @@ pub mod process_work_item_type_field {
         #[serde(rename = "custom")]
         Custom,
     }
+    impl std::fmt::Display for Customization {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::System => write!(f, "system"),
+                Self::Inherited => write!(f, "inherited"),
+                Self::Custom => write!(f, "custom"),
+            }
+        }
+    }
     #[doc = "Type of the field."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Type {
@@ -1083,6 +1167,26 @@ pub mod process_work_item_type_field {
         PicklistString,
         #[serde(rename = "picklistDouble")]
         PicklistDouble,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::String => write!(f, "string"),
+                Self::Integer => write!(f, "integer"),
+                Self::DateTime => write!(f, "dateTime"),
+                Self::PlainText => write!(f, "plainText"),
+                Self::Html => write!(f, "html"),
+                Self::TreePath => write!(f, "treePath"),
+                Self::History => write!(f, "history"),
+                Self::Double => write!(f, "double"),
+                Self::Guid => write!(f, "guid"),
+                Self::Boolean => write!(f, "boolean"),
+                Self::Identity => write!(f, "identity"),
+                Self::PicklistInteger => write!(f, "picklistInteger"),
+                Self::PicklistString => write!(f, "picklistString"),
+                Self::PicklistDouble => write!(f, "picklistDouble"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1200,6 +1304,27 @@ pub mod rule_action {
         #[serde(rename = "disallowValue")]
         DisallowValue,
     }
+    impl std::fmt::Display for ActionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::MakeRequired => write!(f, "makeRequired"),
+                Self::MakeReadOnly => write!(f, "makeReadOnly"),
+                Self::SetDefaultValue => write!(f, "setDefaultValue"),
+                Self::SetDefaultFromClock => write!(f, "setDefaultFromClock"),
+                Self::SetDefaultFromCurrentUser => write!(f, "setDefaultFromCurrentUser"),
+                Self::SetDefaultFromField => write!(f, "setDefaultFromField"),
+                Self::CopyValue => write!(f, "copyValue"),
+                Self::CopyFromClock => write!(f, "copyFromClock"),
+                Self::CopyFromCurrentUser => write!(f, "copyFromCurrentUser"),
+                Self::CopyFromField => write!(f, "copyFromField"),
+                Self::SetValueToEmpty => write!(f, "setValueToEmpty"),
+                Self::CopyFromServerClock => write!(f, "copyFromServerClock"),
+                Self::CopyFromServerCurrentUser => write!(f, "copyFromServerCurrentUser"),
+                Self::HideTargetField => write!(f, "hideTargetField"),
+                Self::DisallowValue => write!(f, "disallowValue"),
+            }
+        }
+    }
 }
 #[doc = "Action to take when the rule is triggered."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1275,6 +1400,26 @@ pub mod rule_condition {
         WhenCurrentUserIsMemberOfGroup,
         #[serde(rename = "whenCurrentUserIsNotMemberOfGroup")]
         WhenCurrentUserIsNotMemberOfGroup,
+    }
+    impl std::fmt::Display for ConditionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::When => write!(f, "when"),
+                Self::WhenNot => write!(f, "whenNot"),
+                Self::WhenChanged => write!(f, "whenChanged"),
+                Self::WhenNotChanged => write!(f, "whenNotChanged"),
+                Self::WhenWas => write!(f, "whenWas"),
+                Self::WhenStateChangedTo => write!(f, "whenStateChangedTo"),
+                Self::WhenStateChangedFromAndTo => write!(f, "whenStateChangedFromAndTo"),
+                Self::WhenWorkItemIsCreated => write!(f, "whenWorkItemIsCreated"),
+                Self::WhenValueIsDefined => write!(f, "whenValueIsDefined"),
+                Self::WhenValueIsNotDefined => write!(f, "whenValueIsNotDefined"),
+                Self::WhenCurrentUserIsMemberOfGroup => write!(f, "whenCurrentUserIsMemberOfGroup"),
+                Self::WhenCurrentUserIsNotMemberOfGroup => {
+                    write!(f, "whenCurrentUserIsNotMemberOfGroup")
+                }
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1612,6 +1757,15 @@ pub mod work_item_state_result_model {
         #[serde(rename = "custom")]
         Custom,
     }
+    impl std::fmt::Display for CustomizationType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::System => write!(f, "system"),
+                Self::Inherited => write!(f, "inherited"),
+                Self::Custom => write!(f, "custom"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct WorkItemStateResultModelList {
@@ -1726,5 +1880,14 @@ pub mod work_item_type_model {
         Derived,
         #[serde(rename = "custom")]
         Custom,
+    }
+    impl std::fmt::Display for Class {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::System => write!(f, "system"),
+                Self::Derived => write!(f, "derived"),
+                Self::Custom => write!(f, "custom"),
+            }
+        }
     }
 }

--- a/azure_devops_rust_api/src/profile/models.rs
+++ b/azure_devops_rust_api/src/profile/models.rs
@@ -90,6 +90,15 @@ pub mod avatar {
         #[serde(rename = "large")]
         Large,
     }
+    impl std::fmt::Display for Size {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Small => write!(f, "small"),
+                Self::Medium => write!(f, "medium"),
+                Self::Large => write!(f, "large"),
+            }
+        }
+    }
 }
 #[doc = "A profile attribute which always has a value for each profile."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -168,6 +177,15 @@ pub mod create_profile_context {
         CustomReadOnly,
         #[serde(rename = "readOnly")]
         ReadOnly,
+    }
+    impl std::fmt::Display for ProfileState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Custom => write!(f, "custom"),
+                Self::CustomReadOnly => write!(f, "customReadOnly"),
+                Self::ReadOnly => write!(f, "readOnly"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -260,6 +278,15 @@ pub mod profile {
         CustomReadOnly,
         #[serde(rename = "readOnly")]
         ReadOnly,
+    }
+    impl std::fmt::Display for ProfileState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Custom => write!(f, "custom"),
+                Self::CustomReadOnly => write!(f, "customReadOnly"),
+                Self::ReadOnly => write!(f, "readOnly"),
+            }
+        }
     }
 }
 #[doc = "A named object associated with a profile."]

--- a/azure_devops_rust_api/src/release/mod.rs
+++ b/azure_devops_rust_api/src/release/mod.rs
@@ -445,14 +445,17 @@ pub mod releases {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) release_id: i32,
-            pub(crate) approval_filters: Option<String>,
+            pub(crate) approval_filters: Option<models::ApprovalFilters>,
             pub(crate) property_filters: Option<String>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::SingleReleaseExpands>,
             pub(crate) top_gate_records: Option<i32>,
         }
         impl RequestBuilder {
             #[doc = "A filter which would allow fetching approval steps selectively based on whether it is automated, or manual. This would also decide whether we should fetch pre and post approval snapshots. Assumes All by default"]
-            pub fn approval_filters(mut self, approval_filters: impl Into<String>) -> Self {
+            pub fn approval_filters(
+                mut self,
+                approval_filters: impl Into<models::ApprovalFilters>,
+            ) -> Self {
                 self.approval_filters = Some(approval_filters.into());
                 self
             }
@@ -462,7 +465,7 @@ pub mod releases {
                 self
             }
             #[doc = "A property that should be expanded in the release."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::SingleReleaseExpands>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -496,7 +499,7 @@ pub mod releases {
                         if let Some(approval_filters) = &this.approval_filters {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("approvalFilters", approval_filters);
+                                .append_pair("approvalFilters", &approval_filters.to_string());
                         }
                         if let Some(property_filters) = &this.property_filters {
                             req.url_mut()
@@ -506,7 +509,7 @@ pub mod releases {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(top_gate_records) = &this.top_gate_records {
                             req.url_mut()
@@ -590,14 +593,14 @@ pub mod releases {
             pub(crate) definition_environment_id: Option<i32>,
             pub(crate) search_text: Option<String>,
             pub(crate) created_by: Option<String>,
-            pub(crate) status_filter: Option<String>,
+            pub(crate) status_filter: Option<models::ReleaseStatus>,
             pub(crate) environment_status_filter: Option<i32>,
             pub(crate) min_created_time: Option<time::OffsetDateTime>,
             pub(crate) max_created_time: Option<time::OffsetDateTime>,
-            pub(crate) query_order: Option<String>,
+            pub(crate) query_order: Option<models::ReleaseQueryOrder>,
             pub(crate) top: Option<i32>,
             pub(crate) continuation_token: Option<i32>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::ReleaseExpands>,
             pub(crate) artifact_type_id: Option<String>,
             pub(crate) source_id: Option<String>,
             pub(crate) artifact_version_id: Option<String>,
@@ -629,7 +632,10 @@ pub mod releases {
                 self
             }
             #[doc = "Releases that have this status."]
-            pub fn status_filter(mut self, status_filter: impl Into<String>) -> Self {
+            pub fn status_filter(
+                mut self,
+                status_filter: impl Into<models::ReleaseStatus>,
+            ) -> Self {
                 self.status_filter = Some(status_filter.into());
                 self
             }
@@ -654,7 +660,10 @@ pub mod releases {
                 self
             }
             #[doc = "Gets the results in the defined order of created date for releases. Default is descending."]
-            pub fn query_order(mut self, query_order: impl Into<String>) -> Self {
+            pub fn query_order(
+                mut self,
+                query_order: impl Into<models::ReleaseQueryOrder>,
+            ) -> Self {
                 self.query_order = Some(query_order.into());
                 self
             }
@@ -669,7 +678,7 @@ pub mod releases {
                 self
             }
             #[doc = "The property that should be expanded in the list of releases."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::ReleaseExpands>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -764,7 +773,7 @@ pub mod releases {
                         if let Some(status_filter) = &this.status_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("statusFilter", status_filter);
+                                .append_pair("statusFilter", &status_filter.to_string());
                         }
                         if let Some(environment_status_filter) = &this.environment_status_filter {
                             req.url_mut().query_pairs_mut().append_pair(
@@ -789,7 +798,7 @@ pub mod releases {
                         if let Some(query_order) = &this.query_order {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryOrder", query_order);
+                                .append_pair("queryOrder", &query_order.to_string());
                         }
                         if let Some(top) = &this.top {
                             req.url_mut()
@@ -804,7 +813,7 @@ pub mod releases {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(artifact_type_id) = &this.artifact_type_id {
                             req.url_mut()
@@ -1323,11 +1332,11 @@ pub mod releases {
             pub(crate) project: String,
             pub(crate) release_id: i32,
             pub(crate) environment_id: i32,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::ReleaseEnvironmentExpands>,
         }
         impl RequestBuilder {
             #[doc = "A property that should be expanded in the environment."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::ReleaseEnvironmentExpands>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1356,7 +1365,7 @@ pub mod releases {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1802,12 +1811,12 @@ pub mod approvals {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) assigned_to_filter: Option<String>,
-            pub(crate) status_filter: Option<String>,
+            pub(crate) status_filter: Option<models::ApprovalStatus>,
             pub(crate) release_ids_filter: Option<String>,
-            pub(crate) type_filter: Option<String>,
+            pub(crate) type_filter: Option<models::ApprovalType>,
             pub(crate) top: Option<i32>,
             pub(crate) continuation_token: Option<i32>,
-            pub(crate) query_order: Option<String>,
+            pub(crate) query_order: Option<models::ReleaseQueryOrder>,
             pub(crate) include_my_group_approvals: Option<bool>,
         }
         impl RequestBuilder {
@@ -1817,7 +1826,10 @@ pub mod approvals {
                 self
             }
             #[doc = "Approvals with this status. Default is 'pending'."]
-            pub fn status_filter(mut self, status_filter: impl Into<String>) -> Self {
+            pub fn status_filter(
+                mut self,
+                status_filter: impl Into<models::ApprovalStatus>,
+            ) -> Self {
                 self.status_filter = Some(status_filter.into());
                 self
             }
@@ -1827,7 +1839,7 @@ pub mod approvals {
                 self
             }
             #[doc = "Approval with this type."]
-            pub fn type_filter(mut self, type_filter: impl Into<String>) -> Self {
+            pub fn type_filter(mut self, type_filter: impl Into<models::ApprovalType>) -> Self {
                 self.type_filter = Some(type_filter.into());
                 self
             }
@@ -1842,7 +1854,10 @@ pub mod approvals {
                 self
             }
             #[doc = "Gets the results in the defined order of created approvals. Default is 'descending'."]
-            pub fn query_order(mut self, query_order: impl Into<String>) -> Self {
+            pub fn query_order(
+                mut self,
+                query_order: impl Into<models::ReleaseQueryOrder>,
+            ) -> Self {
                 self.query_order = Some(query_order.into());
                 self
             }
@@ -1881,7 +1896,7 @@ pub mod approvals {
                         if let Some(status_filter) = &this.status_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("statusFilter", status_filter);
+                                .append_pair("statusFilter", &status_filter.to_string());
                         }
                         if let Some(release_ids_filter) = &this.release_ids_filter {
                             req.url_mut()
@@ -1891,7 +1906,7 @@ pub mod approvals {
                         if let Some(type_filter) = &this.type_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("typeFilter", type_filter);
+                                .append_pair("typeFilter", &type_filter.to_string());
                         }
                         if let Some(top) = &this.top {
                             req.url_mut()
@@ -1906,7 +1921,7 @@ pub mod approvals {
                         if let Some(query_order) = &this.query_order {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryOrder", query_order);
+                                .append_pair("queryOrder", &query_order.to_string());
                         }
                         if let Some(include_my_group_approvals) = &this.include_my_group_approvals {
                             req.url_mut().query_pairs_mut().append_pair(
@@ -2247,12 +2262,12 @@ pub mod definitions {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) search_text: Option<String>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::ReleaseDefinitionExpands>,
             pub(crate) artifact_type: Option<String>,
             pub(crate) artifact_source_id: Option<String>,
             pub(crate) top: Option<i32>,
             pub(crate) continuation_token: Option<String>,
-            pub(crate) query_order: Option<String>,
+            pub(crate) query_order: Option<models::ReleaseDefinitionQueryOrder>,
             pub(crate) path: Option<String>,
             pub(crate) is_exact_name_match: Option<bool>,
             pub(crate) tag_filter: Option<String>,
@@ -2268,7 +2283,7 @@ pub mod definitions {
                 self
             }
             #[doc = "The properties that should be expanded in the list of Release definitions."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::ReleaseDefinitionExpands>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -2293,7 +2308,10 @@ pub mod definitions {
                 self
             }
             #[doc = "Gets the results in the defined order. Default is 'IdAscending'."]
-            pub fn query_order(mut self, query_order: impl Into<String>) -> Self {
+            pub fn query_order(
+                mut self,
+                query_order: impl Into<models::ReleaseDefinitionQueryOrder>,
+            ) -> Self {
                 self.query_order = Some(query_order.into());
                 self
             }
@@ -2365,7 +2383,7 @@ pub mod definitions {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(artifact_type) = &this.artifact_type {
                             req.url_mut()
@@ -2390,7 +2408,7 @@ pub mod definitions {
                         if let Some(query_order) = &this.query_order {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryOrder", query_order);
+                                .append_pair("queryOrder", &query_order.to_string());
                         }
                         if let Some(path) = &this.path {
                             req.url_mut().query_pairs_mut().append_pair("path", path);
@@ -3167,10 +3185,10 @@ pub mod deployments {
             pub(crate) created_by: Option<String>,
             pub(crate) min_modified_time: Option<time::OffsetDateTime>,
             pub(crate) max_modified_time: Option<time::OffsetDateTime>,
-            pub(crate) deployment_status: Option<String>,
-            pub(crate) operation_status: Option<String>,
+            pub(crate) deployment_status: Option<models::DeploymentStatus>,
+            pub(crate) operation_status: Option<models::DeploymentOperationStatus>,
             pub(crate) latest_attempts_only: Option<bool>,
-            pub(crate) query_order: Option<String>,
+            pub(crate) query_order: Option<models::ReleaseQueryOrder>,
             pub(crate) top: Option<i32>,
             pub(crate) continuation_token: Option<i32>,
             pub(crate) created_for: Option<String>,
@@ -3205,11 +3223,17 @@ pub mod deployments {
                 self.max_modified_time = Some(max_modified_time.into());
                 self
             }
-            pub fn deployment_status(mut self, deployment_status: impl Into<String>) -> Self {
+            pub fn deployment_status(
+                mut self,
+                deployment_status: impl Into<models::DeploymentStatus>,
+            ) -> Self {
                 self.deployment_status = Some(deployment_status.into());
                 self
             }
-            pub fn operation_status(mut self, operation_status: impl Into<String>) -> Self {
+            pub fn operation_status(
+                mut self,
+                operation_status: impl Into<models::DeploymentOperationStatus>,
+            ) -> Self {
                 self.operation_status = Some(operation_status.into());
                 self
             }
@@ -3217,7 +3241,10 @@ pub mod deployments {
                 self.latest_attempts_only = Some(latest_attempts_only);
                 self
             }
-            pub fn query_order(mut self, query_order: impl Into<String>) -> Self {
+            pub fn query_order(
+                mut self,
+                query_order: impl Into<models::ReleaseQueryOrder>,
+            ) -> Self {
                 self.query_order = Some(query_order.into());
                 self
             }
@@ -3306,12 +3333,12 @@ pub mod deployments {
                         if let Some(deployment_status) = &this.deployment_status {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("deploymentStatus", deployment_status);
+                                .append_pair("deploymentStatus", &deployment_status.to_string());
                         }
                         if let Some(operation_status) = &this.operation_status {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("operationStatus", operation_status);
+                                .append_pair("operationStatus", &operation_status.to_string());
                         }
                         if let Some(latest_attempts_only) = &this.latest_attempts_only {
                             req.url_mut().query_pairs_mut().append_pair(
@@ -3322,7 +3349,7 @@ pub mod deployments {
                         if let Some(query_order) = &this.query_order {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryOrder", query_order);
+                                .append_pair("queryOrder", &query_order.to_string());
                         }
                         if let Some(top) = &this.top {
                             req.url_mut()
@@ -3524,11 +3551,14 @@ pub mod folders {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) path: String,
-            pub(crate) query_order: Option<String>,
+            pub(crate) query_order: Option<models::FolderPathQueryOrder>,
         }
         impl RequestBuilder {
             #[doc = "Gets the results in the defined order. Default is 'None'."]
-            pub fn query_order(mut self, query_order: impl Into<String>) -> Self {
+            pub fn query_order(
+                mut self,
+                query_order: impl Into<models::FolderPathQueryOrder>,
+            ) -> Self {
                 self.query_order = Some(query_order.into());
                 self
             }
@@ -3557,7 +3587,7 @@ pub mod folders {
                         if let Some(query_order) = &this.query_order {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("queryOrder", query_order);
+                                .append_pair("queryOrder", &query_order.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/release/models.rs
+++ b/azure_devops_rust_api/src/release/models.rs
@@ -146,6 +146,31 @@ impl AgentSpecification {
         Self::default()
     }
 }
+#[doc = "A filter which would allow fetching approval steps selectively based on whether it is automated, or manual. This would also decide whether we should fetch pre and post approval snapshots. Assumes All by default"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ApprovalFilters {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "manualApprovals")]
+    ManualApprovals,
+    #[serde(rename = "automatedApprovals")]
+    AutomatedApprovals,
+    #[serde(rename = "approvalSnapshots")]
+    ApprovalSnapshots,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for ApprovalFilters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::ManualApprovals => write!(f, "manualApprovals"),
+            Self::AutomatedApprovals => write!(f, "automatedApprovals"),
+            Self::ApprovalSnapshots => write!(f, "approvalSnapshots"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ApprovalOptions {
     #[doc = "Specify whether the approval can be skipped if the same approver approved the previous stage."]
@@ -215,6 +240,59 @@ pub mod approval_options {
                 Self::AfterSuccessfulGates => write!(f, "afterSuccessfulGates"),
                 Self::AfterGatesAlways => write!(f, "afterGatesAlways"),
             }
+        }
+    }
+}
+#[doc = "Approvals with this status. Default is 'pending'."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ApprovalStatus {
+    #[serde(rename = "undefined")]
+    Undefined,
+    #[serde(rename = "pending")]
+    Pending,
+    #[serde(rename = "approved")]
+    Approved,
+    #[serde(rename = "rejected")]
+    Rejected,
+    #[serde(rename = "reassigned")]
+    Reassigned,
+    #[serde(rename = "canceled")]
+    Canceled,
+    #[serde(rename = "skipped")]
+    Skipped,
+}
+impl std::fmt::Display for ApprovalStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Undefined => write!(f, "undefined"),
+            Self::Pending => write!(f, "pending"),
+            Self::Approved => write!(f, "approved"),
+            Self::Rejected => write!(f, "rejected"),
+            Self::Reassigned => write!(f, "reassigned"),
+            Self::Canceled => write!(f, "canceled"),
+            Self::Skipped => write!(f, "skipped"),
+        }
+    }
+}
+#[doc = "Approval with this type."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ApprovalType {
+    #[serde(rename = "undefined")]
+    Undefined,
+    #[serde(rename = "preDeploy")]
+    PreDeploy,
+    #[serde(rename = "postDeploy")]
+    PostDeploy,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for ApprovalType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Undefined => write!(f, "undefined"),
+            Self::PreDeploy => write!(f, "preDeploy"),
+            Self::PostDeploy => write!(f, "postDeploy"),
+            Self::All => write!(f, "all"),
         }
     }
 }
@@ -2253,6 +2331,75 @@ impl DeploymentManualInterventionPendingEvent {
         Self::default()
     }
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DeploymentOperationStatus {
+    #[serde(rename = "undefined")]
+    Undefined,
+    #[serde(rename = "queued")]
+    Queued,
+    #[serde(rename = "scheduled")]
+    Scheduled,
+    #[serde(rename = "pending")]
+    Pending,
+    #[serde(rename = "approved")]
+    Approved,
+    #[serde(rename = "rejected")]
+    Rejected,
+    #[serde(rename = "deferred")]
+    Deferred,
+    #[serde(rename = "queuedForAgent")]
+    QueuedForAgent,
+    #[serde(rename = "phaseInProgress")]
+    PhaseInProgress,
+    #[serde(rename = "phaseSucceeded")]
+    PhaseSucceeded,
+    #[serde(rename = "phasePartiallySucceeded")]
+    PhasePartiallySucceeded,
+    #[serde(rename = "phaseFailed")]
+    PhaseFailed,
+    #[serde(rename = "canceled")]
+    Canceled,
+    #[serde(rename = "phaseCanceled")]
+    PhaseCanceled,
+    #[serde(rename = "manualInterventionPending")]
+    ManualInterventionPending,
+    #[serde(rename = "queuedForPipeline")]
+    QueuedForPipeline,
+    #[serde(rename = "cancelling")]
+    Cancelling,
+    #[serde(rename = "evaluatingGates")]
+    EvaluatingGates,
+    #[serde(rename = "gateFailed")]
+    GateFailed,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for DeploymentOperationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Undefined => write!(f, "undefined"),
+            Self::Queued => write!(f, "queued"),
+            Self::Scheduled => write!(f, "scheduled"),
+            Self::Pending => write!(f, "pending"),
+            Self::Approved => write!(f, "approved"),
+            Self::Rejected => write!(f, "rejected"),
+            Self::Deferred => write!(f, "deferred"),
+            Self::QueuedForAgent => write!(f, "queuedForAgent"),
+            Self::PhaseInProgress => write!(f, "phaseInProgress"),
+            Self::PhaseSucceeded => write!(f, "phaseSucceeded"),
+            Self::PhasePartiallySucceeded => write!(f, "phasePartiallySucceeded"),
+            Self::PhaseFailed => write!(f, "phaseFailed"),
+            Self::Canceled => write!(f, "canceled"),
+            Self::PhaseCanceled => write!(f, "phaseCanceled"),
+            Self::ManualInterventionPending => write!(f, "manualInterventionPending"),
+            Self::QueuedForPipeline => write!(f, "queuedForPipeline"),
+            Self::Cancelling => write!(f, "cancelling"),
+            Self::EvaluatingGates => write!(f, "evaluatingGates"),
+            Self::GateFailed => write!(f, "gateFailed"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct DeploymentQueryParameters {
     #[doc = "Query deployments based specified artifact source id."]
@@ -2463,6 +2610,36 @@ pub struct DeploymentStartedEvent {
 impl DeploymentStartedEvent {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DeploymentStatus {
+    #[serde(rename = "undefined")]
+    Undefined,
+    #[serde(rename = "notDeployed")]
+    NotDeployed,
+    #[serde(rename = "inProgress")]
+    InProgress,
+    #[serde(rename = "succeeded")]
+    Succeeded,
+    #[serde(rename = "partiallySucceeded")]
+    PartiallySucceeded,
+    #[serde(rename = "failed")]
+    Failed,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for DeploymentStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Undefined => write!(f, "undefined"),
+            Self::NotDeployed => write!(f, "notDeployed"),
+            Self::InProgress => write!(f, "inProgress"),
+            Self::Succeeded => write!(f, "succeeded"),
+            Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+            Self::Failed => write!(f, "failed"),
+            Self::All => write!(f, "all"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2764,6 +2941,25 @@ pub struct FolderList {
 impl FolderList {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Gets the results in the defined order. Default is 'None'."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum FolderPathQueryOrder {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "ascending")]
+    Ascending,
+    #[serde(rename = "descending")]
+    Descending,
+}
+impl std::fmt::Display for FolderPathQueryOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Ascending => write!(f, "ascending"),
+            Self::Descending => write!(f, "descending"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4962,6 +5158,37 @@ impl ReleaseDefinitionEnvironmentTemplate {
         Self::default()
     }
 }
+#[doc = "The properties that should be expanded in the list of Release definitions."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ReleaseDefinitionExpands {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "environments")]
+    Environments,
+    #[serde(rename = "artifacts")]
+    Artifacts,
+    #[serde(rename = "triggers")]
+    Triggers,
+    #[serde(rename = "variables")]
+    Variables,
+    #[serde(rename = "tags")]
+    Tags,
+    #[serde(rename = "lastRelease")]
+    LastRelease,
+}
+impl std::fmt::Display for ReleaseDefinitionExpands {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Environments => write!(f, "environments"),
+            Self::Artifacts => write!(f, "artifacts"),
+            Self::Triggers => write!(f, "triggers"),
+            Self::Variables => write!(f, "variables"),
+            Self::Tags => write!(f, "tags"),
+            Self::LastRelease => write!(f, "lastRelease"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReleaseDefinitionGate {
     #[doc = "Gets or sets the gates workflow."]
@@ -5050,6 +5277,28 @@ pub struct ReleaseDefinitionList {
 impl ReleaseDefinitionList {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Gets the results in the defined order. Default is 'IdAscending'."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ReleaseDefinitionQueryOrder {
+    #[serde(rename = "idAscending")]
+    IdAscending,
+    #[serde(rename = "idDescending")]
+    IdDescending,
+    #[serde(rename = "nameAscending")]
+    NameAscending,
+    #[serde(rename = "nameDescending")]
+    NameDescending,
+}
+impl std::fmt::Display for ReleaseDefinitionQueryOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IdAscending => write!(f, "idAscending"),
+            Self::IdDescending => write!(f, "idDescending"),
+            Self::NameAscending => write!(f, "nameAscending"),
+            Self::NameDescending => write!(f, "nameDescending"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5653,6 +5902,22 @@ pub mod release_environment_completed_event {
         }
     }
 }
+#[doc = "A property that should be expanded in the environment."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ReleaseEnvironmentExpands {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "tasks")]
+    Tasks,
+}
+impl std::fmt::Display for ReleaseEnvironmentExpands {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Tasks => write!(f, "tasks"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReleaseEnvironmentShallowReference {
     #[doc = "Links"]
@@ -5926,6 +6191,37 @@ impl ReleaseEvent {
         Self::default()
     }
 }
+#[doc = "The property that should be expanded in the list of releases."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ReleaseExpands {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "environments")]
+    Environments,
+    #[serde(rename = "artifacts")]
+    Artifacts,
+    #[serde(rename = "approvals")]
+    Approvals,
+    #[serde(rename = "manualInterventions")]
+    ManualInterventions,
+    #[serde(rename = "variables")]
+    Variables,
+    #[serde(rename = "tags")]
+    Tags,
+}
+impl std::fmt::Display for ReleaseExpands {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Environments => write!(f, "environments"),
+            Self::Artifacts => write!(f, "artifacts"),
+            Self::Approvals => write!(f, "approvals"),
+            Self::ManualInterventions => write!(f, "manualInterventions"),
+            Self::Variables => write!(f, "variables"),
+            Self::Tags => write!(f, "tags"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReleaseGates {
     #[doc = "Contains the gates job details of each evaluation."]
@@ -6142,6 +6438,22 @@ pub mod release_not_created_event {
                 Self::Schedule => write!(f, "schedule"),
                 Self::PullRequest => write!(f, "pullRequest"),
             }
+        }
+    }
+}
+#[doc = "Gets the results in the defined order of created approvals. Default is 'descending'."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ReleaseQueryOrder {
+    #[serde(rename = "descending")]
+    Descending,
+    #[serde(rename = "ascending")]
+    Ascending,
+}
+impl std::fmt::Display for ReleaseQueryOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Descending => write!(f, "descending"),
+            Self::Ascending => write!(f, "ascending"),
         }
     }
 }
@@ -6492,6 +6804,28 @@ pub mod release_start_metadata {
                 Self::Schedule => write!(f, "schedule"),
                 Self::PullRequest => write!(f, "pullRequest"),
             }
+        }
+    }
+}
+#[doc = "Releases that have this status."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ReleaseStatus {
+    #[serde(rename = "undefined")]
+    Undefined,
+    #[serde(rename = "draft")]
+    Draft,
+    #[serde(rename = "active")]
+    Active,
+    #[serde(rename = "abandoned")]
+    Abandoned,
+}
+impl std::fmt::Display for ReleaseStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Undefined => write!(f, "undefined"),
+            Self::Draft => write!(f, "draft"),
+            Self::Active => write!(f, "active"),
+            Self::Abandoned => write!(f, "abandoned"),
         }
     }
 }
@@ -6986,6 +7320,22 @@ pub struct ServiceEndpointReference {
 impl ServiceEndpointReference {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "A property that should be expanded in the release."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum SingleReleaseExpands {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "tasks")]
+    Tasks,
+}
+impl std::fmt::Display for SingleReleaseExpands {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Tasks => write!(f, "tasks"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/release/models.rs
+++ b/azure_devops_rust_api/src/release/models.rs
@@ -60,6 +60,23 @@ pub mod agent_artifact_definition {
         #[serde(rename = "tfvc")]
         Tfvc,
     }
+    impl std::fmt::Display for ArtifactType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::XamlBuild => write!(f, "xamlBuild"),
+                Self::Build => write!(f, "build"),
+                Self::Jenkins => write!(f, "jenkins"),
+                Self::FileShare => write!(f, "fileShare"),
+                Self::Nuget => write!(f, "nuget"),
+                Self::TfsOnPrem => write!(f, "tfsOnPrem"),
+                Self::GitHub => write!(f, "gitHub"),
+                Self::TfGit => write!(f, "tfGit"),
+                Self::ExternalTfsBuild => write!(f, "externalTfsBuild"),
+                Self::Custom => write!(f, "custom"),
+                Self::Tfvc => write!(f, "tfvc"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AgentBasedDeployPhase {
@@ -190,6 +207,15 @@ pub mod approval_options {
         AfterSuccessfulGates,
         #[serde(rename = "afterGatesAlways")]
         AfterGatesAlways,
+    }
+    impl std::fmt::Display for ExecutionOrder {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::BeforeGates => write!(f, "beforeGates"),
+                Self::AfterSuccessfulGates => write!(f, "afterSuccessfulGates"),
+                Self::AfterGatesAlways => write!(f, "afterGatesAlways"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -750,6 +776,15 @@ pub mod auto_trigger_issue {
         #[serde(rename = "system")]
         System,
     }
+    impl std::fmt::Display for IssueSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::User => write!(f, "user"),
+                Self::System => write!(f, "system"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum ReleaseTriggerType {
         #[serde(rename = "undefined")]
@@ -766,6 +801,19 @@ pub mod auto_trigger_issue {
         Package,
         #[serde(rename = "pullRequest")]
         PullRequest,
+    }
+    impl std::fmt::Display for ReleaseTriggerType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::ArtifactSource => write!(f, "artifactSource"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::SourceRepo => write!(f, "sourceRepo"),
+                Self::ContainerImage => write!(f, "containerImage"),
+                Self::Package => write!(f, "package"),
+                Self::PullRequest => write!(f, "pullRequest"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1016,6 +1064,15 @@ pub mod code_repository_reference {
         #[serde(rename = "gitHub")]
         GitHub,
     }
+    impl std::fmt::Display for SystemType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::TfsGit => write!(f, "tfsGit"),
+                Self::GitHub => write!(f, "gitHub"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ComplianceSettings {
@@ -1066,6 +1123,16 @@ pub mod condition {
         EnvironmentState,
         #[serde(rename = "artifact")]
         Artifact,
+    }
+    impl std::fmt::Display for ConditionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Event => write!(f, "event"),
+                Self::EnvironmentState => write!(f, "environmentState"),
+                Self::Artifact => write!(f, "artifact"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1460,6 +1527,17 @@ pub mod deploy_phase {
         #[serde(rename = "deploymentGates")]
         DeploymentGates,
     }
+    impl std::fmt::Display for PhaseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::AgentBasedDeployment => write!(f, "agentBasedDeployment"),
+                Self::RunOnServer => write!(f, "runOnServer"),
+                Self::MachineGroupBasedDeployment => write!(f, "machineGroupBasedDeployment"),
+                Self::DeploymentGates => write!(f, "deploymentGates"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct Deployment {
@@ -1620,6 +1698,19 @@ pub mod deployment {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for DeploymentStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::NotDeployed => write!(f, "notDeployed"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[doc = "Gets operation status of deployment."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum OperationStatus {
@@ -1644,6 +1735,32 @@ pub mod deployment {
         GateFailed,
         All,
     }
+    impl std::fmt::Display for OperationStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "Undefined"),
+                Self::Queued => write!(f, "Queued"),
+                Self::Scheduled => write!(f, "Scheduled"),
+                Self::Pending => write!(f, "Pending"),
+                Self::Approved => write!(f, "Approved"),
+                Self::Rejected => write!(f, "Rejected"),
+                Self::Deferred => write!(f, "Deferred"),
+                Self::QueuedForAgent => write!(f, "QueuedForAgent"),
+                Self::PhaseInProgress => write!(f, "PhaseInProgress"),
+                Self::PhaseSucceeded => write!(f, "PhaseSucceeded"),
+                Self::PhasePartiallySucceeded => write!(f, "PhasePartiallySucceeded"),
+                Self::PhaseFailed => write!(f, "PhaseFailed"),
+                Self::Canceled => write!(f, "Canceled"),
+                Self::PhaseCanceled => write!(f, "PhaseCanceled"),
+                Self::ManualInterventionPending => write!(f, "ManualInterventionPending"),
+                Self::QueuedForPipeline => write!(f, "QueuedForPipeline"),
+                Self::Cancelling => write!(f, "Cancelling"),
+                Self::EvaluatingGates => write!(f, "EvaluatingGates"),
+                Self::GateFailed => write!(f, "GateFailed"),
+                Self::All => write!(f, "All"),
+            }
+        }
+    }
     #[doc = "Gets reason of deployment."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Reason {
@@ -1657,6 +1774,17 @@ pub mod deployment {
         Scheduled,
         #[serde(rename = "redeployTrigger")]
         RedeployTrigger,
+    }
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::Automated => write!(f, "automated"),
+                Self::Scheduled => write!(f, "scheduled"),
+                Self::RedeployTrigger => write!(f, "redeployTrigger"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1849,6 +1977,32 @@ pub mod deployment_attempt {
         GateFailed,
         All,
     }
+    impl std::fmt::Display for OperationStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "Undefined"),
+                Self::Queued => write!(f, "Queued"),
+                Self::Scheduled => write!(f, "Scheduled"),
+                Self::Pending => write!(f, "Pending"),
+                Self::Approved => write!(f, "Approved"),
+                Self::Rejected => write!(f, "Rejected"),
+                Self::Deferred => write!(f, "Deferred"),
+                Self::QueuedForAgent => write!(f, "QueuedForAgent"),
+                Self::PhaseInProgress => write!(f, "PhaseInProgress"),
+                Self::PhaseSucceeded => write!(f, "PhaseSucceeded"),
+                Self::PhasePartiallySucceeded => write!(f, "PhasePartiallySucceeded"),
+                Self::PhaseFailed => write!(f, "PhaseFailed"),
+                Self::Canceled => write!(f, "Canceled"),
+                Self::PhaseCanceled => write!(f, "PhaseCanceled"),
+                Self::ManualInterventionPending => write!(f, "ManualInterventionPending"),
+                Self::QueuedForPipeline => write!(f, "QueuedForPipeline"),
+                Self::Cancelling => write!(f, "Cancelling"),
+                Self::EvaluatingGates => write!(f, "EvaluatingGates"),
+                Self::GateFailed => write!(f, "GateFailed"),
+                Self::All => write!(f, "All"),
+            }
+        }
+    }
     #[doc = "Reason for the deployment."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Reason {
@@ -1862,6 +2016,17 @@ pub mod deployment_attempt {
         Scheduled,
         #[serde(rename = "redeployTrigger")]
         RedeployTrigger,
+    }
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::Automated => write!(f, "automated"),
+                Self::Scheduled => write!(f, "scheduled"),
+                Self::RedeployTrigger => write!(f, "redeployTrigger"),
+            }
+        }
     }
     #[doc = "status of the deployment."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1880,6 +2045,19 @@ pub mod deployment_attempt {
         Failed,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::NotDeployed => write!(f, "notDeployed"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1923,6 +2101,14 @@ pub mod deployment_authorization_info {
         RevalidateApproverIdentity,
         #[serde(rename = "onBehalfOf")]
         OnBehalfOf,
+    }
+    impl std::fmt::Display for AuthorizationHeaderFor {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::RevalidateApproverIdentity => write!(f, "revalidateApproverIdentity"),
+                Self::OnBehalfOf => write!(f, "onBehalfOf"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2161,6 +2347,19 @@ pub mod deployment_query_parameters {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for DeploymentStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::NotDeployed => write!(f, "notDeployed"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[doc = "Query deployments based specified expands."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Expands {
@@ -2172,6 +2371,16 @@ pub mod deployment_query_parameters {
         Approvals,
         #[serde(rename = "artifacts")]
         Artifacts,
+    }
+    impl std::fmt::Display for Expands {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::All => write!(f, "all"),
+                Self::DeploymentOnly => write!(f, "deploymentOnly"),
+                Self::Approvals => write!(f, "approvals"),
+                Self::Artifacts => write!(f, "artifacts"),
+            }
+        }
     }
     #[doc = "Query deployment based on deployment operation status."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -2197,6 +2406,32 @@ pub mod deployment_query_parameters {
         GateFailed,
         All,
     }
+    impl std::fmt::Display for OperationStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "Undefined"),
+                Self::Queued => write!(f, "Queued"),
+                Self::Scheduled => write!(f, "Scheduled"),
+                Self::Pending => write!(f, "Pending"),
+                Self::Approved => write!(f, "Approved"),
+                Self::Rejected => write!(f, "Rejected"),
+                Self::Deferred => write!(f, "Deferred"),
+                Self::QueuedForAgent => write!(f, "QueuedForAgent"),
+                Self::PhaseInProgress => write!(f, "PhaseInProgress"),
+                Self::PhaseSucceeded => write!(f, "PhaseSucceeded"),
+                Self::PhasePartiallySucceeded => write!(f, "PhasePartiallySucceeded"),
+                Self::PhaseFailed => write!(f, "PhaseFailed"),
+                Self::Canceled => write!(f, "Canceled"),
+                Self::PhaseCanceled => write!(f, "PhaseCanceled"),
+                Self::ManualInterventionPending => write!(f, "ManualInterventionPending"),
+                Self::QueuedForPipeline => write!(f, "QueuedForPipeline"),
+                Self::Cancelling => write!(f, "Cancelling"),
+                Self::EvaluatingGates => write!(f, "EvaluatingGates"),
+                Self::GateFailed => write!(f, "GateFailed"),
+                Self::All => write!(f, "All"),
+            }
+        }
+    }
     #[doc = "Query deployments based query type."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum QueryType {
@@ -2204,6 +2439,14 @@ pub mod deployment_query_parameters {
         Regular,
         #[serde(rename = "failingSince")]
         FailingSince,
+    }
+    impl std::fmt::Display for QueryType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Regular => write!(f, "regular"),
+                Self::FailingSince => write!(f, "failingSince"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2382,6 +2625,15 @@ pub mod environment_trigger {
         #[serde(rename = "rollbackRedeploy")]
         RollbackRedeploy,
     }
+    impl std::fmt::Display for TriggerType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::DeploymentGroupRedeploy => write!(f, "deploymentGroupRedeploy"),
+                Self::RollbackRedeploy => write!(f, "rollbackRedeploy"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct EnvironmentTriggerContent {
@@ -2428,6 +2680,15 @@ pub mod execution_input {
         MultiConfiguration,
         #[serde(rename = "multiMachine")]
         MultiMachine,
+    }
+    impl std::fmt::Display for ParallelExecutionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::MultiConfiguration => write!(f, "multiConfiguration"),
+                Self::MultiMachine => write!(f, "multiMachine"),
+            }
+        }
     }
 }
 #[doc = "Class to represent favorite entry."]
@@ -2781,6 +3042,19 @@ pub mod input_descriptor {
         #[serde(rename = "textArea")]
         TextArea,
     }
+    impl std::fmt::Display for InputMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::TextBox => write!(f, "textBox"),
+                Self::PasswordBox => write!(f, "passwordBox"),
+                Self::Combo => write!(f, "combo"),
+                Self::RadioButtons => write!(f, "radioButtons"),
+                Self::CheckBox => write!(f, "checkBox"),
+                Self::TextArea => write!(f, "textArea"),
+            }
+        }
+    }
 }
 #[doc = "Describes what values are valid for a subscription input"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2840,6 +3114,18 @@ pub mod input_validation {
         Guid,
         #[serde(rename = "uri")]
         Uri,
+    }
+    impl std::fmt::Display for DataType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::String => write!(f, "string"),
+                Self::Number => write!(f, "number"),
+                Self::Boolean => write!(f, "boolean"),
+                Self::Guid => write!(f, "guid"),
+                Self::Uri => write!(f, "uri"),
+            }
+        }
     }
 }
 #[doc = "Information about a single value for an input"]
@@ -3084,6 +3370,14 @@ pub mod mail_message {
         #[serde(rename = "requestingUser")]
         RequestingUser,
     }
+    impl std::fmt::Display for SenderType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ServiceAccount => write!(f, "serviceAccount"),
+                Self::RequestingUser => write!(f, "requestingUser"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ManualIntervention {
@@ -3166,6 +3460,17 @@ pub mod manual_intervention {
         #[serde(rename = "canceled")]
         Canceled,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Pending => write!(f, "pending"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Approved => write!(f, "approved"),
+                Self::Canceled => write!(f, "canceled"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ManualInterventionList {
@@ -3212,6 +3517,17 @@ pub mod manual_intervention_update_metadata {
         Approved,
         #[serde(rename = "canceled")]
         Canceled,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Pending => write!(f, "pending"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Approved => write!(f, "approved"),
+                Self::Canceled => write!(f, "canceled"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3355,6 +3671,14 @@ pub mod pipeline_process {
         Designer,
         #[serde(rename = "yaml")]
         Yaml,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Designer => write!(f, "designer"),
+                Self::Yaml => write!(f, "yaml"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3509,6 +3833,14 @@ pub mod property_selector {
         Inclusion,
         #[serde(rename = "exclusion")]
         Exclusion,
+    }
+    impl std::fmt::Display for SelectorType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Inclusion => write!(f, "inclusion"),
+                Self::Exclusion => write!(f, "exclusion"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3825,6 +4157,17 @@ pub mod release {
         #[serde(rename = "pullRequest")]
         PullRequest,
     }
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::ContinuousIntegration => write!(f, "continuousIntegration"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::PullRequest => write!(f, "pullRequest"),
+            }
+        }
+    }
     #[doc = "Gets status."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -3836,6 +4179,16 @@ pub mod release {
         Active,
         #[serde(rename = "abandoned")]
         Abandoned,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Draft => write!(f, "draft"),
+                Self::Active => write!(f, "active"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3954,6 +4307,16 @@ pub mod release_approval {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for ApprovalType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::PreDeploy => write!(f, "preDeploy"),
+                Self::PostDeploy => write!(f, "postDeploy"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[doc = "Gets or sets the status of the approval."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -3971,6 +4334,19 @@ pub mod release_approval {
         Canceled,
         #[serde(rename = "skipped")]
         Skipped,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Pending => write!(f, "pending"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Reassigned => write!(f, "reassigned"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4298,6 +4674,17 @@ pub mod release_definition {
         Ibiza,
         #[serde(rename = "portalExtensionApi")]
         PortalExtensionApi,
+    }
+    impl std::fmt::Display for Source {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::RestApi => write!(f, "restApi"),
+                Self::UserInterface => write!(f, "userInterface"),
+                Self::Ibiza => write!(f, "ibiza"),
+                Self::PortalExtensionApi => write!(f, "portalExtensionApi"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4731,6 +5118,16 @@ pub mod release_definition_revision {
         #[serde(rename = "undelete")]
         Undelete,
     }
+    impl std::fmt::Display for ChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Update => write!(f, "update"),
+                Self::Delete => write!(f, "delete"),
+                Self::Undelete => write!(f, "undelete"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReleaseDefinitionRevisionList {
@@ -4885,6 +5282,17 @@ pub mod release_deploy_phase {
         #[serde(rename = "deploymentGates")]
         DeploymentGates,
     }
+    impl std::fmt::Display for PhaseType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::AgentBasedDeployment => write!(f, "agentBasedDeployment"),
+                Self::RunOnServer => write!(f, "runOnServer"),
+                Self::MachineGroupBasedDeployment => write!(f, "machineGroupBasedDeployment"),
+                Self::DeploymentGates => write!(f, "deploymentGates"),
+            }
+        }
+    }
     #[doc = "Status of the phase."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -4906,6 +5314,21 @@ pub mod release_deploy_phase {
         Skipped,
         #[serde(rename = "cancelling")]
         Cancelling,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Cancelling => write!(f, "cancelling"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5117,6 +5540,21 @@ pub mod release_environment {
         #[serde(rename = "partiallySucceeded")]
         PartiallySucceeded,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Queued => write!(f, "queued"),
+                Self::Scheduled => write!(f, "scheduled"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReleaseEnvironmentCompletedEvent {
@@ -5203,6 +5641,17 @@ pub mod release_environment_completed_event {
         #[serde(rename = "redeployTrigger")]
         RedeployTrigger,
     }
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::Automated => write!(f, "automated"),
+                Self::Scheduled => write!(f, "scheduled"),
+                Self::RedeployTrigger => write!(f, "redeployTrigger"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReleaseEnvironmentShallowReference {
@@ -5285,6 +5734,21 @@ pub mod release_environment_status_updated_event {
         #[serde(rename = "partiallySucceeded")]
         PartiallySucceeded,
     }
+    impl std::fmt::Display for EnvironmentStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Queued => write!(f, "queued"),
+                Self::Scheduled => write!(f, "scheduled"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum LatestDeploymentOperationStatus {
         #[serde(rename = "undefined")]
@@ -5328,6 +5792,32 @@ pub mod release_environment_status_updated_event {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for LatestDeploymentOperationStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Queued => write!(f, "queued"),
+                Self::Scheduled => write!(f, "scheduled"),
+                Self::Pending => write!(f, "pending"),
+                Self::Approved => write!(f, "approved"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Deferred => write!(f, "deferred"),
+                Self::QueuedForAgent => write!(f, "queuedForAgent"),
+                Self::PhaseInProgress => write!(f, "phaseInProgress"),
+                Self::PhaseSucceeded => write!(f, "phaseSucceeded"),
+                Self::PhasePartiallySucceeded => write!(f, "phasePartiallySucceeded"),
+                Self::PhaseFailed => write!(f, "phaseFailed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::PhaseCanceled => write!(f, "phaseCanceled"),
+                Self::ManualInterventionPending => write!(f, "manualInterventionPending"),
+                Self::QueuedForPipeline => write!(f, "queuedForPipeline"),
+                Self::Cancelling => write!(f, "cancelling"),
+                Self::EvaluatingGates => write!(f, "evaluatingGates"),
+                Self::GateFailed => write!(f, "gateFailed"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum LatestDeploymentStatus {
         #[serde(rename = "undefined")]
@@ -5344,6 +5834,19 @@ pub mod release_environment_status_updated_event {
         Failed,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for LatestDeploymentStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::NotDeployed => write!(f, "notDeployed"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5394,6 +5897,21 @@ pub mod release_environment_update_metadata {
         Scheduled,
         #[serde(rename = "partiallySucceeded")]
         PartiallySucceeded,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Rejected => write!(f, "rejected"),
+                Self::Queued => write!(f, "queued"),
+                Self::Scheduled => write!(f, "scheduled"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5490,6 +6008,18 @@ pub mod release_gates {
         Failed,
         #[serde(rename = "canceled")]
         Canceled,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Pending => write!(f, "pending"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5603,6 +6133,17 @@ pub mod release_not_created_event {
         #[serde(rename = "pullRequest")]
         PullRequest,
     }
+    impl std::fmt::Display for ReleaseReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::ContinuousIntegration => write!(f, "continuousIntegration"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::PullRequest => write!(f, "pullRequest"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReleaseReference {
@@ -5671,6 +6212,17 @@ pub mod release_reference {
         Schedule,
         #[serde(rename = "pullRequest")]
         PullRequest,
+    }
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::ContinuousIntegration => write!(f, "continuousIntegration"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::PullRequest => write!(f, "pullRequest"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5787,6 +6339,21 @@ pub mod release_schedule {
         Sunday,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for DaysToRelease {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Monday => write!(f, "monday"),
+                Self::Tuesday => write!(f, "tuesday"),
+                Self::Wednesday => write!(f, "wednesday"),
+                Self::Thursday => write!(f, "thursday"),
+                Self::Friday => write!(f, "friday"),
+                Self::Saturday => write!(f, "saturday"),
+                Self::Sunday => write!(f, "sunday"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5916,6 +6483,17 @@ pub mod release_start_metadata {
         #[serde(rename = "pullRequest")]
         PullRequest,
     }
+    impl std::fmt::Display for Reason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Manual => write!(f, "manual"),
+                Self::ContinuousIntegration => write!(f, "continuousIntegration"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::PullRequest => write!(f, "pullRequest"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReleaseTask {
@@ -6017,6 +6595,22 @@ pub mod release_task {
         Failed,
         #[serde(rename = "partiallySucceeded")]
         PartiallySucceeded,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Pending => write!(f, "pending"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Success => write!(f, "success"),
+                Self::Failure => write!(f, "failure"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::Failed => write!(f, "failed"),
+                Self::PartiallySucceeded => write!(f, "partiallySucceeded"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6173,6 +6767,19 @@ pub mod release_trigger_base {
         #[serde(rename = "pullRequest")]
         PullRequest,
     }
+    impl std::fmt::Display for TriggerType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::ArtifactSource => write!(f, "artifactSource"),
+                Self::Schedule => write!(f, "schedule"),
+                Self::SourceRepo => write!(f, "sourceRepo"),
+                Self::ContainerImage => write!(f, "containerImage"),
+                Self::Package => write!(f, "package"),
+                Self::PullRequest => write!(f, "pullRequest"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReleaseUpdateMetadata {
@@ -6219,6 +6826,16 @@ pub mod release_update_metadata {
         Active,
         #[serde(rename = "abandoned")]
         Abandoned,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Undefined => write!(f, "undefined"),
+                Self::Draft => write!(f, "draft"),
+                Self::Active => write!(f, "active"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6501,6 +7118,18 @@ pub mod summary_mail_section {
         WorkItems,
         #[serde(rename = "releaseInfo")]
         ReleaseInfo,
+    }
+    impl std::fmt::Display for SectionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Details => write!(f, "details"),
+                Self::Environments => write!(f, "environments"),
+                Self::Issues => write!(f, "issues"),
+                Self::TestResults => write!(f, "testResults"),
+                Self::WorkItems => write!(f, "workItems"),
+                Self::ReleaseInfo => write!(f, "releaseInfo"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6927,6 +7556,14 @@ pub mod yaml_file_source {
         None,
         #[serde(rename = "tfsGit")]
         TfsGit,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::TfsGit => write!(f, "tfsGit"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/search/models.rs
+++ b/azure_devops_rust_api/src/search/models.rs
@@ -582,6 +582,15 @@ pub mod repository {
         #[serde(rename = "custom")]
         Custom,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Git => write!(f, "git"),
+                Self::Tfvc => write!(f, "tfvc"),
+                Self::Custom => write!(f, "custom"),
+            }
+        }
+    }
 }
 #[doc = "Defines the repository status."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -671,6 +680,16 @@ pub mod setting_result {
         Project,
         #[serde(rename = "user")]
         User,
+    }
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Organization => write!(f, "organization"),
+                Self::Project => write!(f, "project"),
+                Self::User => write!(f, "user"),
+            }
+        }
     }
 }
 #[doc = "Defines a setting search request"]

--- a/azure_devops_rust_api/src/security_roles/models.rs
+++ b/azure_devops_rust_api/src/security_roles/models.rs
@@ -132,6 +132,14 @@ pub mod role_assignment {
         #[serde(rename = "inherited")]
         Inherited,
     }
+    impl std::fmt::Display for Access {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Assigned => write!(f, "assigned"),
+                Self::Inherited => write!(f, "inherited"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct RoleAssignmentList {

--- a/azure_devops_rust_api/src/service_endpoint/mod.rs
+++ b/azure_devops_rust_api/src/service_endpoint/mod.rs
@@ -631,7 +631,7 @@ pub mod endpoints {
             pub(crate) owner: Option<String>,
             pub(crate) include_failed: Option<bool>,
             pub(crate) include_details: Option<bool>,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) action_filter: Option<models::ServiceEndpointActionFilter>,
         }
         impl RequestBuilder {
             #[doc = "Type of the service endpoints."]
@@ -665,7 +665,10 @@ pub mod endpoints {
                 self
             }
             #[doc = "The \"actionFilter\" parameter allows users to evaluate requestor permissions and retrieve a list of endpoints that match the specified conditions, ensuring that only relevant endpoints are returned based on their permissions"]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::ServiceEndpointActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -720,7 +723,7 @@ pub mod endpoints {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -1557,11 +1560,14 @@ pub mod endpoints {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) endpoint_id: String,
-            pub(crate) action_filter: Option<String>,
+            pub(crate) action_filter: Option<models::ServiceEndpointActionFilter>,
         }
         impl RequestBuilder {
             #[doc = "Action filter for the service connection. It specifies the action which can be performed on the service connection."]
-            pub fn action_filter(mut self, action_filter: impl Into<String>) -> Self {
+            pub fn action_filter(
+                mut self,
+                action_filter: impl Into<models::ServiceEndpointActionFilter>,
+            ) -> Self {
                 self.action_filter = Some(action_filter.into());
                 self
             }
@@ -1590,7 +1596,7 @@ pub mod endpoints {
                         if let Some(action_filter) = &this.action_filter {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("actionFilter", action_filter);
+                                .append_pair("actionFilter", &action_filter.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/service_endpoint/models.rs
+++ b/azure_devops_rust_api/src/service_endpoint/models.rs
@@ -864,6 +864,19 @@ pub mod input_descriptor {
         #[serde(rename = "textArea")]
         TextArea,
     }
+    impl std::fmt::Display for InputMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::TextBox => write!(f, "textBox"),
+                Self::PasswordBox => write!(f, "passwordBox"),
+                Self::Combo => write!(f, "combo"),
+                Self::RadioButtons => write!(f, "radioButtons"),
+                Self::CheckBox => write!(f, "checkBox"),
+                Self::TextArea => write!(f, "textArea"),
+            }
+        }
+    }
 }
 #[doc = "Describes what values are valid for a subscription input"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -923,6 +936,18 @@ pub mod input_validation {
         Guid,
         #[serde(rename = "uri")]
         Uri,
+    }
+    impl std::fmt::Display for DataType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::String => write!(f, "string"),
+                Self::Number => write!(f, "number"),
+                Self::Boolean => write!(f, "boolean"),
+                Self::Guid => write!(f, "guid"),
+                Self::Uri => write!(f, "uri"),
+            }
+        }
     }
 }
 #[doc = "Information about a single value for an input"]
@@ -1548,6 +1573,18 @@ pub mod service_endpoint_execution_data {
         #[serde(rename = "abandoned")]
         Abandoned,
     }
+    impl std::fmt::Display for Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Succeeded => write!(f, "succeeded"),
+                Self::SucceededWithIssues => write!(f, "succeededWithIssues"),
+                Self::Failed => write!(f, "failed"),
+                Self::Canceled => write!(f, "canceled"),
+                Self::Skipped => write!(f, "skipped"),
+                Self::Abandoned => write!(f, "abandoned"),
+            }
+        }
+    }
 }
 #[doc = "Represents execution owner of the service endpoint."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1850,6 +1887,59 @@ pub mod service_endpoint_request_result {
         GatewayTimeout,
         #[serde(rename = "httpVersionNotSupported")]
         HttpVersionNotSupported,
+    }
+    impl std::fmt::Display for StatusCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Continue => write!(f, "continue"),
+                Self::SwitchingProtocols => write!(f, "switchingProtocols"),
+                Self::Ok => write!(f, "ok"),
+                Self::Created => write!(f, "created"),
+                Self::Accepted => write!(f, "accepted"),
+                Self::NonAuthoritativeInformation => write!(f, "nonAuthoritativeInformation"),
+                Self::NoContent => write!(f, "noContent"),
+                Self::ResetContent => write!(f, "resetContent"),
+                Self::PartialContent => write!(f, "partialContent"),
+                Self::MultipleChoices => write!(f, "multipleChoices"),
+                Self::Ambiguous => write!(f, "ambiguous"),
+                Self::MovedPermanently => write!(f, "movedPermanently"),
+                Self::Moved => write!(f, "moved"),
+                Self::Found => write!(f, "found"),
+                Self::Redirect => write!(f, "redirect"),
+                Self::SeeOther => write!(f, "seeOther"),
+                Self::RedirectMethod => write!(f, "redirectMethod"),
+                Self::NotModified => write!(f, "notModified"),
+                Self::UseProxy => write!(f, "useProxy"),
+                Self::Unused => write!(f, "unused"),
+                Self::TemporaryRedirect => write!(f, "temporaryRedirect"),
+                Self::RedirectKeepVerb => write!(f, "redirectKeepVerb"),
+                Self::BadRequest => write!(f, "badRequest"),
+                Self::Unauthorized => write!(f, "unauthorized"),
+                Self::PaymentRequired => write!(f, "paymentRequired"),
+                Self::Forbidden => write!(f, "forbidden"),
+                Self::NotFound => write!(f, "notFound"),
+                Self::MethodNotAllowed => write!(f, "methodNotAllowed"),
+                Self::NotAcceptable => write!(f, "notAcceptable"),
+                Self::ProxyAuthenticationRequired => write!(f, "proxyAuthenticationRequired"),
+                Self::RequestTimeout => write!(f, "requestTimeout"),
+                Self::Conflict => write!(f, "conflict"),
+                Self::Gone => write!(f, "gone"),
+                Self::LengthRequired => write!(f, "lengthRequired"),
+                Self::PreconditionFailed => write!(f, "preconditionFailed"),
+                Self::RequestEntityTooLarge => write!(f, "requestEntityTooLarge"),
+                Self::RequestUriTooLong => write!(f, "requestUriTooLong"),
+                Self::UnsupportedMediaType => write!(f, "unsupportedMediaType"),
+                Self::RequestedRangeNotSatisfiable => write!(f, "requestedRangeNotSatisfiable"),
+                Self::ExpectationFailed => write!(f, "expectationFailed"),
+                Self::UpgradeRequired => write!(f, "upgradeRequired"),
+                Self::InternalServerError => write!(f, "internalServerError"),
+                Self::NotImplemented => write!(f, "notImplemented"),
+                Self::BadGateway => write!(f, "badGateway"),
+                Self::ServiceUnavailable => write!(f, "serviceUnavailable"),
+                Self::GatewayTimeout => write!(f, "gatewayTimeout"),
+                Self::HttpVersionNotSupported => write!(f, "httpVersionNotSupported"),
+            }
+        }
     }
 }
 #[doc = "Represents type of the service endpoint."]

--- a/azure_devops_rust_api/src/service_endpoint/models.rs
+++ b/azure_devops_rust_api/src/service_endpoint/models.rs
@@ -1419,6 +1419,28 @@ impl ServiceEndpoint {
         }
     }
 }
+#[doc = "The \"actionFilter\" parameter allows users to evaluate requestor permissions and retrieve a list of endpoints that match the specified conditions, ensuring that only relevant endpoints are returned based on their permissions"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ServiceEndpointActionFilter {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "manage")]
+    Manage,
+    #[serde(rename = "use")]
+    Use,
+    #[serde(rename = "view")]
+    View,
+}
+impl std::fmt::Display for ServiceEndpointActionFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Manage => write!(f, "manage"),
+            Self::Use => write!(f, "use"),
+            Self::View => write!(f, "view"),
+        }
+    }
+}
 #[doc = "Represents the authentication scheme used to authenticate the endpoint."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ServiceEndpointAuthenticationScheme {

--- a/azure_devops_rust_api/src/status/models.rs
+++ b/azure_devops_rust_api/src/status/models.rs
@@ -60,6 +60,17 @@ pub mod geography_with_health {
         #[serde(rename = "healthy")]
         Healthy,
     }
+    impl std::fmt::Display for Health {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Unhealthy => write!(f, "unhealthy"),
+                Self::Degraded => write!(f, "degraded"),
+                Self::Advisory => write!(f, "advisory"),
+                Self::Healthy => write!(f, "healthy"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct LiveSiteEvent {
@@ -129,12 +140,29 @@ pub mod live_site_event {
         #[serde(rename = "advisory")]
         Advisory,
     }
+    impl std::fmt::Display for Severity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unhealthy => write!(f, "unhealthy"),
+                Self::Degraded => write!(f, "degraded"),
+                Self::Advisory => write!(f, "advisory"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum State {
         #[serde(rename = "active")]
         Active,
         #[serde(rename = "resolved")]
         Resolved,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Active => write!(f, "active"),
+                Self::Resolved => write!(f, "resolved"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -175,6 +203,14 @@ pub mod live_site_event_impact {
         Geography,
         #[serde(rename = "organization")]
         Organization,
+    }
+    impl std::fmt::Display for ScopeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Geography => write!(f, "geography"),
+                Self::Organization => write!(f, "organization"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -226,6 +262,14 @@ pub mod live_site_event_log {
         #[serde(rename = "organization")]
         Organization,
     }
+    impl std::fmt::Display for ScopeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Geography => write!(f, "geography"),
+                Self::Organization => write!(f, "organization"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Type {
         #[serde(rename = "event")]
@@ -234,6 +278,15 @@ pub mod live_site_event_log {
         Postmortem,
         #[serde(rename = "notification")]
         Notification,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Event => write!(f, "event"),
+                Self::Postmortem => write!(f, "postmortem"),
+                Self::Notification => write!(f, "notification"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -275,6 +328,14 @@ pub mod live_site_event_log_attachment {
         Geography,
         #[serde(rename = "organization")]
         Organization,
+    }
+    impl std::fmt::Display for ScopeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Geography => write!(f, "geography"),
+                Self::Organization => write!(f, "organization"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -413,6 +474,15 @@ pub mod service {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Active => write!(f, "active"),
+                Self::Hidden => write!(f, "hidden"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ServiceHealth {
@@ -477,6 +547,17 @@ pub mod service_with_health {
         Advisory,
         #[serde(rename = "healthy")]
         Healthy,
+    }
+    impl std::fmt::Display for Health {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Unhealthy => write!(f, "unhealthy"),
+                Self::Degraded => write!(f, "degraded"),
+                Self::Advisory => write!(f, "advisory"),
+                Self::Healthy => write!(f, "healthy"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -544,6 +625,17 @@ pub mod status_summary {
         Advisory,
         #[serde(rename = "healthy")]
         Healthy,
+    }
+    impl std::fmt::Display for Health {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::Unhealthy => write!(f, "unhealthy"),
+                Self::Degraded => write!(f, "degraded"),
+                Self::Advisory => write!(f, "advisory"),
+                Self::Healthy => write!(f, "healthy"),
+            }
+        }
     }
 }
 #[doc = "This class is used to serialize collections as a single JSON object on the wire."]

--- a/azure_devops_rust_api/src/symbol/models.rs
+++ b/azure_devops_rust_api/src/symbol/models.rs
@@ -77,6 +77,21 @@ pub mod debug_entry {
         #[serde(rename = "sourceIndexed")]
         SourceIndexed,
     }
+    impl std::fmt::Display for InformationLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Binary => write!(f, "binary"),
+                Self::Publics => write!(f, "publics"),
+                Self::TraceFormatPresent => write!(f, "traceFormatPresent"),
+                Self::TypeInfo => write!(f, "typeInfo"),
+                Self::LineNumbers => write!(f, "lineNumbers"),
+                Self::GlobalSymbols => write!(f, "globalSymbols"),
+                Self::Private => write!(f, "private"),
+                Self::SourceIndexed => write!(f, "sourceIndexed"),
+            }
+        }
+    }
     #[doc = "The status of debug entry."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -86,6 +101,15 @@ pub mod debug_entry {
         Created,
         #[serde(rename = "blobMissing")]
         BlobMissing,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Created => write!(f, "created"),
+                Self::BlobMissing => write!(f, "blobMissing"),
+            }
+        }
     }
 }
 #[doc = "A batch of debug entry to create."]
@@ -131,6 +155,15 @@ pub mod debug_entry_create_batch {
         SkipIfExists,
         #[serde(rename = "overwriteIfExists")]
         OverwriteIfExists,
+    }
+    impl std::fmt::Display for CreateBehavior {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ThrowIfExists => write!(f, "throwIfExists"),
+                Self::SkipIfExists => write!(f, "skipIfExists"),
+                Self::OverwriteIfExists => write!(f, "overwriteIfExists"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -262,6 +295,16 @@ pub mod request {
         Sealed,
         #[serde(rename = "unavailable")]
         Unavailable,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Created => write!(f, "created"),
+                Self::Sealed => write!(f, "sealed"),
+                Self::Unavailable => write!(f, "unavailable"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/test/mod.rs
+++ b/azure_devops_rust_api/src/test/mod.rs
@@ -372,10 +372,10 @@ pub mod runs {
             pub(crate) project: String,
             pub(crate) min_last_updated_date: time::OffsetDateTime,
             pub(crate) max_last_updated_date: time::OffsetDateTime,
-            pub(crate) state: Option<String>,
+            pub(crate) state: Option<models::TestRunState>,
             pub(crate) plan_ids: Option<String>,
             pub(crate) is_automated: Option<bool>,
-            pub(crate) publish_context: Option<String>,
+            pub(crate) publish_context: Option<models::TestRunPublishContext>,
             pub(crate) build_ids: Option<String>,
             pub(crate) build_def_ids: Option<String>,
             pub(crate) branch_name: Option<String>,
@@ -389,7 +389,7 @@ pub mod runs {
         }
         impl RequestBuilder {
             #[doc = "Current state of the Runs to be queried."]
-            pub fn state(mut self, state: impl Into<String>) -> Self {
+            pub fn state(mut self, state: impl Into<models::TestRunState>) -> Self {
                 self.state = Some(state.into());
                 self
             }
@@ -404,7 +404,10 @@ pub mod runs {
                 self
             }
             #[doc = "PublishContext of the Runs to be queried."]
-            pub fn publish_context(mut self, publish_context: impl Into<String>) -> Self {
+            pub fn publish_context(
+                mut self,
+                publish_context: impl Into<models::TestRunPublishContext>,
+            ) -> Self {
                 self.publish_context = Some(publish_context.into());
                 self
             }
@@ -493,7 +496,9 @@ pub mod runs {
                             .query_pairs_mut()
                             .append_pair("maxLastUpdatedDate", &formatted_date_time);
                         if let Some(state) = &this.state {
-                            req.url_mut().query_pairs_mut().append_pair("state", state);
+                            req.url_mut()
+                                .query_pairs_mut()
+                                .append_pair("state", &state.to_string());
                         }
                         if let Some(plan_ids) = &this.plan_ids {
                             req.url_mut()
@@ -508,7 +513,7 @@ pub mod runs {
                         if let Some(publish_context) = &this.publish_context {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("publishContext", publish_context);
+                                .append_pair("publishContext", &publish_context.to_string());
                         }
                         if let Some(build_ids) = &this.build_ids {
                             req.url_mut()
@@ -4483,14 +4488,17 @@ pub mod results {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) run_id: i32,
-            pub(crate) details_to_include: Option<String>,
+            pub(crate) details_to_include: Option<models::ResultDetails>,
             pub(crate) skip: Option<i32>,
             pub(crate) top: Option<i32>,
             pub(crate) outcomes: Option<String>,
         }
         impl RequestBuilder {
             #[doc = "Details to include with test results. Default is None. Other values are Iterations and WorkItems."]
-            pub fn details_to_include(mut self, details_to_include: impl Into<String>) -> Self {
+            pub fn details_to_include(
+                mut self,
+                details_to_include: impl Into<models::ResultDetails>,
+            ) -> Self {
                 self.details_to_include = Some(details_to_include.into());
                 self
             }
@@ -4534,7 +4542,7 @@ pub mod results {
                         if let Some(details_to_include) = &this.details_to_include {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("detailsToInclude", details_to_include);
+                                .append_pair("detailsToInclude", &details_to_include.to_string());
                         }
                         if let Some(skip) = &this.skip {
                             req.url_mut()
@@ -4826,11 +4834,14 @@ pub mod results {
             pub(crate) project: String,
             pub(crate) run_id: i32,
             pub(crate) test_case_result_id: i32,
-            pub(crate) details_to_include: Option<String>,
+            pub(crate) details_to_include: Option<models::ResultDetails>,
         }
         impl RequestBuilder {
             #[doc = "Details to include with test results. Default is None. Other values are Iterations, WorkItems and SubResults."]
-            pub fn details_to_include(mut self, details_to_include: impl Into<String>) -> Self {
+            pub fn details_to_include(
+                mut self,
+                details_to_include: impl Into<models::ResultDetails>,
+            ) -> Self {
                 self.details_to_include = Some(details_to_include.into());
                 self
             }
@@ -4859,7 +4870,7 @@ pub mod results {
                         if let Some(details_to_include) = &this.details_to_include {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("detailsToInclude", details_to_include);
+                                .append_pair("detailsToInclude", &details_to_include.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -5435,7 +5446,7 @@ pub mod session {
             pub(crate) period: Option<i32>,
             pub(crate) all_sessions: Option<bool>,
             pub(crate) include_all_properties: Option<bool>,
-            pub(crate) source: Option<String>,
+            pub(crate) source: Option<models::TestSessionSource>,
             pub(crate) include_only_completed_sessions: Option<bool>,
         }
         impl RequestBuilder {
@@ -5455,7 +5466,7 @@ pub mod session {
                 self
             }
             #[doc = "Source of the test session."]
-            pub fn source(mut self, source: impl Into<String>) -> Self {
+            pub fn source(mut self, source: impl Into<models::TestSessionSource>) -> Self {
                 self.source = Some(source.into());
                 self
             }
@@ -5508,7 +5519,7 @@ pub mod session {
                         if let Some(source) = &this.source {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("source", source);
+                                .append_pair("source", &source.to_string());
                         }
                         if let Some(include_only_completed_sessions) =
                             &this.include_only_completed_sessions

--- a/azure_devops_rust_api/src/test/models.rs
+++ b/azure_devops_rust_api/src/test/models.rs
@@ -186,6 +186,27 @@ pub mod aggregated_result_details_by_outcome {
         #[serde(rename = "notImpacted")]
         NotImpacted,
     }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::None => write!(f, "none"),
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Inconclusive => write!(f, "inconclusive"),
+                Self::Timeout => write!(f, "timeout"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Blocked => write!(f, "blocked"),
+                Self::NotExecuted => write!(f, "notExecuted"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Paused => write!(f, "paused"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AggregatedResultsAnalysis {
@@ -306,6 +327,27 @@ pub mod aggregated_results_by_outcome {
         #[serde(rename = "notImpacted")]
         NotImpacted,
     }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::None => write!(f, "none"),
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Inconclusive => write!(f, "inconclusive"),
+                Self::Timeout => write!(f, "timeout"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Blocked => write!(f, "blocked"),
+                Self::NotExecuted => write!(f, "notExecuted"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Paused => write!(f, "paused"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AggregatedResultsDifference {
@@ -376,6 +418,16 @@ pub mod aggregated_runs_by_outcome {
         #[serde(rename = "others")]
         Others,
     }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+                Self::Others => write!(f, "others"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AggregatedRunsByState {
@@ -413,6 +465,19 @@ pub mod aggregated_runs_by_state {
         Waiting,
         #[serde(rename = "needsInvestigation")]
         NeedsInvestigation,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Waiting => write!(f, "waiting"),
+                Self::NeedsInvestigation => write!(f, "needsInvestigation"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -531,6 +596,59 @@ pub mod batch_response {
         GatewayTimeout,
         #[serde(rename = "httpVersionNotSupported")]
         HttpVersionNotSupported,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Continue => write!(f, "continue"),
+                Self::SwitchingProtocols => write!(f, "switchingProtocols"),
+                Self::Ok => write!(f, "ok"),
+                Self::Created => write!(f, "created"),
+                Self::Accepted => write!(f, "accepted"),
+                Self::NonAuthoritativeInformation => write!(f, "nonAuthoritativeInformation"),
+                Self::NoContent => write!(f, "noContent"),
+                Self::ResetContent => write!(f, "resetContent"),
+                Self::PartialContent => write!(f, "partialContent"),
+                Self::MultipleChoices => write!(f, "multipleChoices"),
+                Self::Ambiguous => write!(f, "ambiguous"),
+                Self::MovedPermanently => write!(f, "movedPermanently"),
+                Self::Moved => write!(f, "moved"),
+                Self::Found => write!(f, "found"),
+                Self::Redirect => write!(f, "redirect"),
+                Self::SeeOther => write!(f, "seeOther"),
+                Self::RedirectMethod => write!(f, "redirectMethod"),
+                Self::NotModified => write!(f, "notModified"),
+                Self::UseProxy => write!(f, "useProxy"),
+                Self::Unused => write!(f, "unused"),
+                Self::TemporaryRedirect => write!(f, "temporaryRedirect"),
+                Self::RedirectKeepVerb => write!(f, "redirectKeepVerb"),
+                Self::BadRequest => write!(f, "badRequest"),
+                Self::Unauthorized => write!(f, "unauthorized"),
+                Self::PaymentRequired => write!(f, "paymentRequired"),
+                Self::Forbidden => write!(f, "forbidden"),
+                Self::NotFound => write!(f, "notFound"),
+                Self::MethodNotAllowed => write!(f, "methodNotAllowed"),
+                Self::NotAcceptable => write!(f, "notAcceptable"),
+                Self::ProxyAuthenticationRequired => write!(f, "proxyAuthenticationRequired"),
+                Self::RequestTimeout => write!(f, "requestTimeout"),
+                Self::Conflict => write!(f, "conflict"),
+                Self::Gone => write!(f, "gone"),
+                Self::LengthRequired => write!(f, "lengthRequired"),
+                Self::PreconditionFailed => write!(f, "preconditionFailed"),
+                Self::RequestEntityTooLarge => write!(f, "requestEntityTooLarge"),
+                Self::RequestUriTooLong => write!(f, "requestUriTooLong"),
+                Self::UnsupportedMediaType => write!(f, "unsupportedMediaType"),
+                Self::RequestedRangeNotSatisfiable => write!(f, "requestedRangeNotSatisfiable"),
+                Self::ExpectationFailed => write!(f, "expectationFailed"),
+                Self::UpgradeRequired => write!(f, "upgradeRequired"),
+                Self::InternalServerError => write!(f, "internalServerError"),
+                Self::NotImplemented => write!(f, "notImplemented"),
+                Self::BadGateway => write!(f, "badGateway"),
+                Self::ServiceUnavailable => write!(f, "serviceUnavailable"),
+                Self::GatewayTimeout => write!(f, "gatewayTimeout"),
+                Self::HttpVersionNotSupported => write!(f, "httpVersionNotSupported"),
+            }
+        }
     }
 }
 #[doc = "BuildConfiguration Details."]
@@ -919,6 +1037,14 @@ pub mod clone_operation_information {
         #[serde(rename = "testPlan")]
         TestPlan,
     }
+    impl std::fmt::Display for ResultObjectType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::TestSuite => write!(f, "testSuite"),
+                Self::TestPlan => write!(f, "testPlan"),
+            }
+        }
+    }
     #[doc = "Current state of the operation. When State reaches Succeeded or Failed, the operation is complete"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum State {
@@ -930,6 +1056,16 @@ pub mod clone_operation_information {
         Queued,
         #[serde(rename = "succeeded")]
         Succeeded,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Failed => write!(f, "failed"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Queued => write!(f, "queued"),
+                Self::Succeeded => write!(f, "succeeded"),
+            }
+        }
     }
 }
 #[doc = "Clone options for cloning the test suite."]
@@ -1206,6 +1342,35 @@ pub mod code_coverage_summary {
         #[serde(rename = "invalidCoverageInput")]
         InvalidCoverageInput,
     }
+    impl std::fmt::Display for CoverageDetailedSummaryStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Finalized => write!(f, "finalized"),
+                Self::Pending => write!(f, "pending"),
+                Self::UpdateRequestQueued => write!(f, "updateRequestQueued"),
+                Self::NoModulesFound => write!(f, "noModulesFound"),
+                Self::NumberOfFilesExceeded => write!(f, "numberOfFilesExceeded"),
+                Self::NoInputFiles => write!(f, "noInputFiles"),
+                Self::BuildCancelled => write!(f, "buildCancelled"),
+                Self::FailedJobs => write!(f, "failedJobs"),
+                Self::ModuleMergeJobTimeout => write!(f, "moduleMergeJobTimeout"),
+                Self::CodeCoverageSuccess => write!(f, "codeCoverageSuccess"),
+                Self::InvalidBuildConfiguration => write!(f, "invalidBuildConfiguration"),
+                Self::CoverageAnalyzerBuildNotFound => write!(f, "coverageAnalyzerBuildNotFound"),
+                Self::FailedToRequeue => write!(f, "failedToRequeue"),
+                Self::BuildBailedOut => write!(f, "buildBailedOut"),
+                Self::NoCodeCoverageTask => write!(f, "noCodeCoverageTask"),
+                Self::MergeJobFailed => write!(f, "mergeJobFailed"),
+                Self::MergeInvokerJobFailed => write!(f, "mergeInvokerJobFailed"),
+                Self::MonitorJobFailed => write!(f, "monitorJobFailed"),
+                Self::ModuleMergeInvokerJobTimeout => write!(f, "moduleMergeInvokerJobTimeout"),
+                Self::MonitorJobTimeout => write!(f, "monitorJobTimeout"),
+                Self::InvalidCoverageInput => write!(f, "invalidCoverageInput"),
+            }
+        }
+    }
     #[doc = "Uri of build against which difference in coverage is computed"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -1221,6 +1386,18 @@ pub mod code_coverage_summary {
         Pending,
         #[serde(rename = "updateRequestQueued")]
         UpdateRequestQueued,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Finalized => write!(f, "finalized"),
+                Self::Pending => write!(f, "pending"),
+                Self::UpdateRequestQueued => write!(f, "updateRequestQueued"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1436,6 +1613,18 @@ pub mod custom_test_field_definition {
         #[serde(rename = "guid")]
         Guid,
     }
+    impl std::fmt::Display for FieldType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Bit => write!(f, "bit"),
+                Self::DateTime => write!(f, "dateTime"),
+                Self::Int => write!(f, "int"),
+                Self::Float => write!(f, "float"),
+                Self::String => write!(f, "string"),
+                Self::Guid => write!(f, "guid"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Scope {
         #[serde(rename = "none")]
@@ -1448,6 +1637,17 @@ pub mod custom_test_field_definition {
         System,
         #[serde(rename = "all")]
         All,
+    }
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::TestRun => write!(f, "testRun"),
+                Self::TestResult => write!(f, "testResult"),
+                Self::System => write!(f, "system"),
+                Self::All => write!(f, "all"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1775,6 +1975,14 @@ pub mod flaky_detection {
         Custom,
         #[serde(rename = "system")]
         System,
+    }
+    impl std::fmt::Display for FlakyDetectionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Custom => write!(f, "custom"),
+                Self::System => write!(f, "system"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2565,6 +2773,17 @@ pub mod legacy_test_case_result {
         OrderedTest,
         #[serde(rename = "generic")]
         Generic,
+    }
+    impl std::fmt::Display for ResultGroupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Rerun => write!(f, "rerun"),
+                Self::DataDriven => write!(f, "dataDriven"),
+                Self::OrderedTest => write!(f, "orderedTest"),
+                Self::Generic => write!(f, "generic"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4173,6 +4392,59 @@ pub mod response {
         #[serde(rename = "httpVersionNotSupported")]
         HttpVersionNotSupported,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Continue => write!(f, "continue"),
+                Self::SwitchingProtocols => write!(f, "switchingProtocols"),
+                Self::Ok => write!(f, "ok"),
+                Self::Created => write!(f, "created"),
+                Self::Accepted => write!(f, "accepted"),
+                Self::NonAuthoritativeInformation => write!(f, "nonAuthoritativeInformation"),
+                Self::NoContent => write!(f, "noContent"),
+                Self::ResetContent => write!(f, "resetContent"),
+                Self::PartialContent => write!(f, "partialContent"),
+                Self::MultipleChoices => write!(f, "multipleChoices"),
+                Self::Ambiguous => write!(f, "ambiguous"),
+                Self::MovedPermanently => write!(f, "movedPermanently"),
+                Self::Moved => write!(f, "moved"),
+                Self::Found => write!(f, "found"),
+                Self::Redirect => write!(f, "redirect"),
+                Self::SeeOther => write!(f, "seeOther"),
+                Self::RedirectMethod => write!(f, "redirectMethod"),
+                Self::NotModified => write!(f, "notModified"),
+                Self::UseProxy => write!(f, "useProxy"),
+                Self::Unused => write!(f, "unused"),
+                Self::TemporaryRedirect => write!(f, "temporaryRedirect"),
+                Self::RedirectKeepVerb => write!(f, "redirectKeepVerb"),
+                Self::BadRequest => write!(f, "badRequest"),
+                Self::Unauthorized => write!(f, "unauthorized"),
+                Self::PaymentRequired => write!(f, "paymentRequired"),
+                Self::Forbidden => write!(f, "forbidden"),
+                Self::NotFound => write!(f, "notFound"),
+                Self::MethodNotAllowed => write!(f, "methodNotAllowed"),
+                Self::NotAcceptable => write!(f, "notAcceptable"),
+                Self::ProxyAuthenticationRequired => write!(f, "proxyAuthenticationRequired"),
+                Self::RequestTimeout => write!(f, "requestTimeout"),
+                Self::Conflict => write!(f, "conflict"),
+                Self::Gone => write!(f, "gone"),
+                Self::LengthRequired => write!(f, "lengthRequired"),
+                Self::PreconditionFailed => write!(f, "preconditionFailed"),
+                Self::RequestEntityTooLarge => write!(f, "requestEntityTooLarge"),
+                Self::RequestUriTooLong => write!(f, "requestUriTooLong"),
+                Self::UnsupportedMediaType => write!(f, "unsupportedMediaType"),
+                Self::RequestedRangeNotSatisfiable => write!(f, "requestedRangeNotSatisfiable"),
+                Self::ExpectationFailed => write!(f, "expectationFailed"),
+                Self::UpgradeRequired => write!(f, "upgradeRequired"),
+                Self::InternalServerError => write!(f, "internalServerError"),
+                Self::NotImplemented => write!(f, "notImplemented"),
+                Self::BadGateway => write!(f, "badGateway"),
+                Self::ServiceUnavailable => write!(f, "serviceUnavailable"),
+                Self::GatewayTimeout => write!(f, "gatewayTimeout"),
+                Self::HttpVersionNotSupported => write!(f, "httpVersionNotSupported"),
+            }
+        }
+    }
 }
 #[doc = "Test result retention settings"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4538,6 +4810,15 @@ pub mod results_filter {
         #[serde(rename = "tfs")]
         Tfs,
     }
+    impl std::fmt::Display for ExecutedIn {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Any => write!(f, "any"),
+                Self::Tcm => write!(f, "tcm"),
+                Self::Tfs => write!(f, "tfs"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ResultsStoreQuery {
@@ -4873,6 +5154,14 @@ pub mod run_statistic {
         #[serde(rename = "flaky")]
         Flaky,
     }
+    impl std::fmt::Display for ResultMetadata {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Rerun => write!(f, "rerun"),
+                Self::Flaky => write!(f, "flaky"),
+            }
+        }
+    }
 }
 #[doc = "Summary of runs for a pipeline instance."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4975,6 +5264,27 @@ pub mod run_summary_model {
         InProgress,
         #[serde(rename = "notImpacted")]
         NotImpacted,
+    }
+    impl std::fmt::Display for TestOutcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::None => write!(f, "none"),
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Inconclusive => write!(f, "inconclusive"),
+                Self::Timeout => write!(f, "timeout"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Blocked => write!(f, "blocked"),
+                Self::NotExecuted => write!(f, "notExecuted"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Paused => write!(f, "paused"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5160,6 +5470,21 @@ pub mod run_update_model {
         Analyzed,
         #[serde(rename = "cancellationInProgress")]
         CancellationInProgress,
+    }
+    impl std::fmt::Display for Substate {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::CreatingEnvironment => write!(f, "creatingEnvironment"),
+                Self::RunningTests => write!(f, "runningTests"),
+                Self::CanceledByUser => write!(f, "canceledByUser"),
+                Self::AbortedBySystem => write!(f, "abortedBySystem"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::PendingAnalysis => write!(f, "pendingAnalysis"),
+                Self::Analyzed => write!(f, "analyzed"),
+                Self::CancellationInProgress => write!(f, "cancellationInProgress"),
+            }
+        }
     }
 }
 #[doc = "An abstracted reference to some other resource. This class is used to provide the build data contracts with a uniform way to reference other resources in a way that provides easy traversal through links."]
@@ -5574,6 +5899,19 @@ pub mod team_project_reference {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deleting => write!(f, "deleting"),
+                Self::New => write!(f, "new"),
+                Self::WellFormed => write!(f, "wellFormed"),
+                Self::CreatePending => write!(f, "createPending"),
+                Self::All => write!(f, "all"),
+                Self::Unchanged => write!(f, "unchanged"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
     #[doc = "Project visibility."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Visibility {
@@ -5585,6 +5923,16 @@ pub mod team_project_reference {
         Organization,
         #[serde(rename = "unchanged")]
         Unchanged,
+    }
+    impl std::fmt::Display for Visibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+                Self::Organization => write!(f, "organization"),
+                Self::Unchanged => write!(f, "unchanged"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -5839,6 +6187,15 @@ pub mod test_attachment {
         #[serde(rename = "consoleLog")]
         ConsoleLog,
     }
+    impl std::fmt::Display for AttachmentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::GeneralAttachment => write!(f, "generalAttachment"),
+                Self::CodeCoverage => write!(f, "codeCoverage"),
+                Self::ConsoleLog => write!(f, "consoleLog"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TestAttachmentList {
@@ -5951,6 +6308,18 @@ pub mod test_authoring_details {
         InProgress,
         #[serde(rename = "maxValue")]
         MaxValue,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Ready => write!(f, "ready"),
+                Self::Completed => write!(f, "completed"),
+                Self::NotReady => write!(f, "notReady"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::MaxValue => write!(f, "maxValue"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6376,6 +6745,17 @@ pub mod test_case_result {
         #[serde(rename = "generic")]
         Generic,
     }
+    impl std::fmt::Display for ResultGroupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Rerun => write!(f, "rerun"),
+                Self::DataDriven => write!(f, "dataDriven"),
+                Self::OrderedTest => write!(f, "orderedTest"),
+                Self::Generic => write!(f, "generic"),
+            }
+        }
+    }
 }
 #[doc = "Test attachment information in a test iteration."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6625,6 +7005,14 @@ pub mod test_configuration {
         #[serde(rename = "inactive")]
         Inactive,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Active => write!(f, "active"),
+                Self::Inactive => write!(f, "inactive"),
+            }
+        }
+    }
 }
 #[doc = "Test environment Detail."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6774,6 +7162,43 @@ pub mod test_extension_field_details {
         DateTime2,
         #[serde(rename = "dateTimeOffset")]
         DateTimeOffset,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::BigInt => write!(f, "bigInt"),
+                Self::Binary => write!(f, "binary"),
+                Self::Bit => write!(f, "bit"),
+                Self::Char => write!(f, "char"),
+                Self::DateTime => write!(f, "dateTime"),
+                Self::Decimal => write!(f, "decimal"),
+                Self::Float => write!(f, "float"),
+                Self::Image => write!(f, "image"),
+                Self::Int => write!(f, "int"),
+                Self::Money => write!(f, "money"),
+                Self::NChar => write!(f, "nChar"),
+                Self::NText => write!(f, "nText"),
+                Self::NVarChar => write!(f, "nVarChar"),
+                Self::Real => write!(f, "real"),
+                Self::UniqueIdentifier => write!(f, "uniqueIdentifier"),
+                Self::SmallDateTime => write!(f, "smallDateTime"),
+                Self::SmallInt => write!(f, "smallInt"),
+                Self::SmallMoney => write!(f, "smallMoney"),
+                Self::Text => write!(f, "text"),
+                Self::Timestamp => write!(f, "timestamp"),
+                Self::TinyInt => write!(f, "tinyInt"),
+                Self::VarBinary => write!(f, "varBinary"),
+                Self::VarChar => write!(f, "varChar"),
+                Self::Variant => write!(f, "variant"),
+                Self::Xml => write!(f, "xml"),
+                Self::Udt => write!(f, "udt"),
+                Self::Structured => write!(f, "structured"),
+                Self::Date => write!(f, "date"),
+                Self::Time => write!(f, "time"),
+                Self::DateTime2 => write!(f, "dateTime2"),
+                Self::DateTimeOffset => write!(f, "dateTimeOffset"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -6984,6 +7409,14 @@ pub mod test_history_query {
         #[serde(rename = "environment")]
         Environment,
     }
+    impl std::fmt::Display for GroupBy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Branch => write!(f, "branch"),
+                Self::Environment => write!(f, "environment"),
+            }
+        }
+    }
 }
 #[doc = "Represents a test iteration result."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -7156,11 +7589,25 @@ pub mod test_log_reference {
         #[serde(rename = "run")]
         Run,
     }
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Run => write!(f, "run"),
+            }
+        }
+    }
     #[doc = "Log Type"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Type {
         #[serde(rename = "generalAttachment")]
         GeneralAttachment,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::GeneralAttachment => write!(f, "generalAttachment"),
+            }
+        }
     }
 }
 #[doc = "Represents Test Log Status object."]
@@ -7225,6 +7672,29 @@ pub mod test_log_status {
         #[serde(rename = "storageCapacityExceeded")]
         StorageCapacityExceeded,
     }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Success => write!(f, "success"),
+                Self::Failed => write!(f, "failed"),
+                Self::FileAlreadyExists => write!(f, "fileAlreadyExists"),
+                Self::InvalidInput => write!(f, "invalidInput"),
+                Self::InvalidFileName => write!(f, "invalidFileName"),
+                Self::InvalidContainer => write!(f, "invalidContainer"),
+                Self::TransferFailed => write!(f, "transferFailed"),
+                Self::FeatureDisabled => write!(f, "featureDisabled"),
+                Self::BuildDoesNotExist => write!(f, "buildDoesNotExist"),
+                Self::RunDoesNotExist => write!(f, "runDoesNotExist"),
+                Self::ContainerNotCreated => write!(f, "containerNotCreated"),
+                Self::ApiNotSupported => write!(f, "apiNotSupported"),
+                Self::FileSizeExceeds => write!(f, "fileSizeExceeds"),
+                Self::ContainerNotFound => write!(f, "containerNotFound"),
+                Self::FileNotFound => write!(f, "fileNotFound"),
+                Self::DirectoryNotFound => write!(f, "directoryNotFound"),
+                Self::StorageCapacityExceeded => write!(f, "storageCapacityExceeded"),
+            }
+        }
+    }
 }
 #[doc = "Attachment metadata for test attachments from LogStore."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -7273,6 +7743,15 @@ pub mod test_log_store_attachment {
         CodeCoverage,
         #[serde(rename = "consoleLog")]
         ConsoleLog,
+    }
+    impl std::fmt::Display for AttachmentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::GeneralAttachment => write!(f, "generalAttachment"),
+                Self::CodeCoverage => write!(f, "codeCoverage"),
+                Self::ConsoleLog => write!(f, "consoleLog"),
+            }
+        }
     }
 }
 #[doc = "Reference to test attachment."]
@@ -7323,6 +7802,14 @@ pub mod test_log_store_endpoint_details {
         #[serde(rename = "file")]
         File,
     }
+    impl std::fmt::Display for EndpointType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Root => write!(f, "root"),
+                Self::File => write!(f, "file"),
+            }
+        }
+    }
     #[doc = "Test log store status code"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -7360,6 +7847,29 @@ pub mod test_log_store_endpoint_details {
         DirectoryNotFound,
         #[serde(rename = "storageCapacityExceeded")]
         StorageCapacityExceeded,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Success => write!(f, "success"),
+                Self::Failed => write!(f, "failed"),
+                Self::FileAlreadyExists => write!(f, "fileAlreadyExists"),
+                Self::InvalidInput => write!(f, "invalidInput"),
+                Self::InvalidFileName => write!(f, "invalidFileName"),
+                Self::InvalidContainer => write!(f, "invalidContainer"),
+                Self::TransferFailed => write!(f, "transferFailed"),
+                Self::FeatureDisabled => write!(f, "featureDisabled"),
+                Self::BuildDoesNotExist => write!(f, "buildDoesNotExist"),
+                Self::RunDoesNotExist => write!(f, "runDoesNotExist"),
+                Self::ContainerNotCreated => write!(f, "containerNotCreated"),
+                Self::ApiNotSupported => write!(f, "apiNotSupported"),
+                Self::FileSizeExceeds => write!(f, "fileSizeExceeds"),
+                Self::ContainerNotFound => write!(f, "containerNotFound"),
+                Self::FileNotFound => write!(f, "fileNotFound"),
+                Self::DirectoryNotFound => write!(f, "directoryNotFound"),
+                Self::StorageCapacityExceeded => write!(f, "storageCapacityExceeded"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -7925,6 +8435,18 @@ pub mod test_point_reference {
         #[serde(rename = "maxValue")]
         MaxValue,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Ready => write!(f, "ready"),
+                Self::Completed => write!(f, "completed"),
+                Self::NotReady => write!(f, "notReady"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::MaxValue => write!(f, "maxValue"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TestPointsEvent {
@@ -8208,6 +8730,15 @@ pub mod test_result_attachment {
         CodeCoverage,
         #[serde(rename = "consoleLog")]
         ConsoleLog,
+    }
+    impl std::fmt::Display for AttachmentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::GeneralAttachment => write!(f, "generalAttachment"),
+                Self::CodeCoverage => write!(f, "codeCoverage"),
+                Self::ConsoleLog => write!(f, "consoleLog"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -8915,6 +9446,15 @@ pub mod test_results_context {
         #[serde(rename = "pipeline")]
         Pipeline,
     }
+    impl std::fmt::Display for ContextType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Build => write!(f, "build"),
+                Self::Release => write!(f, "release"),
+                Self::Pipeline => write!(f, "pipeline"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TestResultsDetails {
@@ -9444,6 +9984,21 @@ pub mod test_run {
         Analyzed,
         #[serde(rename = "cancellationInProgress")]
         CancellationInProgress,
+    }
+    impl std::fmt::Display for Substate {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::CreatingEnvironment => write!(f, "creatingEnvironment"),
+                Self::RunningTests => write!(f, "runningTests"),
+                Self::CanceledByUser => write!(f, "canceledByUser"),
+                Self::AbortedBySystem => write!(f, "abortedBySystem"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::PendingAnalysis => write!(f, "pendingAnalysis"),
+                Self::Analyzed => write!(f, "analyzed"),
+                Self::CancellationInProgress => write!(f, "cancellationInProgress"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -10110,6 +10665,19 @@ pub mod test_session {
         #[serde(rename = "sessionInsightsForAll")]
         SessionInsightsForAll,
     }
+    impl std::fmt::Display for Source {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unknown => write!(f, "unknown"),
+                Self::XtDesktop => write!(f, "xtDesktop"),
+                Self::FeedbackDesktop => write!(f, "feedbackDesktop"),
+                Self::XtWeb => write!(f, "xtWeb"),
+                Self::FeedbackWeb => write!(f, "feedbackWeb"),
+                Self::XtDesktop2 => write!(f, "xtDesktop2"),
+                Self::SessionInsightsForAll => write!(f, "sessionInsightsForAll"),
+            }
+        }
+    }
     #[doc = "State of the test session"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum State {
@@ -10125,6 +10693,18 @@ pub mod test_session {
         Completed,
         #[serde(rename = "declined")]
         Declined,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Paused => write!(f, "paused"),
+                Self::Completed => write!(f, "completed"),
+                Self::Declined => write!(f, "declined"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -10459,6 +11039,17 @@ pub mod test_sub_result {
         OrderedTest,
         #[serde(rename = "generic")]
         Generic,
+    }
+    impl std::fmt::Display for ResultGroupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Rerun => write!(f, "rerun"),
+                Self::DataDriven => write!(f, "dataDriven"),
+                Self::OrderedTest => write!(f, "orderedTest"),
+                Self::Generic => write!(f, "generic"),
+            }
+        }
     }
 }
 #[doc = "Test suite"]
@@ -10919,5 +11510,14 @@ pub mod work_item_to_test_links {
         Tcm,
         #[serde(rename = "tfs")]
         Tfs,
+    }
+    impl std::fmt::Display for ExecutedIn {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Any => write!(f, "any"),
+                Self::Tcm => write!(f, "tcm"),
+                Self::Tfs => write!(f, "tfs"),
+            }
+        }
     }
 }

--- a/azure_devops_rust_api/src/test/models.rs
+++ b/azure_devops_rust_api/src/test/models.rs
@@ -4446,6 +4446,31 @@ pub mod response {
         }
     }
 }
+#[doc = "Details to include with test results. Default is None. Other values are Iterations and WorkItems."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ResultDetails {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "iterations")]
+    Iterations,
+    #[serde(rename = "workItems")]
+    WorkItems,
+    #[serde(rename = "subResults")]
+    SubResults,
+    #[serde(rename = "point")]
+    Point,
+}
+impl std::fmt::Display for ResultDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Iterations => write!(f, "iterations"),
+            Self::WorkItems => write!(f, "workItems"),
+            Self::SubResults => write!(f, "subResults"),
+            Self::Point => write!(f, "point"),
+        }
+    }
+}
 #[doc = "Test result retention settings"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ResultRetentionSettings {
@@ -10449,6 +10474,25 @@ impl TestRunList {
         Self::default()
     }
 }
+#[doc = "PublishContext of the Runs to be queried."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TestRunPublishContext {
+    #[serde(rename = "build")]
+    Build,
+    #[serde(rename = "release")]
+    Release,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for TestRunPublishContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Build => write!(f, "build"),
+            Self::Release => write!(f, "release"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TestRunStartedEvent {
     #[serde(flatten)]
@@ -10457,6 +10501,37 @@ pub struct TestRunStartedEvent {
 impl TestRunStartedEvent {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Current state of the Runs to be queried."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TestRunState {
+    #[serde(rename = "unspecified")]
+    Unspecified,
+    #[serde(rename = "notStarted")]
+    NotStarted,
+    #[serde(rename = "inProgress")]
+    InProgress,
+    #[serde(rename = "completed")]
+    Completed,
+    #[serde(rename = "aborted")]
+    Aborted,
+    #[serde(rename = "waiting")]
+    Waiting,
+    #[serde(rename = "needsInvestigation")]
+    NeedsInvestigation,
+}
+impl std::fmt::Display for TestRunState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unspecified => write!(f, "unspecified"),
+            Self::NotStarted => write!(f, "notStarted"),
+            Self::InProgress => write!(f, "inProgress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Aborted => write!(f, "aborted"),
+            Self::Waiting => write!(f, "waiting"),
+            Self::NeedsInvestigation => write!(f, "needsInvestigation"),
+        }
     }
 }
 #[doc = "Test run statistics."]
@@ -10755,6 +10830,37 @@ pub struct TestSessionList {
 impl TestSessionList {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Source of the test session."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TestSessionSource {
+    #[serde(rename = "unknown")]
+    Unknown,
+    #[serde(rename = "xtDesktop")]
+    XtDesktop,
+    #[serde(rename = "feedbackDesktop")]
+    FeedbackDesktop,
+    #[serde(rename = "xtWeb")]
+    XtWeb,
+    #[serde(rename = "feedbackWeb")]
+    FeedbackWeb,
+    #[serde(rename = "xtDesktop2")]
+    XtDesktop2,
+    #[serde(rename = "sessionInsightsForAll")]
+    SessionInsightsForAll,
+}
+impl std::fmt::Display for TestSessionSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unknown => write!(f, "unknown"),
+            Self::XtDesktop => write!(f, "xtDesktop"),
+            Self::FeedbackDesktop => write!(f, "feedbackDesktop"),
+            Self::XtWeb => write!(f, "xtWeb"),
+            Self::FeedbackWeb => write!(f, "feedbackWeb"),
+            Self::XtDesktop2 => write!(f, "xtDesktop2"),
+            Self::SessionInsightsForAll => write!(f, "sessionInsightsForAll"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/test_plan/mod.rs
+++ b/azure_devops_rust_api/src/test_plan/mod.rs
@@ -480,7 +480,7 @@ pub mod suite_test_case {
             pub(crate) continuation_token: Option<String>,
             pub(crate) return_identity_ref: Option<bool>,
             pub(crate) expand: Option<bool>,
-            pub(crate) exclude_flags: Option<String>,
+            pub(crate) exclude_flags: Option<models::ExcludeFlags>,
             pub(crate) is_recursive: Option<bool>,
         }
         impl RequestBuilder {
@@ -515,7 +515,7 @@ pub mod suite_test_case {
                 self
             }
             #[doc = "Flag to exclude various values from payload. For example to remove point assignments pass exclude = 1. To remove extra information (links, test plan , test suite) pass exclude = 2. To remove both extra information and point assignments pass exclude = 3 (1 + 2)."]
-            pub fn exclude_flags(mut self, exclude_flags: impl Into<String>) -> Self {
+            pub fn exclude_flags(mut self, exclude_flags: impl Into<models::ExcludeFlags>) -> Self {
                 self.exclude_flags = Some(exclude_flags.into());
                 self
             }
@@ -578,7 +578,7 @@ pub mod suite_test_case {
                         if let Some(exclude_flags) = &this.exclude_flags {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("excludeFlags", exclude_flags);
+                                .append_pair("excludeFlags", &exclude_flags.to_string());
                         }
                         if let Some(is_recursive) = &this.is_recursive {
                             req.url_mut()
@@ -1842,13 +1842,13 @@ pub mod test_suites {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) plan_id: i32,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::SuiteExpand>,
             pub(crate) continuation_token: Option<String>,
             pub(crate) as_tree_view: Option<bool>,
         }
         impl RequestBuilder {
             #[doc = "Include the children suites and testers details."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::SuiteExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1887,7 +1887,7 @@ pub mod test_suites {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("expand", expand);
+                                .append_pair("expand", &expand.to_string());
                         }
                         if let Some(continuation_token) = &this.continuation_token {
                             req.url_mut()
@@ -2074,11 +2074,11 @@ pub mod test_suites {
             pub(crate) project: String,
             pub(crate) plan_id: i32,
             pub(crate) suite_id: i32,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::SuiteExpand>,
         }
         impl RequestBuilder {
             #[doc = "Include the children suites and testers details"]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::SuiteExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -2107,7 +2107,7 @@ pub mod test_suites {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("expand", expand);
+                                .append_pair("expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -3955,10 +3955,13 @@ pub mod test_suite_entry {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) suite_id: i32,
-            pub(crate) suite_entry_type: Option<String>,
+            pub(crate) suite_entry_type: Option<models::SuiteEntryTypes>,
         }
         impl RequestBuilder {
-            pub fn suite_entry_type(mut self, suite_entry_type: impl Into<String>) -> Self {
+            pub fn suite_entry_type(
+                mut self,
+                suite_entry_type: impl Into<models::SuiteEntryTypes>,
+            ) -> Self {
                 self.suite_entry_type = Some(suite_entry_type.into());
                 self
             }
@@ -3987,7 +3990,7 @@ pub mod test_suite_entry {
                         if let Some(suite_entry_type) = &this.suite_entry_type {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("suiteEntryType", suite_entry_type);
+                                .append_pair("suiteEntryType", &suite_entry_type.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/test_plan/models.rs
+++ b/azure_devops_rust_api/src/test_plan/models.rs
@@ -485,6 +485,25 @@ impl DestinationTestSuiteInfo {
         Self::default()
     }
 }
+#[doc = "Flag to exclude various values from payload. For example to remove point assignments pass exclude = 1. To remove extra information (links, test plan , test suite) pass exclude = 2. To remove both extra information and point assignments pass exclude = 3 (1 + 2)."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ExcludeFlags {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "pointAssignments")]
+    PointAssignments,
+    #[serde(rename = "extraInformation")]
+    ExtraInformation,
+}
+impl std::fmt::Display for ExcludeFlags {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::PointAssignments => write!(f, "pointAssignments"),
+            Self::ExtraInformation => write!(f, "extraInformation"),
+        }
+    }
+}
 #[doc = "Parameters for test case export operation"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ExportTestCaseParams {
@@ -1052,6 +1071,21 @@ impl SuiteEntryList {
         Self::default()
     }
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum SuiteEntryTypes {
+    #[serde(rename = "testCase")]
+    TestCase,
+    #[serde(rename = "suite")]
+    Suite,
+}
+impl std::fmt::Display for SuiteEntryTypes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TestCase => write!(f, "testCase"),
+            Self::Suite => write!(f, "suite"),
+        }
+    }
+}
 #[doc = "A suite entry defines properties for a test suite."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct SuiteEntryUpdateParams {
@@ -1094,6 +1128,25 @@ pub mod suite_entry_update_params {
                 Self::TestCase => write!(f, "testCase"),
                 Self::Suite => write!(f, "suite"),
             }
+        }
+    }
+}
+#[doc = "Include the children suites and testers details."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum SuiteExpand {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "children")]
+    Children,
+    #[serde(rename = "defaultTesters")]
+    DefaultTesters,
+}
+impl std::fmt::Display for SuiteExpand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Children => write!(f, "children"),
+            Self::DefaultTesters => write!(f, "defaultTesters"),
         }
     }
 }

--- a/azure_devops_rust_api/src/test_plan/models.rs
+++ b/azure_devops_rust_api/src/test_plan/models.rs
@@ -78,6 +78,16 @@ pub mod clone_operation_common_response {
         #[serde(rename = "succeeded")]
         Succeeded,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Failed => write!(f, "failed"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Queued => write!(f, "queued"),
+                Self::Succeeded => write!(f, "succeeded"),
+            }
+        }
+    }
 }
 #[doc = "Clone options for cloning the test suite."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -682,6 +692,14 @@ pub mod library_work_items_data {
         #[serde(rename = "error")]
         Error,
     }
+    impl std::fmt::Display for ReturnCode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Success => write!(f, "success"),
+                Self::Error => write!(f, "error"),
+            }
+        }
+    }
 }
 #[doc = "This is the request data contract for LibraryTestCaseDataProvider."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -763,6 +781,23 @@ pub mod library_work_items_data_provider_request {
         AllSharedSteps,
         #[serde(rename = "sharedStepsNotLinkedToRequirement")]
         SharedStepsNotLinkedToRequirement,
+    }
+    impl std::fmt::Display for LibraryQueryType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::AllTestCases => write!(f, "allTestCases"),
+                Self::TestCasesWithActiveBugs => write!(f, "testCasesWithActiveBugs"),
+                Self::TestCasesNotLinkedToRequirements => {
+                    write!(f, "testCasesNotLinkedToRequirements")
+                }
+                Self::TestCasesLinkedToRequirements => write!(f, "testCasesLinkedToRequirements"),
+                Self::AllSharedSteps => write!(f, "allSharedSteps"),
+                Self::SharedStepsNotLinkedToRequirement => {
+                    write!(f, "sharedStepsNotLinkedToRequirement")
+                }
+            }
+        }
     }
 }
 #[doc = "Name value pair"]
@@ -887,6 +922,28 @@ pub mod results {
         NotImpacted,
         #[serde(rename = "maxValue")]
         MaxValue,
+    }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::None => write!(f, "none"),
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Inconclusive => write!(f, "inconclusive"),
+                Self::Timeout => write!(f, "timeout"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Blocked => write!(f, "blocked"),
+                Self::NotExecuted => write!(f, "notExecuted"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Paused => write!(f, "paused"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+                Self::MaxValue => write!(f, "maxValue"),
+            }
+        }
     }
 }
 #[doc = "Source Test Plan information for Test Plan clone operation"]
@@ -1031,6 +1088,14 @@ pub mod suite_entry_update_params {
         #[serde(rename = "suite")]
         Suite,
     }
+    impl std::fmt::Display for SuiteEntryType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::TestCase => write!(f, "testCase"),
+                Self::Suite => write!(f, "suite"),
+            }
+        }
+    }
 }
 #[doc = "Create and Update Suite Test Case Parameters"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1129,6 +1194,19 @@ pub mod team_project_reference {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deleting => write!(f, "deleting"),
+                Self::New => write!(f, "new"),
+                Self::WellFormed => write!(f, "wellFormed"),
+                Self::CreatePending => write!(f, "createPending"),
+                Self::All => write!(f, "all"),
+                Self::Unchanged => write!(f, "unchanged"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
     #[doc = "Project visibility."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Visibility {
@@ -1140,6 +1218,16 @@ pub mod team_project_reference {
         Organization,
         #[serde(rename = "unchanged")]
         Unchanged,
+    }
+    impl std::fmt::Display for Visibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+                Self::Organization => write!(f, "organization"),
+                Self::Unchanged => write!(f, "unchanged"),
+            }
+        }
     }
 }
 #[doc = "Test Case Class"]
@@ -1251,6 +1339,29 @@ pub mod test_case_associated_result {
         Unspecified,
         #[serde(rename = "maxValue")]
         MaxValue,
+    }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Blocked => write!(f, "blocked"),
+                Self::Failed => write!(f, "failed"),
+                Self::Passed => write!(f, "passed"),
+                Self::Ready => write!(f, "ready"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Paused => write!(f, "paused"),
+                Self::Timeout => write!(f, "timeout"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+                Self::NotExecuted => write!(f, "notExecuted"),
+                Self::Inconclusive => write!(f, "inconclusive"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::None => write!(f, "none"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::MaxValue => write!(f, "maxValue"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1376,6 +1487,14 @@ pub mod test_configuration_create_update_parameters {
         Active,
         #[serde(rename = "inactive")]
         Inactive,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Active => write!(f, "active"),
+                Self::Inactive => write!(f, "inactive"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1822,6 +1941,14 @@ pub mod test_plans_library_work_item_filter {
         #[serde(rename = "and")]
         And,
     }
+    impl std::fmt::Display for FilterMode {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Or => write!(f, "or"),
+                Self::And => write!(f, "and"),
+            }
+        }
+    }
 }
 #[doc = "Test Point Class"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2018,6 +2145,19 @@ pub mod test_point_results {
         #[serde(rename = "maxValue")]
         MaxValue,
     }
+    impl std::fmt::Display for FailureType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Regression => write!(f, "regression"),
+                Self::NewIssue => write!(f, "new_Issue"),
+                Self::KnownIssue => write!(f, "known_Issue"),
+                Self::Unknown => write!(f, "unknown"),
+                Self::NullValue => write!(f, "null_Value"),
+                Self::MaxValue => write!(f, "maxValue"),
+            }
+        }
+    }
     #[doc = "Last Resolution State Id for the Test Point"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum LastResolutionState {
@@ -2036,6 +2176,19 @@ pub mod test_point_results {
         #[serde(rename = "maxValue")]
         MaxValue,
     }
+    impl std::fmt::Display for LastResolutionState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::NeedsInvestigation => write!(f, "needsInvestigation"),
+                Self::TestIssue => write!(f, "testIssue"),
+                Self::ProductIssue => write!(f, "productIssue"),
+                Self::ConfigurationIssue => write!(f, "configurationIssue"),
+                Self::NullValue => write!(f, "nullValue"),
+                Self::MaxValue => write!(f, "maxValue"),
+            }
+        }
+    }
     #[doc = "Last Result State of the Test Point"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum LastResultState {
@@ -2053,6 +2206,19 @@ pub mod test_point_results {
         Completed,
         #[serde(rename = "maxValue")]
         MaxValue,
+    }
+    impl std::fmt::Display for LastResultState {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::Pending => write!(f, "pending"),
+                Self::Queued => write!(f, "queued"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Paused => write!(f, "paused"),
+                Self::Completed => write!(f, "completed"),
+                Self::MaxValue => write!(f, "maxValue"),
+            }
+        }
     }
     #[doc = "Outcome of the Test Point"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -2090,6 +2256,28 @@ pub mod test_point_results {
         #[serde(rename = "maxValue")]
         MaxValue,
     }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::None => write!(f, "none"),
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Inconclusive => write!(f, "inconclusive"),
+                Self::Timeout => write!(f, "timeout"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Blocked => write!(f, "blocked"),
+                Self::NotExecuted => write!(f, "notExecuted"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Paused => write!(f, "paused"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+                Self::MaxValue => write!(f, "maxValue"),
+            }
+        }
+    }
     #[doc = "State of the Test Point"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum State {
@@ -2105,6 +2293,18 @@ pub mod test_point_results {
         InProgress,
         #[serde(rename = "maxValue")]
         MaxValue,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Ready => write!(f, "ready"),
+                Self::Completed => write!(f, "completed"),
+                Self::NotReady => write!(f, "notReady"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::MaxValue => write!(f, "maxValue"),
+            }
+        }
     }
 }
 #[doc = "Test Point Update Parameters"]
@@ -2272,6 +2472,16 @@ pub mod test_suite_create_params {
         StaticTestSuite,
         #[serde(rename = "requirementTestSuite")]
         RequirementTestSuite,
+    }
+    impl std::fmt::Display for SuiteType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::DynamicTestSuite => write!(f, "dynamicTestSuite"),
+                Self::StaticTestSuite => write!(f, "staticTestSuite"),
+                Self::RequirementTestSuite => write!(f, "requirementTestSuite"),
+            }
+        }
     }
 }
 #[doc = "Test Suite Create/Update Common Parameters"]

--- a/azure_devops_rust_api/src/test_results/mod.rs
+++ b/azure_devops_rust_api/src/test_results/mod.rs
@@ -936,10 +936,10 @@ pub mod runs {
             pub(crate) project: String,
             pub(crate) min_last_updated_date: time::OffsetDateTime,
             pub(crate) max_last_updated_date: time::OffsetDateTime,
-            pub(crate) state: Option<String>,
+            pub(crate) state: Option<models::TestRunState>,
             pub(crate) plan_ids: Option<String>,
             pub(crate) is_automated: Option<bool>,
-            pub(crate) publish_context: Option<String>,
+            pub(crate) publish_context: Option<models::TestRunPublishContext>,
             pub(crate) build_ids: Option<String>,
             pub(crate) build_def_ids: Option<String>,
             pub(crate) branch_name: Option<String>,
@@ -953,7 +953,7 @@ pub mod runs {
         }
         impl RequestBuilder {
             #[doc = "Current state of the Runs to be queried."]
-            pub fn state(mut self, state: impl Into<String>) -> Self {
+            pub fn state(mut self, state: impl Into<models::TestRunState>) -> Self {
                 self.state = Some(state.into());
                 self
             }
@@ -968,7 +968,10 @@ pub mod runs {
                 self
             }
             #[doc = "PublishContext of the Runs to be queried."]
-            pub fn publish_context(mut self, publish_context: impl Into<String>) -> Self {
+            pub fn publish_context(
+                mut self,
+                publish_context: impl Into<models::TestRunPublishContext>,
+            ) -> Self {
                 self.publish_context = Some(publish_context.into());
                 self
             }
@@ -1057,7 +1060,9 @@ pub mod runs {
                             .query_pairs_mut()
                             .append_pair("maxLastUpdatedDate", &formatted_date_time);
                         if let Some(state) = &this.state {
-                            req.url_mut().query_pairs_mut().append_pair("state", state);
+                            req.url_mut()
+                                .query_pairs_mut()
+                                .append_pair("state", &state.to_string());
                         }
                         if let Some(plan_ids) = &this.plan_ids {
                             req.url_mut()
@@ -1072,7 +1077,7 @@ pub mod runs {
                         if let Some(publish_context) = &this.publish_context {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("publishContext", publish_context);
+                                .append_pair("publishContext", &publish_context.to_string());
                         }
                         if let Some(build_ids) = &this.build_ids {
                             req.url_mut()
@@ -1771,7 +1776,7 @@ pub mod testlog {
             run_id: i32,
             result_id: i32,
             sub_result_id: i32,
-            type_: impl Into<String>,
+            type_: impl Into<models::TestLogType>,
         ) -> get_test_sub_result_logs::RequestBuilder {
             get_test_sub_result_logs::RequestBuilder {
                 client: self.0.clone(),
@@ -1802,7 +1807,7 @@ pub mod testlog {
             project: impl Into<String>,
             run_id: i32,
             result_id: i32,
-            type_: impl Into<String>,
+            type_: impl Into<models::TestLogType>,
         ) -> get_test_result_logs::RequestBuilder {
             get_test_result_logs::RequestBuilder {
                 client: self.0.clone(),
@@ -1830,7 +1835,7 @@ pub mod testlog {
             organization: impl Into<String>,
             project: impl Into<String>,
             run_id: i32,
-            type_: impl Into<String>,
+            type_: impl Into<models::TestLogType>,
         ) -> get_test_run_logs::RequestBuilder {
             get_test_run_logs::RequestBuilder {
                 client: self.0.clone(),
@@ -1857,7 +1862,7 @@ pub mod testlog {
             organization: impl Into<String>,
             project: impl Into<String>,
             build_id: i32,
-            type_: impl Into<String>,
+            type_: impl Into<models::TestLogType>,
         ) -> get_test_logs_for_build::RequestBuilder {
             get_test_logs_for_build::RequestBuilder {
                 client: self.0.clone(),
@@ -1914,7 +1919,7 @@ pub mod testlog {
             pub(crate) run_id: i32,
             pub(crate) result_id: i32,
             pub(crate) sub_result_id: i32,
-            pub(crate) type_: String,
+            pub(crate) type_: models::TestLogType,
             pub(crate) directory_path: Option<String>,
             pub(crate) file_name_prefix: Option<String>,
             pub(crate) fetch_meta_data: Option<bool>,
@@ -1974,7 +1979,9 @@ pub mod testlog {
                             .query_pairs_mut()
                             .append_pair("subResultId", &sub_result_id.to_string());
                         let type_ = &this.type_;
-                        req.url_mut().query_pairs_mut().append_pair("type", type_);
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair("type", &type_.to_string());
                         if let Some(directory_path) = &this.directory_path {
                             req.url_mut()
                                 .query_pairs_mut()
@@ -2076,7 +2083,7 @@ pub mod testlog {
             pub(crate) project: String,
             pub(crate) run_id: i32,
             pub(crate) result_id: i32,
-            pub(crate) type_: String,
+            pub(crate) type_: models::TestLogType,
             pub(crate) directory_path: Option<String>,
             pub(crate) file_name_prefix: Option<String>,
             pub(crate) fetch_meta_data: Option<bool>,
@@ -2132,7 +2139,9 @@ pub mod testlog {
                             );
                         }
                         let type_ = &this.type_;
-                        req.url_mut().query_pairs_mut().append_pair("type", type_);
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair("type", &type_.to_string());
                         if let Some(directory_path) = &this.directory_path {
                             req.url_mut()
                                 .query_pairs_mut()
@@ -2231,7 +2240,7 @@ pub mod testlog {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) run_id: i32,
-            pub(crate) type_: String,
+            pub(crate) type_: models::TestLogType,
             pub(crate) directory_path: Option<String>,
             pub(crate) file_name_prefix: Option<String>,
             pub(crate) fetch_meta_data: Option<bool>,
@@ -2287,7 +2296,9 @@ pub mod testlog {
                             );
                         }
                         let type_ = &this.type_;
-                        req.url_mut().query_pairs_mut().append_pair("type", type_);
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair("type", &type_.to_string());
                         if let Some(directory_path) = &this.directory_path {
                             req.url_mut()
                                 .query_pairs_mut()
@@ -2385,7 +2396,7 @@ pub mod testlog {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) build_id: i32,
-            pub(crate) type_: String,
+            pub(crate) type_: models::TestLogType,
             pub(crate) directory_path: Option<String>,
             pub(crate) file_name_prefix: Option<String>,
             pub(crate) fetch_meta_data: Option<bool>,
@@ -2445,7 +2456,9 @@ pub mod testlog {
                             .query_pairs_mut()
                             .append_pair("buildId", &build_id.to_string());
                         let type_ = &this.type_;
-                        req.url_mut().query_pairs_mut().append_pair("type", type_);
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair("type", &type_.to_string());
                         if let Some(directory_path) = &this.directory_path {
                             req.url_mut()
                                 .query_pairs_mut()
@@ -2529,7 +2542,7 @@ pub mod testlogstoreendpoint {
             run_id: i32,
             result_id: i32,
             sub_result_id: i32,
-            type_: impl Into<String>,
+            type_: impl Into<models::TestLogType>,
             file_path: impl Into<String>,
         ) -> get_test_log_store_endpoint_details_for_sub_result_log::RequestBuilder {
             get_test_log_store_endpoint_details_for_sub_result_log::RequestBuilder {
@@ -2558,7 +2571,7 @@ pub mod testlogstoreendpoint {
             project: impl Into<String>,
             run_id: i32,
             result_id: i32,
-            type_: impl Into<String>,
+            type_: impl Into<models::TestLogType>,
             file_path: impl Into<String>,
         ) -> get_test_log_store_endpoint_details_for_result_log::RequestBuilder {
             get_test_log_store_endpoint_details_for_result_log::RequestBuilder {
@@ -2589,7 +2602,7 @@ pub mod testlogstoreendpoint {
             result_id: i32,
             sub_result_id: i32,
             file_path: impl Into<String>,
-            type_: impl Into<String>,
+            type_: impl Into<models::TestLogType>,
         ) -> test_log_store_endpoint_details_for_result::RequestBuilder {
             test_log_store_endpoint_details_for_result::RequestBuilder {
                 client: self.0.clone(),
@@ -2615,7 +2628,7 @@ pub mod testlogstoreendpoint {
             organization: impl Into<String>,
             project: impl Into<String>,
             run_id: i32,
-            type_: impl Into<String>,
+            type_: impl Into<models::TestLogType>,
             file_path: impl Into<String>,
         ) -> get_test_log_store_endpoint_details_for_run_log::RequestBuilder {
             get_test_log_store_endpoint_details_for_run_log::RequestBuilder {
@@ -2639,7 +2652,7 @@ pub mod testlogstoreendpoint {
             organization: impl Into<String>,
             project: impl Into<String>,
             run_id: i32,
-            test_log_store_operation_type: impl Into<String>,
+            test_log_store_operation_type: impl Into<models::TestLogStoreOperationType>,
         ) -> test_log_store_endpoint_details_for_run::RequestBuilder {
             test_log_store_endpoint_details_for_run::RequestBuilder {
                 client: self.0.clone(),
@@ -2664,7 +2677,7 @@ pub mod testlogstoreendpoint {
             organization: impl Into<String>,
             project: impl Into<String>,
             build: i32,
-            type_: impl Into<String>,
+            type_: impl Into<models::TestLogType>,
             file_path: impl Into<String>,
         ) -> get_test_log_store_endpoint_details_for_build_log::RequestBuilder {
             get_test_log_store_endpoint_details_for_build_log::RequestBuilder {
@@ -2688,7 +2701,7 @@ pub mod testlogstoreendpoint {
             organization: impl Into<String>,
             project: impl Into<String>,
             build_id: i32,
-            test_log_store_operation_type: impl Into<String>,
+            test_log_store_operation_type: impl Into<models::TestLogStoreOperationType>,
         ) -> test_log_store_endpoint_details_for_build::RequestBuilder {
             test_log_store_endpoint_details_for_build::RequestBuilder {
                 client: self.0.clone(),
@@ -2743,7 +2756,7 @@ pub mod testlogstoreendpoint {
             pub(crate) run_id: i32,
             pub(crate) result_id: i32,
             pub(crate) sub_result_id: i32,
-            pub(crate) type_: String,
+            pub(crate) type_: models::TestLogType,
             pub(crate) file_path: String,
         }
         impl RequestBuilder {
@@ -2774,7 +2787,9 @@ pub mod testlogstoreendpoint {
                             .query_pairs_mut()
                             .append_pair("subResultId", &sub_result_id.to_string());
                         let type_ = &this.type_;
-                        req.url_mut().query_pairs_mut().append_pair("type", type_);
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair("type", &type_.to_string());
                         let file_path = &this.file_path;
                         req.url_mut()
                             .query_pairs_mut()
@@ -2852,7 +2867,7 @@ pub mod testlogstoreendpoint {
             pub(crate) project: String,
             pub(crate) run_id: i32,
             pub(crate) result_id: i32,
-            pub(crate) type_: String,
+            pub(crate) type_: models::TestLogType,
             pub(crate) file_path: String,
         }
         impl RequestBuilder {
@@ -2879,7 +2894,9 @@ pub mod testlogstoreendpoint {
                             );
                         }
                         let type_ = &this.type_;
-                        req.url_mut().query_pairs_mut().append_pair("type", type_);
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair("type", &type_.to_string());
                         let file_path = &this.file_path;
                         req.url_mut()
                             .query_pairs_mut()
@@ -2966,7 +2983,7 @@ pub mod testlogstoreendpoint {
             pub(crate) result_id: i32,
             pub(crate) sub_result_id: i32,
             pub(crate) file_path: String,
-            pub(crate) type_: String,
+            pub(crate) type_: models::TestLogType,
         }
         impl RequestBuilder {
             #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
@@ -3000,7 +3017,9 @@ pub mod testlogstoreendpoint {
                             .query_pairs_mut()
                             .append_pair("filePath", file_path);
                         let type_ = &this.type_;
-                        req.url_mut().query_pairs_mut().append_pair("type", type_);
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair("type", &type_.to_string());
                         let req_body = azure_core::Bytes::new();
                         req.insert_header(azure_core::http::headers::CONTENT_LENGTH, "0");
                         req.set_body(req_body);
@@ -3081,7 +3100,7 @@ pub mod testlogstoreendpoint {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) run_id: i32,
-            pub(crate) type_: String,
+            pub(crate) type_: models::TestLogType,
             pub(crate) file_path: String,
         }
         impl RequestBuilder {
@@ -3108,7 +3127,9 @@ pub mod testlogstoreendpoint {
                             );
                         }
                         let type_ = &this.type_;
-                        req.url_mut().query_pairs_mut().append_pair("type", type_);
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair("type", &type_.to_string());
                         let file_path = &this.file_path;
                         req.url_mut()
                             .query_pairs_mut()
@@ -3191,9 +3212,9 @@ pub mod testlogstoreendpoint {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) run_id: i32,
-            pub(crate) test_log_store_operation_type: String,
+            pub(crate) test_log_store_operation_type: models::TestLogStoreOperationType,
             pub(crate) file_path: Option<String>,
-            pub(crate) type_: Option<String>,
+            pub(crate) type_: Option<models::TestLogType>,
         }
         impl RequestBuilder {
             #[doc = "file path to create an empty file"]
@@ -3202,7 +3223,7 @@ pub mod testlogstoreendpoint {
                 self
             }
             #[doc = "Default is GeneralAttachment, type of empty file to be created"]
-            pub fn type_(mut self, type_: impl Into<String>) -> Self {
+            pub fn type_(mut self, type_: impl Into<models::TestLogType>) -> Self {
                 self.type_ = Some(type_.into());
                 self
             }
@@ -3231,7 +3252,7 @@ pub mod testlogstoreendpoint {
                         let test_log_store_operation_type = &this.test_log_store_operation_type;
                         req.url_mut().query_pairs_mut().append_pair(
                             "testLogStoreOperationType",
-                            test_log_store_operation_type,
+                            &test_log_store_operation_type.to_string(),
                         );
                         if let Some(file_path) = &this.file_path {
                             req.url_mut()
@@ -3239,7 +3260,9 @@ pub mod testlogstoreendpoint {
                                 .append_pair("filePath", file_path);
                         }
                         if let Some(type_) = &this.type_ {
-                            req.url_mut().query_pairs_mut().append_pair("type", type_);
+                            req.url_mut()
+                                .query_pairs_mut()
+                                .append_pair("type", &type_.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.insert_header(azure_core::http::headers::CONTENT_LENGTH, "0");
@@ -3320,7 +3343,7 @@ pub mod testlogstoreendpoint {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) build: i32,
-            pub(crate) type_: String,
+            pub(crate) type_: models::TestLogType,
             pub(crate) file_path: String,
         }
         impl RequestBuilder {
@@ -3351,7 +3374,9 @@ pub mod testlogstoreendpoint {
                             .query_pairs_mut()
                             .append_pair("build", &build.to_string());
                         let type_ = &this.type_;
-                        req.url_mut().query_pairs_mut().append_pair("type", type_);
+                        req.url_mut()
+                            .query_pairs_mut()
+                            .append_pair("type", &type_.to_string());
                         let file_path = &this.file_path;
                         req.url_mut()
                             .query_pairs_mut()
@@ -3433,7 +3458,7 @@ pub mod testlogstoreendpoint {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) build_id: i32,
-            pub(crate) test_log_store_operation_type: String,
+            pub(crate) test_log_store_operation_type: models::TestLogStoreOperationType,
         }
         impl RequestBuilder {
             #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
@@ -3465,7 +3490,7 @@ pub mod testlogstoreendpoint {
                         let test_log_store_operation_type = &this.test_log_store_operation_type;
                         req.url_mut().query_pairs_mut().append_pair(
                             "testLogStoreOperationType",
-                            test_log_store_operation_type,
+                            &test_log_store_operation_type.to_string(),
                         );
                         let req_body = azure_core::Bytes::new();
                         req.insert_header(azure_core::http::headers::CONTENT_LENGTH, "0");
@@ -8636,14 +8661,17 @@ pub mod results {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) run_id: i32,
-            pub(crate) details_to_include: Option<String>,
+            pub(crate) details_to_include: Option<models::ResultDetails>,
             pub(crate) skip: Option<i32>,
             pub(crate) top: Option<i32>,
             pub(crate) outcomes: Option<String>,
             pub(crate) new_tests_only: Option<bool>,
         }
         impl RequestBuilder {
-            pub fn details_to_include(mut self, details_to_include: impl Into<String>) -> Self {
+            pub fn details_to_include(
+                mut self,
+                details_to_include: impl Into<models::ResultDetails>,
+            ) -> Self {
                 self.details_to_include = Some(details_to_include.into());
                 self
             }
@@ -8688,7 +8716,7 @@ pub mod results {
                         if let Some(details_to_include) = &this.details_to_include {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("detailsToInclude", details_to_include);
+                                .append_pair("detailsToInclude", &details_to_include.to_string());
                         }
                         if let Some(skip) = &this.skip {
                             req.url_mut()
@@ -8985,10 +9013,13 @@ pub mod results {
             pub(crate) project: String,
             pub(crate) run_id: i32,
             pub(crate) test_result_id: i32,
-            pub(crate) details_to_include: Option<String>,
+            pub(crate) details_to_include: Option<models::ResultDetails>,
         }
         impl RequestBuilder {
-            pub fn details_to_include(mut self, details_to_include: impl Into<String>) -> Self {
+            pub fn details_to_include(
+                mut self,
+                details_to_include: impl Into<models::ResultDetails>,
+            ) -> Self {
                 self.details_to_include = Some(details_to_include.into());
                 self
             }
@@ -9017,7 +9048,7 @@ pub mod results {
                         if let Some(details_to_include) = &this.details_to_include {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("detailsToInclude", details_to_include);
+                                .append_pair("detailsToInclude", &details_to_include.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -9273,11 +9304,14 @@ pub mod result_meta_data {
             pub(crate) organization: String,
             pub(crate) body: Vec<String>,
             pub(crate) project: String,
-            pub(crate) details_to_include: Option<String>,
+            pub(crate) details_to_include: Option<models::ResultMetaDataDetails>,
         }
         impl RequestBuilder {
             #[doc = "Details to include with test results metadata. Default is None. Other values are FlakyIdentifiers."]
-            pub fn details_to_include(mut self, details_to_include: impl Into<String>) -> Self {
+            pub fn details_to_include(
+                mut self,
+                details_to_include: impl Into<models::ResultMetaDataDetails>,
+            ) -> Self {
                 self.details_to_include = Some(details_to_include.into());
                 self
             }
@@ -9308,7 +9342,7 @@ pub mod result_meta_data {
                         if let Some(details_to_include) = &this.details_to_include {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("detailsToInclude", details_to_include);
+                                .append_pair("detailsToInclude", &details_to_include.to_string());
                         }
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))
@@ -12509,10 +12543,13 @@ pub mod settings {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) project: String,
-            pub(crate) settings_type: Option<String>,
+            pub(crate) settings_type: Option<models::TestResultsSettingsType>,
         }
         impl RequestBuilder {
-            pub fn settings_type(mut self, settings_type: impl Into<String>) -> Self {
+            pub fn settings_type(
+                mut self,
+                settings_type: impl Into<models::TestResultsSettingsType>,
+            ) -> Self {
                 self.settings_type = Some(settings_type.into());
                 self
             }
@@ -12541,7 +12578,7 @@ pub mod settings {
                         if let Some(settings_type) = &this.settings_type {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("settingsType", settings_type);
+                                .append_pair("settingsType", &settings_type.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/test_results/models.rs
+++ b/azure_devops_rust_api/src/test_results/models.rs
@@ -117,6 +117,27 @@ pub mod aggregated_result_details_by_outcome {
         #[serde(rename = "notImpacted")]
         NotImpacted,
     }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::None => write!(f, "none"),
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Inconclusive => write!(f, "inconclusive"),
+                Self::Timeout => write!(f, "timeout"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Blocked => write!(f, "blocked"),
+                Self::NotExecuted => write!(f, "notExecuted"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Paused => write!(f, "paused"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AggregatedResultsAnalysis {
@@ -237,6 +258,27 @@ pub mod aggregated_results_by_outcome {
         #[serde(rename = "notImpacted")]
         NotImpacted,
     }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::None => write!(f, "none"),
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Inconclusive => write!(f, "inconclusive"),
+                Self::Timeout => write!(f, "timeout"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Blocked => write!(f, "blocked"),
+                Self::NotExecuted => write!(f, "notExecuted"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Paused => write!(f, "paused"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AggregatedResultsDifference {
@@ -307,6 +349,16 @@ pub mod aggregated_runs_by_outcome {
         #[serde(rename = "others")]
         Others,
     }
+    impl std::fmt::Display for Outcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+                Self::Others => write!(f, "others"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AggregatedRunsByState {
@@ -344,6 +396,19 @@ pub mod aggregated_runs_by_state {
         Waiting,
         #[serde(rename = "needsInvestigation")]
         NeedsInvestigation,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::NotStarted => write!(f, "notStarted"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Waiting => write!(f, "waiting"),
+                Self::NeedsInvestigation => write!(f, "needsInvestigation"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -692,6 +757,35 @@ pub mod code_coverage_summary {
         #[serde(rename = "invalidCoverageInput")]
         InvalidCoverageInput,
     }
+    impl std::fmt::Display for CoverageDetailedSummaryStatus {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Finalized => write!(f, "finalized"),
+                Self::Pending => write!(f, "pending"),
+                Self::UpdateRequestQueued => write!(f, "updateRequestQueued"),
+                Self::NoModulesFound => write!(f, "noModulesFound"),
+                Self::NumberOfFilesExceeded => write!(f, "numberOfFilesExceeded"),
+                Self::NoInputFiles => write!(f, "noInputFiles"),
+                Self::BuildCancelled => write!(f, "buildCancelled"),
+                Self::FailedJobs => write!(f, "failedJobs"),
+                Self::ModuleMergeJobTimeout => write!(f, "moduleMergeJobTimeout"),
+                Self::CodeCoverageSuccess => write!(f, "codeCoverageSuccess"),
+                Self::InvalidBuildConfiguration => write!(f, "invalidBuildConfiguration"),
+                Self::CoverageAnalyzerBuildNotFound => write!(f, "coverageAnalyzerBuildNotFound"),
+                Self::FailedToRequeue => write!(f, "failedToRequeue"),
+                Self::BuildBailedOut => write!(f, "buildBailedOut"),
+                Self::NoCodeCoverageTask => write!(f, "noCodeCoverageTask"),
+                Self::MergeJobFailed => write!(f, "mergeJobFailed"),
+                Self::MergeInvokerJobFailed => write!(f, "mergeInvokerJobFailed"),
+                Self::MonitorJobFailed => write!(f, "monitorJobFailed"),
+                Self::ModuleMergeInvokerJobTimeout => write!(f, "moduleMergeInvokerJobTimeout"),
+                Self::MonitorJobTimeout => write!(f, "monitorJobTimeout"),
+                Self::InvalidCoverageInput => write!(f, "invalidCoverageInput"),
+            }
+        }
+    }
     #[doc = "Uri of build against which difference in coverage is computed"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -707,6 +801,18 @@ pub mod code_coverage_summary {
         Pending,
         #[serde(rename = "updateRequestQueued")]
         UpdateRequestQueued,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Completed => write!(f, "completed"),
+                Self::Finalized => write!(f, "finalized"),
+                Self::Pending => write!(f, "pending"),
+                Self::UpdateRequestQueued => write!(f, "updateRequestQueued"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -906,6 +1012,14 @@ pub mod flaky_detection {
         Custom,
         #[serde(rename = "system")]
         System,
+    }
+    impl std::fmt::Display for FlakyDetectionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Custom => write!(f, "custom"),
+                Self::System => write!(f, "system"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1444,6 +1558,15 @@ pub mod results_filter {
         #[serde(rename = "tfs")]
         Tfs,
     }
+    impl std::fmt::Display for ExecutedIn {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Any => write!(f, "any"),
+                Self::Tcm => write!(f, "tcm"),
+                Self::Tfs => write!(f, "tfs"),
+            }
+        }
+    }
 }
 #[doc = "Result summary by the outcome of test results."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1755,6 +1878,14 @@ pub mod run_statistic {
         #[serde(rename = "flaky")]
         Flaky,
     }
+    impl std::fmt::Display for ResultMetadata {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Rerun => write!(f, "rerun"),
+                Self::Flaky => write!(f, "flaky"),
+            }
+        }
+    }
 }
 #[doc = "Summary of runs for a pipeline instance."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1857,6 +1988,27 @@ pub mod run_summary_model {
         InProgress,
         #[serde(rename = "notImpacted")]
         NotImpacted,
+    }
+    impl std::fmt::Display for TestOutcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Unspecified => write!(f, "unspecified"),
+                Self::None => write!(f, "none"),
+                Self::Passed => write!(f, "passed"),
+                Self::Failed => write!(f, "failed"),
+                Self::Inconclusive => write!(f, "inconclusive"),
+                Self::Timeout => write!(f, "timeout"),
+                Self::Aborted => write!(f, "aborted"),
+                Self::Blocked => write!(f, "blocked"),
+                Self::NotExecuted => write!(f, "notExecuted"),
+                Self::Warning => write!(f, "warning"),
+                Self::Error => write!(f, "error"),
+                Self::NotApplicable => write!(f, "notApplicable"),
+                Self::Paused => write!(f, "paused"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::NotImpacted => write!(f, "notImpacted"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2043,6 +2195,21 @@ pub mod run_update_model {
         #[serde(rename = "cancellationInProgress")]
         CancellationInProgress,
     }
+    impl std::fmt::Display for Substate {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::CreatingEnvironment => write!(f, "creatingEnvironment"),
+                Self::RunningTests => write!(f, "runningTests"),
+                Self::CanceledByUser => write!(f, "canceledByUser"),
+                Self::AbortedBySystem => write!(f, "abortedBySystem"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::PendingAnalysis => write!(f, "pendingAnalysis"),
+                Self::Analyzed => write!(f, "analyzed"),
+                Self::CancellationInProgress => write!(f, "cancellationInProgress"),
+            }
+        }
+    }
 }
 #[doc = "An abstracted reference to some other resource. This class is used to provide the build data contracts with a uniform way to reference other resources in a way that provides easy traversal through links."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2225,6 +2392,19 @@ pub mod team_project_reference {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deleting => write!(f, "deleting"),
+                Self::New => write!(f, "new"),
+                Self::WellFormed => write!(f, "wellFormed"),
+                Self::CreatePending => write!(f, "createPending"),
+                Self::All => write!(f, "all"),
+                Self::Unchanged => write!(f, "unchanged"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Visibility {
         #[serde(rename = "private")]
@@ -2235,6 +2415,16 @@ pub mod team_project_reference {
         Organization,
         #[serde(rename = "unchanged")]
         Unchanged,
+    }
+    impl std::fmt::Display for Visibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+                Self::Organization => write!(f, "organization"),
+                Self::Unchanged => write!(f, "unchanged"),
+            }
+        }
     }
 }
 #[doc = "Represents a test step result."]
@@ -2328,6 +2518,15 @@ pub mod test_attachment {
         CodeCoverage,
         #[serde(rename = "consoleLog")]
         ConsoleLog,
+    }
+    impl std::fmt::Display for AttachmentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::GeneralAttachment => write!(f, "generalAttachment"),
+                Self::CodeCoverage => write!(f, "codeCoverage"),
+                Self::ConsoleLog => write!(f, "consoleLog"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2683,6 +2882,17 @@ pub mod test_case_result {
         #[serde(rename = "generic")]
         Generic,
     }
+    impl std::fmt::Display for ResultGroupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Rerun => write!(f, "rerun"),
+                Self::DataDriven => write!(f, "dataDriven"),
+                Self::OrderedTest => write!(f, "orderedTest"),
+                Self::Generic => write!(f, "generic"),
+            }
+        }
+    }
 }
 #[doc = "Test attachment information in a test iteration."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2924,6 +3134,14 @@ pub mod test_history_query {
         #[serde(rename = "environment")]
         Environment,
     }
+    impl std::fmt::Display for GroupBy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Branch => write!(f, "branch"),
+                Self::Environment => write!(f, "environment"),
+            }
+        }
+    }
 }
 #[doc = "Represents a test iteration result."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3096,11 +3314,25 @@ pub mod test_log_reference {
         #[serde(rename = "run")]
         Run,
     }
+    impl std::fmt::Display for Scope {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Run => write!(f, "run"),
+            }
+        }
+    }
     #[doc = "Log Type"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Type {
         #[serde(rename = "generalAttachment")]
         GeneralAttachment,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::GeneralAttachment => write!(f, "generalAttachment"),
+            }
+        }
     }
 }
 #[doc = "Attachment metadata for test attachments from LogStore."]
@@ -3150,6 +3382,15 @@ pub mod test_log_store_attachment {
         CodeCoverage,
         #[serde(rename = "consoleLog")]
         ConsoleLog,
+    }
+    impl std::fmt::Display for AttachmentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::GeneralAttachment => write!(f, "generalAttachment"),
+                Self::CodeCoverage => write!(f, "codeCoverage"),
+                Self::ConsoleLog => write!(f, "consoleLog"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -3216,6 +3457,14 @@ pub mod test_log_store_endpoint_details {
         #[serde(rename = "file")]
         File,
     }
+    impl std::fmt::Display for EndpointType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Root => write!(f, "root"),
+                Self::File => write!(f, "file"),
+            }
+        }
+    }
     #[doc = "Test log store status code"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Status {
@@ -3253,6 +3502,29 @@ pub mod test_log_store_endpoint_details {
         DirectoryNotFound,
         #[serde(rename = "storageCapacityExceeded")]
         StorageCapacityExceeded,
+    }
+    impl std::fmt::Display for Status {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Success => write!(f, "success"),
+                Self::Failed => write!(f, "failed"),
+                Self::FileAlreadyExists => write!(f, "fileAlreadyExists"),
+                Self::InvalidInput => write!(f, "invalidInput"),
+                Self::InvalidFileName => write!(f, "invalidFileName"),
+                Self::InvalidContainer => write!(f, "invalidContainer"),
+                Self::TransferFailed => write!(f, "transferFailed"),
+                Self::FeatureDisabled => write!(f, "featureDisabled"),
+                Self::BuildDoesNotExist => write!(f, "buildDoesNotExist"),
+                Self::RunDoesNotExist => write!(f, "runDoesNotExist"),
+                Self::ContainerNotCreated => write!(f, "containerNotCreated"),
+                Self::ApiNotSupported => write!(f, "apiNotSupported"),
+                Self::FileSizeExceeds => write!(f, "fileSizeExceeds"),
+                Self::ContainerNotFound => write!(f, "containerNotFound"),
+                Self::FileNotFound => write!(f, "fileNotFound"),
+                Self::DirectoryNotFound => write!(f, "directoryNotFound"),
+                Self::StorageCapacityExceeded => write!(f, "storageCapacityExceeded"),
+            }
+        }
     }
 }
 #[doc = "An abstracted reference to some other resource. This class is used to provide the build data contracts with a uniform way to reference other resources in a way that provides easy traversal through links."]
@@ -3837,6 +4109,15 @@ pub mod test_results_context {
         #[serde(rename = "pipeline")]
         Pipeline,
     }
+    impl std::fmt::Display for ContextType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Build => write!(f, "build"),
+                Self::Release => write!(f, "release"),
+                Self::Pipeline => write!(f, "pipeline"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TestResultsDetails {
@@ -4244,6 +4525,21 @@ pub mod test_run {
         #[serde(rename = "cancellationInProgress")]
         CancellationInProgress,
     }
+    impl std::fmt::Display for Substate {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::CreatingEnvironment => write!(f, "creatingEnvironment"),
+                Self::RunningTests => write!(f, "runningTests"),
+                Self::CanceledByUser => write!(f, "canceledByUser"),
+                Self::AbortedBySystem => write!(f, "abortedBySystem"),
+                Self::TimedOut => write!(f, "timedOut"),
+                Self::PendingAnalysis => write!(f, "pendingAnalysis"),
+                Self::Analyzed => write!(f, "analyzed"),
+                Self::CancellationInProgress => write!(f, "cancellationInProgress"),
+            }
+        }
+    }
 }
 #[doc = "Test Run Code Coverage Details"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -4506,6 +4802,17 @@ pub mod test_sub_result {
         #[serde(rename = "generic")]
         Generic,
     }
+    impl std::fmt::Display for ResultGroupType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Rerun => write!(f, "rerun"),
+                Self::DataDriven => write!(f, "dataDriven"),
+                Self::OrderedTest => write!(f, "orderedTest"),
+                Self::Generic => write!(f, "generic"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TestSummaryForWorkItem {
@@ -4710,5 +5017,14 @@ pub mod work_item_to_test_links {
         Tcm,
         #[serde(rename = "tfs")]
         Tfs,
+    }
+    impl std::fmt::Display for ExecutedIn {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Any => write!(f, "any"),
+                Self::Tcm => write!(f, "tcm"),
+                Self::Tfs => write!(f, "tfs"),
+            }
+        }
     }
 }

--- a/azure_devops_rust_api/src/test_results/models.rs
+++ b/azure_devops_rust_api/src/test_results/models.rs
@@ -1432,6 +1432,46 @@ impl ReleaseReference {
         Self::default()
     }
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ResultDetails {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "iterations")]
+    Iterations,
+    #[serde(rename = "workItems")]
+    WorkItems,
+    #[serde(rename = "subResults")]
+    SubResults,
+    #[serde(rename = "point")]
+    Point,
+}
+impl std::fmt::Display for ResultDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Iterations => write!(f, "iterations"),
+            Self::WorkItems => write!(f, "workItems"),
+            Self::SubResults => write!(f, "subResults"),
+            Self::Point => write!(f, "point"),
+        }
+    }
+}
+#[doc = "Details to include with test results metadata. Default is None. Other values are FlakyIdentifiers."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ResultMetaDataDetails {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "flakyIdentifiers")]
+    FlakyIdentifiers,
+}
+impl std::fmt::Display for ResultMetaDataDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::FlakyIdentifiers => write!(f, "flakyIdentifiers"),
+        }
+    }
+}
 #[doc = "Summary of results for a pipeline instance."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ResultSummary {
@@ -3527,6 +3567,32 @@ pub mod test_log_store_endpoint_details {
         }
     }
 }
+#[doc = "Type of operation to perform using sas uri"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TestLogStoreOperationType {
+    #[serde(rename = "read")]
+    Read,
+}
+impl std::fmt::Display for TestLogStoreOperationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read => write!(f, "read"),
+        }
+    }
+}
+#[doc = "type of the attachments to get"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TestLogType {
+    #[serde(rename = "generalAttachment")]
+    GeneralAttachment,
+}
+impl std::fmt::Display for TestLogType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GeneralAttachment => write!(f, "generalAttachment"),
+        }
+    }
+}
 #[doc = "An abstracted reference to some other resource. This class is used to provide the build data contracts with a uniform way to reference other resources in a way that provides easy traversal through links."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TestMessageLogDetails {
@@ -4218,6 +4284,24 @@ impl TestResultsSettings {
         Self::default()
     }
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TestResultsSettingsType {
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "flaky")]
+    Flaky,
+    #[serde(rename = "newTestLogging")]
+    NewTestLogging,
+}
+impl std::fmt::Display for TestResultsSettingsType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::All => write!(f, "all"),
+            Self::Flaky => write!(f, "flaky"),
+            Self::NewTestLogging => write!(f, "newTestLogging"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TestResultsUpdateSettings {
     #[serde(
@@ -4596,6 +4680,56 @@ pub struct TestRunList {
 impl TestRunList {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "PublishContext of the Runs to be queried."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TestRunPublishContext {
+    #[serde(rename = "build")]
+    Build,
+    #[serde(rename = "release")]
+    Release,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for TestRunPublishContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Build => write!(f, "build"),
+            Self::Release => write!(f, "release"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
+#[doc = "Current state of the Runs to be queried."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TestRunState {
+    #[serde(rename = "unspecified")]
+    Unspecified,
+    #[serde(rename = "notStarted")]
+    NotStarted,
+    #[serde(rename = "inProgress")]
+    InProgress,
+    #[serde(rename = "completed")]
+    Completed,
+    #[serde(rename = "aborted")]
+    Aborted,
+    #[serde(rename = "waiting")]
+    Waiting,
+    #[serde(rename = "needsInvestigation")]
+    NeedsInvestigation,
+}
+impl std::fmt::Display for TestRunState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unspecified => write!(f, "unspecified"),
+            Self::NotStarted => write!(f, "notStarted"),
+            Self::InProgress => write!(f, "inProgress"),
+            Self::Completed => write!(f, "completed"),
+            Self::Aborted => write!(f, "aborted"),
+            Self::Waiting => write!(f, "waiting"),
+            Self::NeedsInvestigation => write!(f, "needsInvestigation"),
+        }
     }
 }
 #[doc = "Test run statistics."]

--- a/azure_devops_rust_api/src/tfvc/mod.rs
+++ b/azure_devops_rust_api/src/tfvc/mod.rs
@@ -1450,10 +1450,10 @@ pub mod items {
             pub(crate) file_name: Option<String>,
             pub(crate) download: Option<bool>,
             pub(crate) scope_path: Option<String>,
-            pub(crate) recursion_level: Option<String>,
+            pub(crate) recursion_level: Option<models::VersionControlRecursionType>,
             pub(crate) version_descriptor_version: Option<String>,
-            pub(crate) version_descriptor_version_option: Option<String>,
-            pub(crate) version_descriptor_version_type: Option<String>,
+            pub(crate) version_descriptor_version_option: Option<models::TfvcVersionOption>,
+            pub(crate) version_descriptor_version_type: Option<models::TfvcVersionType>,
             pub(crate) include_content: Option<bool>,
         }
         impl RequestBuilder {
@@ -1473,7 +1473,10 @@ pub mod items {
                 self
             }
             #[doc = "None (just the item), or OneLevel (contents of a folder)."]
-            pub fn recursion_level(mut self, recursion_level: impl Into<String>) -> Self {
+            pub fn recursion_level(
+                mut self,
+                recursion_level: impl Into<models::VersionControlRecursionType>,
+            ) -> Self {
                 self.recursion_level = Some(recursion_level.into());
                 self
             }
@@ -1488,7 +1491,7 @@ pub mod items {
             #[doc = "Version descriptor.  Default is null."]
             pub fn version_descriptor_version_option(
                 mut self,
-                version_descriptor_version_option: impl Into<String>,
+                version_descriptor_version_option: impl Into<models::TfvcVersionOption>,
             ) -> Self {
                 self.version_descriptor_version_option =
                     Some(version_descriptor_version_option.into());
@@ -1497,7 +1500,7 @@ pub mod items {
             #[doc = "Version descriptor.  Default is null."]
             pub fn version_descriptor_version_type(
                 mut self,
-                version_descriptor_version_type: impl Into<String>,
+                version_descriptor_version_type: impl Into<models::TfvcVersionType>,
             ) -> Self {
                 self.version_descriptor_version_type = Some(version_descriptor_version_type.into());
                 self
@@ -1549,7 +1552,7 @@ pub mod items {
                         if let Some(recursion_level) = &this.recursion_level {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("recursionLevel", recursion_level);
+                                .append_pair("recursionLevel", &recursion_level.to_string());
                         }
                         if let Some(version_descriptor_version) = &this.version_descriptor_version {
                             req.url_mut().query_pairs_mut().append_pair(
@@ -1562,7 +1565,7 @@ pub mod items {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionOption",
-                                version_descriptor_version_option,
+                                &version_descriptor_version_option.to_string(),
                             );
                         }
                         if let Some(version_descriptor_version_type) =
@@ -1570,7 +1573,7 @@ pub mod items {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionType",
-                                version_descriptor_version_type,
+                                &version_descriptor_version_type.to_string(),
                             );
                         }
                         if let Some(include_content) = &this.include_content {
@@ -1748,11 +1751,11 @@ pub mod items {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) scope_path: Option<String>,
-            pub(crate) recursion_level: Option<String>,
+            pub(crate) recursion_level: Option<models::VersionControlRecursionType>,
             pub(crate) include_links: Option<bool>,
             pub(crate) version_descriptor_version: Option<String>,
-            pub(crate) version_descriptor_version_option: Option<String>,
-            pub(crate) version_descriptor_version_type: Option<String>,
+            pub(crate) version_descriptor_version_option: Option<models::TfvcVersionOption>,
+            pub(crate) version_descriptor_version_type: Option<models::TfvcVersionType>,
         }
         impl RequestBuilder {
             #[doc = "Version control path of a folder to return multiple items."]
@@ -1761,7 +1764,10 @@ pub mod items {
                 self
             }
             #[doc = "None (just the item), or OneLevel (contents of a folder)."]
-            pub fn recursion_level(mut self, recursion_level: impl Into<String>) -> Self {
+            pub fn recursion_level(
+                mut self,
+                recursion_level: impl Into<models::VersionControlRecursionType>,
+            ) -> Self {
                 self.recursion_level = Some(recursion_level.into());
                 self
             }
@@ -1780,7 +1786,7 @@ pub mod items {
             }
             pub fn version_descriptor_version_option(
                 mut self,
-                version_descriptor_version_option: impl Into<String>,
+                version_descriptor_version_option: impl Into<models::TfvcVersionOption>,
             ) -> Self {
                 self.version_descriptor_version_option =
                     Some(version_descriptor_version_option.into());
@@ -1788,7 +1794,7 @@ pub mod items {
             }
             pub fn version_descriptor_version_type(
                 mut self,
-                version_descriptor_version_type: impl Into<String>,
+                version_descriptor_version_type: impl Into<models::TfvcVersionType>,
             ) -> Self {
                 self.version_descriptor_version_type = Some(version_descriptor_version_type.into());
                 self
@@ -1823,7 +1829,7 @@ pub mod items {
                         if let Some(recursion_level) = &this.recursion_level {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("recursionLevel", recursion_level);
+                                .append_pair("recursionLevel", &recursion_level.to_string());
                         }
                         if let Some(include_links) = &this.include_links {
                             req.url_mut()
@@ -1841,7 +1847,7 @@ pub mod items {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionOption",
-                                version_descriptor_version_option,
+                                &version_descriptor_version_option.to_string(),
                             );
                         }
                         if let Some(version_descriptor_version_type) =
@@ -1849,7 +1855,7 @@ pub mod items {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionType",
-                                version_descriptor_version_type,
+                                &version_descriptor_version_type.to_string(),
                             );
                         }
                         let req_body = azure_core::Bytes::new();

--- a/azure_devops_rust_api/src/tfvc/models.rs
+++ b/azure_devops_rust_api/src/tfvc/models.rs
@@ -1602,6 +1602,59 @@ pub mod tfvc_version_descriptor {
         }
     }
 }
+#[doc = "Version descriptor.  Default is null."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TfvcVersionOption {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "previous")]
+    Previous,
+    #[serde(rename = "useRename")]
+    UseRename,
+}
+impl std::fmt::Display for TfvcVersionOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Previous => write!(f, "previous"),
+            Self::UseRename => write!(f, "useRename"),
+        }
+    }
+}
+#[doc = "Version descriptor.  Default is null."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TfvcVersionType {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "changeset")]
+    Changeset,
+    #[serde(rename = "shelveset")]
+    Shelveset,
+    #[serde(rename = "change")]
+    Change,
+    #[serde(rename = "date")]
+    Date,
+    #[serde(rename = "latest")]
+    Latest,
+    #[serde(rename = "tip")]
+    Tip,
+    #[serde(rename = "mergeSource")]
+    MergeSource,
+}
+impl std::fmt::Display for TfvcVersionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Changeset => write!(f, "changeset"),
+            Self::Shelveset => write!(f, "shelveset"),
+            Self::Change => write!(f, "change"),
+            Self::Date => write!(f, "date"),
+            Self::Latest => write!(f, "latest"),
+            Self::Tip => write!(f, "tip"),
+            Self::MergeSource => write!(f, "mergeSource"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct VersionControlProjectInfo {
     #[serde(
@@ -1646,6 +1699,28 @@ pub mod version_control_project_info {
                 Self::Tfvc => write!(f, "tfvc"),
                 Self::Git => write!(f, "git"),
             }
+        }
+    }
+}
+#[doc = "None (just the item), or OneLevel (contents of a folder)."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum VersionControlRecursionType {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "oneLevel")]
+    OneLevel,
+    #[serde(rename = "oneLevelPlusNestedEmptyFolders")]
+    OneLevelPlusNestedEmptyFolders,
+    #[serde(rename = "full")]
+    Full,
+}
+impl std::fmt::Display for VersionControlRecursionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::OneLevel => write!(f, "oneLevel"),
+            Self::OneLevelPlusNestedEmptyFolders => write!(f, "oneLevelPlusNestedEmptyFolders"),
+            Self::Full => write!(f, "full"),
         }
     }
 }

--- a/azure_devops_rust_api/src/tfvc/models.rs
+++ b/azure_devops_rust_api/src/tfvc/models.rs
@@ -123,6 +123,27 @@ pub mod change {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for ChangeType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Add => write!(f, "add"),
+                Self::Edit => write!(f, "edit"),
+                Self::Encoding => write!(f, "encoding"),
+                Self::Rename => write!(f, "rename"),
+                Self::Delete => write!(f, "delete"),
+                Self::Undelete => write!(f, "undelete"),
+                Self::Branch => write!(f, "branch"),
+                Self::Merge => write!(f, "merge"),
+                Self::Lock => write!(f, "lock"),
+                Self::Rollback => write!(f, "rollback"),
+                Self::SourceRename => write!(f, "sourceRename"),
+                Self::TargetRename => write!(f, "targetRename"),
+                Self::Property => write!(f, "property"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct CheckinNote {
@@ -362,6 +383,14 @@ pub mod item_content {
         #[serde(rename = "base64Encoded")]
         Base64Encoded,
     }
+    impl std::fmt::Display for ContentType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::RawText => write!(f, "rawText"),
+                Self::Base64Encoded => write!(f, "base64Encoded"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ItemModel {
@@ -500,6 +529,19 @@ pub mod team_project_reference {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deleting => write!(f, "deleting"),
+                Self::New => write!(f, "new"),
+                Self::WellFormed => write!(f, "wellFormed"),
+                Self::CreatePending => write!(f, "createPending"),
+                Self::All => write!(f, "all"),
+                Self::Unchanged => write!(f, "unchanged"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
     #[doc = "Project visibility."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Visibility {
@@ -511,6 +553,16 @@ pub mod team_project_reference {
         Organization,
         #[serde(rename = "unchanged")]
         Unchanged,
+    }
+    impl std::fmt::Display for Visibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+                Self::Organization => write!(f, "organization"),
+                Self::Unchanged => write!(f, "unchanged"),
+            }
+        }
     }
 }
 #[doc = "Class representing a branch object."]
@@ -984,6 +1036,16 @@ pub mod tfvc_item_descriptor {
         #[serde(rename = "full")]
         Full,
     }
+    impl std::fmt::Display for RecursionLevel {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::OneLevel => write!(f, "oneLevel"),
+                Self::OneLevelPlusNestedEmptyFolders => write!(f, "oneLevelPlusNestedEmptyFolders"),
+                Self::Full => write!(f, "full"),
+            }
+        }
+    }
     #[doc = "Defaults to None."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum VersionOption {
@@ -993,6 +1055,15 @@ pub mod tfvc_item_descriptor {
         Previous,
         #[serde(rename = "useRename")]
         UseRename,
+    }
+    impl std::fmt::Display for VersionOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Previous => write!(f, "previous"),
+                Self::UseRename => write!(f, "useRename"),
+            }
+        }
     }
     #[doc = "Defaults to Latest."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1013,6 +1084,20 @@ pub mod tfvc_item_descriptor {
         Tip,
         #[serde(rename = "mergeSource")]
         MergeSource,
+    }
+    impl std::fmt::Display for VersionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Changeset => write!(f, "changeset"),
+                Self::Shelveset => write!(f, "shelveset"),
+                Self::Change => write!(f, "change"),
+                Self::Date => write!(f, "date"),
+                Self::Latest => write!(f, "latest"),
+                Self::Tip => write!(f, "tip"),
+                Self::MergeSource => write!(f, "mergeSource"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1474,6 +1559,15 @@ pub mod tfvc_version_descriptor {
         #[serde(rename = "useRename")]
         UseRename,
     }
+    impl std::fmt::Display for VersionOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Previous => write!(f, "previous"),
+                Self::UseRename => write!(f, "useRename"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum VersionType {
         #[serde(rename = "none")]
@@ -1492,6 +1586,20 @@ pub mod tfvc_version_descriptor {
         Tip,
         #[serde(rename = "mergeSource")]
         MergeSource,
+    }
+    impl std::fmt::Display for VersionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Changeset => write!(f, "changeset"),
+                Self::Shelveset => write!(f, "shelveset"),
+                Self::Change => write!(f, "change"),
+                Self::Date => write!(f, "date"),
+                Self::Latest => write!(f, "latest"),
+                Self::Tip => write!(f, "tip"),
+                Self::MergeSource => write!(f, "mergeSource"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1531,6 +1639,14 @@ pub mod version_control_project_info {
         Tfvc,
         #[serde(rename = "git")]
         Git,
+    }
+    impl std::fmt::Display for DefaultSourceControlType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Tfvc => write!(f, "tfvc"),
+                Self::Git => write!(f, "git"),
+            }
+        }
     }
 }
 #[doc = "This class is used to serialize collections as a single JSON object on the wire."]

--- a/azure_devops_rust_api/src/token_admin/models.rs
+++ b/azure_devops_rust_api/src/token_admin/models.rs
@@ -179,6 +179,45 @@ pub mod session_token_result {
         #[serde(rename = "deploymentHostNotSupported")]
         DeploymentHostNotSupported,
     }
+    impl std::fmt::Display for SessionTokenError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::DisplayNameRequired => write!(f, "displayNameRequired"),
+                Self::InvalidDisplayName => write!(f, "invalidDisplayName"),
+                Self::InvalidValidTo => write!(f, "invalidValidTo"),
+                Self::InvalidScope => write!(f, "invalidScope"),
+                Self::UserIdRequired => write!(f, "userIdRequired"),
+                Self::InvalidUserId => write!(f, "invalidUserId"),
+                Self::InvalidUserType => write!(f, "invalidUserType"),
+                Self::AccessDenied => write!(f, "accessDenied"),
+                Self::FailedToIssueAccessToken => write!(f, "failedToIssueAccessToken"),
+                Self::InvalidClient => write!(f, "invalidClient"),
+                Self::InvalidClientType => write!(f, "invalidClientType"),
+                Self::InvalidClientId => write!(f, "invalidClientId"),
+                Self::InvalidTargetAccounts => write!(f, "invalidTargetAccounts"),
+                Self::HostAuthorizationNotFound => write!(f, "hostAuthorizationNotFound"),
+                Self::AuthorizationNotFound => write!(f, "authorizationNotFound"),
+                Self::FailedToUpdateAccessToken => write!(f, "failedToUpdateAccessToken"),
+                Self::SourceNotSupported => write!(f, "sourceNotSupported"),
+                Self::InvalidSourceIp => write!(f, "invalidSourceIP"),
+                Self::InvalidSource => write!(f, "invalidSource"),
+                Self::DuplicateHash => write!(f, "duplicateHash"),
+                Self::SshPolicyDisabled => write!(f, "sshPolicyDisabled"),
+                Self::InvalidToken => write!(f, "invalidToken"),
+                Self::TokenNotFound => write!(f, "tokenNotFound"),
+                Self::InvalidAuthorizationId => write!(f, "invalidAuthorizationId"),
+                Self::FailedToReadTenantPolicy => write!(f, "failedToReadTenantPolicy"),
+                Self::GlobalPatPolicyViolation => write!(f, "globalPatPolicyViolation"),
+                Self::FullScopePatPolicyViolation => write!(f, "fullScopePatPolicyViolation"),
+                Self::PatLifespanPolicyViolation => write!(f, "patLifespanPolicyViolation"),
+                Self::InvalidTokenType => write!(f, "invalidTokenType"),
+                Self::InvalidAudience => write!(f, "invalidAudience"),
+                Self::InvalidSubject => write!(f, "invalidSubject"),
+                Self::DeploymentHostNotSupported => write!(f, "deploymentHostNotSupported"),
+            }
+        }
+    }
 }
 #[doc = "A paginated list of session tokens. Session tokens correspond to OAuth credentials such as personal access tokens (PATs) and other OAuth authorizations."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/tokens/mod.rs
+++ b/azure_devops_rust_api/src/tokens/mod.rs
@@ -257,8 +257,8 @@ pub mod pats {
         pub struct RequestBuilder {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
-            pub(crate) display_filter_option: Option<String>,
-            pub(crate) sort_by_option: Option<String>,
+            pub(crate) display_filter_option: Option<models::DisplayFilterOptions>,
+            pub(crate) sort_by_option: Option<models::SortByOptions>,
             pub(crate) is_sort_ascending: Option<bool>,
             pub(crate) continuation_token: Option<String>,
             pub(crate) top: Option<i32>,
@@ -267,13 +267,16 @@ pub mod pats {
             #[doc = "(Optional) Refers to the status of the personal access token (PAT)"]
             pub fn display_filter_option(
                 mut self,
-                display_filter_option: impl Into<String>,
+                display_filter_option: impl Into<models::DisplayFilterOptions>,
             ) -> Self {
                 self.display_filter_option = Some(display_filter_option.into());
                 self
             }
             #[doc = "(Optional) Which field to sort by"]
-            pub fn sort_by_option(mut self, sort_by_option: impl Into<String>) -> Self {
+            pub fn sort_by_option(
+                mut self,
+                sort_by_option: impl Into<models::SortByOptions>,
+            ) -> Self {
                 self.sort_by_option = Some(sort_by_option.into());
                 self
             }
@@ -315,14 +318,15 @@ pub mod pats {
                             );
                         }
                         if let Some(display_filter_option) = &this.display_filter_option {
-                            req.url_mut()
-                                .query_pairs_mut()
-                                .append_pair("displayFilterOption", display_filter_option);
+                            req.url_mut().query_pairs_mut().append_pair(
+                                "displayFilterOption",
+                                &display_filter_option.to_string(),
+                            );
                         }
                         if let Some(sort_by_option) = &this.sort_by_option {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("sortByOption", sort_by_option);
+                                .append_pair("sortByOption", &sort_by_option.to_string());
                         }
                         if let Some(is_sort_ascending) = &this.is_sort_ascending {
                             req.url_mut()

--- a/azure_devops_rust_api/src/tokens/models.rs
+++ b/azure_devops_rust_api/src/tokens/models.rs
@@ -137,6 +137,47 @@ pub mod access_token_result {
         #[serde(rename = "invalidScope")]
         InvalidScope,
     }
+    impl std::fmt::Display for AccessTokenError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::GrantTypeRequired => write!(f, "grantTypeRequired"),
+                Self::AuthorizationGrantRequired => write!(f, "authorizationGrantRequired"),
+                Self::ClientSecretRequired => write!(f, "clientSecretRequired"),
+                Self::RedirectUriRequired => write!(f, "redirectUriRequired"),
+                Self::InvalidAuthorizationGrant => write!(f, "invalidAuthorizationGrant"),
+                Self::InvalidAuthorizationScopes => write!(f, "invalidAuthorizationScopes"),
+                Self::InvalidRefreshToken => write!(f, "invalidRefreshToken"),
+                Self::AuthorizationNotFound => write!(f, "authorizationNotFound"),
+                Self::AuthorizationGrantExpired => write!(f, "authorizationGrantExpired"),
+                Self::AccessAlreadyIssued => write!(f, "accessAlreadyIssued"),
+                Self::InvalidRedirectUri => write!(f, "invalidRedirectUri"),
+                Self::AccessTokenNotFound => write!(f, "accessTokenNotFound"),
+                Self::InvalidAccessToken => write!(f, "invalidAccessToken"),
+                Self::AccessTokenAlreadyRefreshed => write!(f, "accessTokenAlreadyRefreshed"),
+                Self::InvalidClientSecret => write!(f, "invalidClientSecret"),
+                Self::ClientSecretExpired => write!(f, "clientSecretExpired"),
+                Self::ServerError => write!(f, "serverError"),
+                Self::AccessDenied => write!(f, "accessDenied"),
+                Self::AccessTokenKeyRequired => write!(f, "accessTokenKeyRequired"),
+                Self::InvalidAccessTokenKey => write!(f, "invalidAccessTokenKey"),
+                Self::FailedToGetAccessToken => write!(f, "failedToGetAccessToken"),
+                Self::InvalidClientId => write!(f, "invalidClientId"),
+                Self::InvalidClient => write!(f, "invalidClient"),
+                Self::InvalidValidTo => write!(f, "invalidValidTo"),
+                Self::InvalidUserId => write!(f, "invalidUserId"),
+                Self::FailedToIssueAccessToken => write!(f, "failedToIssueAccessToken"),
+                Self::AuthorizationGrantScopeMissing => write!(f, "authorizationGrantScopeMissing"),
+                Self::InvalidPublicAccessTokenKey => write!(f, "invalidPublicAccessTokenKey"),
+                Self::InvalidPublicAccessToken => write!(f, "invalidPublicAccessToken"),
+                Self::PublicFeatureFlagNotEnabled => write!(f, "publicFeatureFlagNotEnabled"),
+                Self::SshPolicyDisabled => write!(f, "sshPolicyDisabled"),
+                Self::HostAuthorizationNotFound => write!(f, "hostAuthorizationNotFound"),
+                Self::HostAuthorizationIsNotValid => write!(f, "hostAuthorizationIsNotValid"),
+                Self::InvalidScope => write!(f, "invalidScope"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct AuthorizationGrant {
@@ -162,6 +203,17 @@ pub mod authorization_grant {
         Implicit,
         #[serde(rename = "clientCredentials")]
         ClientCredentials,
+    }
+    impl std::fmt::Display for GrantType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::JwtBearer => write!(f, "jwtBearer"),
+                Self::RefreshToken => write!(f, "refreshToken"),
+                Self::Implicit => write!(f, "implicit"),
+                Self::ClientCredentials => write!(f, "clientCredentials"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -387,6 +439,45 @@ pub mod pat_token_result {
         InvalidSubject,
         #[serde(rename = "deploymentHostNotSupported")]
         DeploymentHostNotSupported,
+    }
+    impl std::fmt::Display for PatTokenError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::DisplayNameRequired => write!(f, "displayNameRequired"),
+                Self::InvalidDisplayName => write!(f, "invalidDisplayName"),
+                Self::InvalidValidTo => write!(f, "invalidValidTo"),
+                Self::InvalidScope => write!(f, "invalidScope"),
+                Self::UserIdRequired => write!(f, "userIdRequired"),
+                Self::InvalidUserId => write!(f, "invalidUserId"),
+                Self::InvalidUserType => write!(f, "invalidUserType"),
+                Self::AccessDenied => write!(f, "accessDenied"),
+                Self::FailedToIssueAccessToken => write!(f, "failedToIssueAccessToken"),
+                Self::InvalidClient => write!(f, "invalidClient"),
+                Self::InvalidClientType => write!(f, "invalidClientType"),
+                Self::InvalidClientId => write!(f, "invalidClientId"),
+                Self::InvalidTargetAccounts => write!(f, "invalidTargetAccounts"),
+                Self::HostAuthorizationNotFound => write!(f, "hostAuthorizationNotFound"),
+                Self::AuthorizationNotFound => write!(f, "authorizationNotFound"),
+                Self::FailedToUpdateAccessToken => write!(f, "failedToUpdateAccessToken"),
+                Self::SourceNotSupported => write!(f, "sourceNotSupported"),
+                Self::InvalidSourceIp => write!(f, "invalidSourceIP"),
+                Self::InvalidSource => write!(f, "invalidSource"),
+                Self::DuplicateHash => write!(f, "duplicateHash"),
+                Self::SshPolicyDisabled => write!(f, "sshPolicyDisabled"),
+                Self::InvalidToken => write!(f, "invalidToken"),
+                Self::TokenNotFound => write!(f, "tokenNotFound"),
+                Self::InvalidAuthorizationId => write!(f, "invalidAuthorizationId"),
+                Self::FailedToReadTenantPolicy => write!(f, "failedToReadTenantPolicy"),
+                Self::GlobalPatPolicyViolation => write!(f, "globalPatPolicyViolation"),
+                Self::FullScopePatPolicyViolation => write!(f, "fullScopePatPolicyViolation"),
+                Self::PatLifespanPolicyViolation => write!(f, "patLifespanPolicyViolation"),
+                Self::InvalidTokenType => write!(f, "invalidTokenType"),
+                Self::InvalidAudience => write!(f, "invalidAudience"),
+                Self::InvalidSubject => write!(f, "invalidSubject"),
+                Self::DeploymentHostNotSupported => write!(f, "deploymentHostNotSupported"),
+            }
+        }
     }
 }
 #[doc = "Encapsulates the request parameters for updating a personal access token (PAT)"]

--- a/azure_devops_rust_api/src/tokens/models.rs
+++ b/azure_devops_rust_api/src/tokens/models.rs
@@ -216,6 +216,28 @@ pub mod authorization_grant {
         }
     }
 }
+#[doc = "(Optional) Refers to the status of the personal access token (PAT)"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DisplayFilterOptions {
+    #[serde(rename = "active")]
+    Active,
+    #[serde(rename = "revoked")]
+    Revoked,
+    #[serde(rename = "expired")]
+    Expired,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for DisplayFilterOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Active => write!(f, "active"),
+            Self::Revoked => write!(f, "revoked"),
+            Self::Expired => write!(f, "expired"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct IssuedToken {
     #[serde(
@@ -607,5 +629,24 @@ pub struct SessionToken {
 impl SessionToken {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "(Optional) Which field to sort by"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum SortByOptions {
+    #[serde(rename = "displayName")]
+    DisplayName,
+    #[serde(rename = "displayDate")]
+    DisplayDate,
+    #[serde(rename = "status")]
+    Status,
+}
+impl std::fmt::Display for SortByOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DisplayName => write!(f, "displayName"),
+            Self::DisplayDate => write!(f, "displayDate"),
+            Self::Status => write!(f, "status"),
+        }
     }
 }

--- a/azure_devops_rust_api/src/wiki/mod.rs
+++ b/azure_devops_rust_api/src/wiki/mod.rs
@@ -833,8 +833,8 @@ pub mod attachments {
             pub(crate) wiki_identifier: String,
             pub(crate) name: String,
             pub(crate) version_descriptor_version: Option<String>,
-            pub(crate) version_descriptor_version_options: Option<String>,
-            pub(crate) version_descriptor_version_type: Option<String>,
+            pub(crate) version_descriptor_version_options: Option<models::GitVersionOptions>,
+            pub(crate) version_descriptor_version_type: Option<models::GitVersionType>,
         }
         impl RequestBuilder {
             #[doc = "Version string identifier (name of tag/branch, SHA1 of commit)"]
@@ -848,7 +848,7 @@ pub mod attachments {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn version_descriptor_version_options(
                 mut self,
-                version_descriptor_version_options: impl Into<String>,
+                version_descriptor_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.version_descriptor_version_options =
                     Some(version_descriptor_version_options.into());
@@ -857,7 +857,7 @@ pub mod attachments {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn version_descriptor_version_type(
                 mut self,
-                version_descriptor_version_type: impl Into<String>,
+                version_descriptor_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.version_descriptor_version_type = Some(version_descriptor_version_type.into());
                 self
@@ -899,7 +899,7 @@ pub mod attachments {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionOptions",
-                                version_descriptor_version_options,
+                                &version_descriptor_version_options.to_string(),
                             );
                         }
                         if let Some(version_descriptor_version_type) =
@@ -907,7 +907,7 @@ pub mod attachments {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionType",
-                                version_descriptor_version_type,
+                                &version_descriptor_version_type.to_string(),
                             );
                         }
                         req.set_body(req_body);
@@ -1032,8 +1032,8 @@ pub mod page_moves {
             pub(crate) wiki_identifier: String,
             pub(crate) comment: Option<String>,
             pub(crate) version_descriptor_version: Option<String>,
-            pub(crate) version_descriptor_version_options: Option<String>,
-            pub(crate) version_descriptor_version_type: Option<String>,
+            pub(crate) version_descriptor_version_options: Option<models::GitVersionOptions>,
+            pub(crate) version_descriptor_version_type: Option<models::GitVersionType>,
         }
         impl RequestBuilder {
             #[doc = "Comment that is to be associated with this page move."]
@@ -1052,7 +1052,7 @@ pub mod page_moves {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn version_descriptor_version_options(
                 mut self,
-                version_descriptor_version_options: impl Into<String>,
+                version_descriptor_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.version_descriptor_version_options =
                     Some(version_descriptor_version_options.into());
@@ -1061,7 +1061,7 @@ pub mod page_moves {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn version_descriptor_version_type(
                 mut self,
-                version_descriptor_version_type: impl Into<String>,
+                version_descriptor_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.version_descriptor_version_type = Some(version_descriptor_version_type.into());
                 self
@@ -1106,7 +1106,7 @@ pub mod page_moves {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionOptions",
-                                version_descriptor_version_options,
+                                &version_descriptor_version_options.to_string(),
                             );
                         }
                         if let Some(version_descriptor_version_type) =
@@ -1114,7 +1114,7 @@ pub mod page_moves {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionType",
-                                version_descriptor_version_type,
+                                &version_descriptor_version_type.to_string(),
                             );
                         }
                         req.set_body(req_body);
@@ -1370,10 +1370,10 @@ pub mod pages {
             pub(crate) project: String,
             pub(crate) wiki_identifier: String,
             pub(crate) path: Option<String>,
-            pub(crate) recursion_level: Option<String>,
+            pub(crate) recursion_level: Option<models::VersionControlRecursionType>,
             pub(crate) version_descriptor_version: Option<String>,
-            pub(crate) version_descriptor_version_options: Option<String>,
-            pub(crate) version_descriptor_version_type: Option<String>,
+            pub(crate) version_descriptor_version_options: Option<models::GitVersionOptions>,
+            pub(crate) version_descriptor_version_type: Option<models::GitVersionType>,
             pub(crate) include_content: Option<bool>,
         }
         impl RequestBuilder {
@@ -1383,7 +1383,10 @@ pub mod pages {
                 self
             }
             #[doc = "Recursion level for subpages retrieval. Defaults to `None` (Optional)."]
-            pub fn recursion_level(mut self, recursion_level: impl Into<String>) -> Self {
+            pub fn recursion_level(
+                mut self,
+                recursion_level: impl Into<models::VersionControlRecursionType>,
+            ) -> Self {
                 self.recursion_level = Some(recursion_level.into());
                 self
             }
@@ -1398,7 +1401,7 @@ pub mod pages {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn version_descriptor_version_options(
                 mut self,
-                version_descriptor_version_options: impl Into<String>,
+                version_descriptor_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.version_descriptor_version_options =
                     Some(version_descriptor_version_options.into());
@@ -1407,7 +1410,7 @@ pub mod pages {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn version_descriptor_version_type(
                 mut self,
-                version_descriptor_version_type: impl Into<String>,
+                version_descriptor_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.version_descriptor_version_type = Some(version_descriptor_version_type.into());
                 self
@@ -1445,7 +1448,7 @@ pub mod pages {
                         if let Some(recursion_level) = &this.recursion_level {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("recursionLevel", recursion_level);
+                                .append_pair("recursionLevel", &recursion_level.to_string());
                         }
                         if let Some(version_descriptor_version) = &this.version_descriptor_version {
                             req.url_mut().query_pairs_mut().append_pair(
@@ -1458,7 +1461,7 @@ pub mod pages {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionOptions",
-                                version_descriptor_version_options,
+                                &version_descriptor_version_options.to_string(),
                             );
                         }
                         if let Some(version_descriptor_version_type) =
@@ -1466,7 +1469,7 @@ pub mod pages {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionType",
-                                version_descriptor_version_type,
+                                &version_descriptor_version_type.to_string(),
                             );
                         }
                         if let Some(include_content) = &this.include_content {
@@ -1563,8 +1566,8 @@ pub mod pages {
             pub(crate) if_match: String,
             pub(crate) comment: Option<String>,
             pub(crate) version_descriptor_version: Option<String>,
-            pub(crate) version_descriptor_version_options: Option<String>,
-            pub(crate) version_descriptor_version_type: Option<String>,
+            pub(crate) version_descriptor_version_options: Option<models::GitVersionOptions>,
+            pub(crate) version_descriptor_version_type: Option<models::GitVersionType>,
         }
         impl RequestBuilder {
             #[doc = "Comment to be associated with the page operation."]
@@ -1583,7 +1586,7 @@ pub mod pages {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn version_descriptor_version_options(
                 mut self,
-                version_descriptor_version_options: impl Into<String>,
+                version_descriptor_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.version_descriptor_version_options =
                     Some(version_descriptor_version_options.into());
@@ -1592,7 +1595,7 @@ pub mod pages {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn version_descriptor_version_type(
                 mut self,
-                version_descriptor_version_type: impl Into<String>,
+                version_descriptor_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.version_descriptor_version_type = Some(version_descriptor_version_type.into());
                 self
@@ -1640,7 +1643,7 @@ pub mod pages {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionOptions",
-                                version_descriptor_version_options,
+                                &version_descriptor_version_options.to_string(),
                             );
                         }
                         if let Some(version_descriptor_version_type) =
@@ -1648,7 +1651,7 @@ pub mod pages {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionType",
-                                version_descriptor_version_type,
+                                &version_descriptor_version_type.to_string(),
                             );
                         }
                         req.set_body(req_body);
@@ -1737,8 +1740,8 @@ pub mod pages {
             pub(crate) path: String,
             pub(crate) comment: Option<String>,
             pub(crate) version_descriptor_version: Option<String>,
-            pub(crate) version_descriptor_version_options: Option<String>,
-            pub(crate) version_descriptor_version_type: Option<String>,
+            pub(crate) version_descriptor_version_options: Option<models::GitVersionOptions>,
+            pub(crate) version_descriptor_version_type: Option<models::GitVersionType>,
         }
         impl RequestBuilder {
             #[doc = "Comment to be associated with this page delete."]
@@ -1757,7 +1760,7 @@ pub mod pages {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn version_descriptor_version_options(
                 mut self,
-                version_descriptor_version_options: impl Into<String>,
+                version_descriptor_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.version_descriptor_version_options =
                     Some(version_descriptor_version_options.into());
@@ -1766,7 +1769,7 @@ pub mod pages {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn version_descriptor_version_type(
                 mut self,
-                version_descriptor_version_type: impl Into<String>,
+                version_descriptor_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.version_descriptor_version_type = Some(version_descriptor_version_type.into());
                 self
@@ -1811,7 +1814,7 @@ pub mod pages {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionOptions",
-                                version_descriptor_version_options,
+                                &version_descriptor_version_options.to_string(),
                             );
                         }
                         if let Some(version_descriptor_version_type) =
@@ -1819,7 +1822,7 @@ pub mod pages {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionType",
-                                version_descriptor_version_type,
+                                &version_descriptor_version_type.to_string(),
                             );
                         }
                         let req_body = azure_core::Bytes::new();
@@ -1907,12 +1910,15 @@ pub mod pages {
             pub(crate) project: String,
             pub(crate) wiki_identifier: String,
             pub(crate) id: i32,
-            pub(crate) recursion_level: Option<String>,
+            pub(crate) recursion_level: Option<models::VersionControlRecursionType>,
             pub(crate) include_content: Option<bool>,
         }
         impl RequestBuilder {
             #[doc = "Recursion level for subpages retrieval. Defaults to `None` (Optional)."]
-            pub fn recursion_level(mut self, recursion_level: impl Into<String>) -> Self {
+            pub fn recursion_level(
+                mut self,
+                recursion_level: impl Into<models::VersionControlRecursionType>,
+            ) -> Self {
                 self.recursion_level = Some(recursion_level.into());
                 self
             }
@@ -1946,7 +1952,7 @@ pub mod pages {
                         if let Some(recursion_level) = &this.recursion_level {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("recursionLevel", recursion_level);
+                                .append_pair("recursionLevel", &recursion_level.to_string());
                         }
                         if let Some(include_content) = &this.include_content {
                             req.url_mut()
@@ -2455,8 +2461,8 @@ pub mod pages_batch {
             pub(crate) project: String,
             pub(crate) wiki_identifier: String,
             pub(crate) version_descriptor_version: Option<String>,
-            pub(crate) version_descriptor_version_options: Option<String>,
-            pub(crate) version_descriptor_version_type: Option<String>,
+            pub(crate) version_descriptor_version_options: Option<models::GitVersionOptions>,
+            pub(crate) version_descriptor_version_type: Option<models::GitVersionType>,
         }
         impl RequestBuilder {
             #[doc = "Version string identifier (name of tag/branch, SHA1 of commit)"]
@@ -2470,7 +2476,7 @@ pub mod pages_batch {
             #[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
             pub fn version_descriptor_version_options(
                 mut self,
-                version_descriptor_version_options: impl Into<String>,
+                version_descriptor_version_options: impl Into<models::GitVersionOptions>,
             ) -> Self {
                 self.version_descriptor_version_options =
                     Some(version_descriptor_version_options.into());
@@ -2479,7 +2485,7 @@ pub mod pages_batch {
             #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
             pub fn version_descriptor_version_type(
                 mut self,
-                version_descriptor_version_type: impl Into<String>,
+                version_descriptor_version_type: impl Into<models::GitVersionType>,
             ) -> Self {
                 self.version_descriptor_version_type = Some(version_descriptor_version_type.into());
                 self
@@ -2519,7 +2525,7 @@ pub mod pages_batch {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionOptions",
-                                version_descriptor_version_options,
+                                &version_descriptor_version_options.to_string(),
                             );
                         }
                         if let Some(version_descriptor_version_type) =
@@ -2527,7 +2533,7 @@ pub mod pages_batch {
                         {
                             req.url_mut().query_pairs_mut().append_pair(
                                 "versionDescriptor.versionType",
-                                version_descriptor_version_type,
+                                &version_descriptor_version_type.to_string(),
                             );
                         }
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/wiki/models.rs
+++ b/azure_devops_rust_api/src/wiki/models.rs
@@ -501,6 +501,44 @@ pub mod git_version_descriptor {
         }
     }
 }
+#[doc = "Version options - Specify additional modifiers to version (e.g Previous)"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GitVersionOptions {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "previousChange")]
+    PreviousChange,
+    #[serde(rename = "firstParent")]
+    FirstParent,
+}
+impl std::fmt::Display for GitVersionOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::PreviousChange => write!(f, "previousChange"),
+            Self::FirstParent => write!(f, "firstParent"),
+        }
+    }
+}
+#[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GitVersionType {
+    #[serde(rename = "branch")]
+    Branch,
+    #[serde(rename = "tag")]
+    Tag,
+    #[serde(rename = "commit")]
+    Commit,
+}
+impl std::fmt::Display for GitVersionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Branch => write!(f, "branch"),
+            Self::Tag => write!(f, "tag"),
+            Self::Commit => write!(f, "commit"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct GraphSubjectBase {
     #[doc = "Links"]
@@ -709,6 +747,28 @@ pub mod team_project_reference {
                 Self::Organization => write!(f, "organization"),
                 Self::Unchanged => write!(f, "unchanged"),
             }
+        }
+    }
+}
+#[doc = "Recursion level for subpages retrieval. Defaults to `None` (Optional)."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum VersionControlRecursionType {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "oneLevel")]
+    OneLevel,
+    #[serde(rename = "oneLevelPlusNestedEmptyFolders")]
+    OneLevelPlusNestedEmptyFolders,
+    #[serde(rename = "full")]
+    Full,
+}
+impl std::fmt::Display for VersionControlRecursionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::OneLevel => write!(f, "oneLevel"),
+            Self::OneLevelPlusNestedEmptyFolders => write!(f, "oneLevelPlusNestedEmptyFolders"),
+            Self::Full => write!(f, "full"),
         }
     }
 }

--- a/azure_devops_rust_api/src/wiki/models.rs
+++ b/azure_devops_rust_api/src/wiki/models.rs
@@ -101,6 +101,15 @@ pub mod comment {
         #[serde(rename = "closed")]
         Closed,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Active => write!(f, "active"),
+                Self::Resolved => write!(f, "resolved"),
+                Self::Closed => write!(f, "closed"),
+            }
+        }
+    }
 }
 #[doc = "Represents an attachment to a comment."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -221,6 +230,15 @@ pub mod comment_mention {
         #[serde(rename = "pullRequest")]
         PullRequest,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Person => write!(f, "person"),
+                Self::WorkItem => write!(f, "workItem"),
+                Self::PullRequest => write!(f, "pullRequest"),
+            }
+        }
+    }
 }
 #[doc = "Contains information about comment reaction for a particular reaction type."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -267,6 +285,18 @@ pub mod comment_reaction {
         #[serde(rename = "confused")]
         Confused,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Like => write!(f, "like"),
+                Self::Dislike => write!(f, "dislike"),
+                Self::Heart => write!(f, "heart"),
+                Self::Hooray => write!(f, "hooray"),
+                Self::Smile => write!(f, "smile"),
+                Self::Confused => write!(f, "confused"),
+            }
+        }
+    }
 }
 #[doc = "Base class for comment resource references"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -305,6 +335,15 @@ pub mod comment_update_parameters {
         Resolved,
         #[serde(rename = "closed")]
         Closed,
+    }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Active => write!(f, "active"),
+                Self::Resolved => write!(f, "resolved"),
+                Self::Closed => write!(f, "closed"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -433,6 +472,15 @@ pub mod git_version_descriptor {
         #[serde(rename = "firstParent")]
         FirstParent,
     }
+    impl std::fmt::Display for VersionOptions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::PreviousChange => write!(f, "previousChange"),
+                Self::FirstParent => write!(f, "firstParent"),
+            }
+        }
+    }
     #[doc = "Version type (branch, tag, or commit). Determines how Id is interpreted"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum VersionType {
@@ -442,6 +490,15 @@ pub mod git_version_descriptor {
         Tag,
         #[serde(rename = "commit")]
         Commit,
+    }
+    impl std::fmt::Display for VersionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Branch => write!(f, "branch"),
+                Self::Tag => write!(f, "tag"),
+                Self::Commit => write!(f, "commit"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -620,6 +677,19 @@ pub mod team_project_reference {
         #[serde(rename = "deleted")]
         Deleted,
     }
+    impl std::fmt::Display for State {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Deleting => write!(f, "deleting"),
+                Self::New => write!(f, "new"),
+                Self::WellFormed => write!(f, "wellFormed"),
+                Self::CreatePending => write!(f, "createPending"),
+                Self::All => write!(f, "all"),
+                Self::Unchanged => write!(f, "unchanged"),
+                Self::Deleted => write!(f, "deleted"),
+            }
+        }
+    }
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Visibility {
         #[serde(rename = "private")]
@@ -630,6 +700,16 @@ pub mod team_project_reference {
         Organization,
         #[serde(rename = "unchanged")]
         Unchanged,
+    }
+    impl std::fmt::Display for Visibility {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Private => write!(f, "private"),
+                Self::Public => write!(f, "public"),
+                Self::Organization => write!(f, "organization"),
+                Self::Unchanged => write!(f, "unchanged"),
+            }
+        }
     }
 }
 #[doc = "This class is used to serialize collections as a single JSON object on the wire."]
@@ -756,6 +836,14 @@ pub mod wiki_create_base_parameters {
         ProjectWiki,
         #[serde(rename = "codeWiki")]
         CodeWiki,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ProjectWiki => write!(f, "projectWiki"),
+                Self::CodeWiki => write!(f, "codeWiki"),
+            }
+        }
     }
 }
 #[doc = "Wiki creations parameters."]

--- a/azure_devops_rust_api/src/wit/mod.rs
+++ b/azure_devops_rust_api/src/wit/mod.rs
@@ -287,7 +287,7 @@ pub mod classification_nodes {
             &self,
             organization: impl Into<String>,
             project: impl Into<String>,
-            structure_group: impl Into<String>,
+            structure_group: impl Into<models::TreeStructureGroup>,
             path: impl Into<String>,
         ) -> get::RequestBuilder {
             get::RequestBuilder {
@@ -312,7 +312,7 @@ pub mod classification_nodes {
             organization: impl Into<String>,
             body: impl Into<models::WorkItemClassificationNode>,
             project: impl Into<String>,
-            structure_group: impl Into<String>,
+            structure_group: impl Into<models::TreeStructureGroup>,
             path: impl Into<String>,
         ) -> create_or_update::RequestBuilder {
             create_or_update::RequestBuilder {
@@ -337,7 +337,7 @@ pub mod classification_nodes {
             organization: impl Into<String>,
             body: impl Into<models::WorkItemClassificationNode>,
             project: impl Into<String>,
-            structure_group: impl Into<String>,
+            structure_group: impl Into<models::TreeStructureGroup>,
             path: impl Into<String>,
         ) -> update::RequestBuilder {
             update::RequestBuilder {
@@ -360,7 +360,7 @@ pub mod classification_nodes {
             &self,
             organization: impl Into<String>,
             project: impl Into<String>,
-            structure_group: impl Into<String>,
+            structure_group: impl Into<models::TreeStructureGroup>,
             path: impl Into<String>,
         ) -> delete::RequestBuilder {
             delete::RequestBuilder {
@@ -416,7 +416,7 @@ pub mod classification_nodes {
             pub(crate) project: String,
             pub(crate) ids: String,
             pub(crate) depth: Option<i32>,
-            pub(crate) error_policy: Option<String>,
+            pub(crate) error_policy: Option<models::ClassificationNodesErrorPolicy>,
         }
         impl RequestBuilder {
             #[doc = "Depth of children to fetch."]
@@ -425,7 +425,10 @@ pub mod classification_nodes {
                 self
             }
             #[doc = "Flag to handle errors in getting some nodes. Possible options are Fail and Omit."]
-            pub fn error_policy(mut self, error_policy: impl Into<String>) -> Self {
+            pub fn error_policy(
+                mut self,
+                error_policy: impl Into<models::ClassificationNodesErrorPolicy>,
+            ) -> Self {
                 self.error_policy = Some(error_policy.into());
                 self
             }
@@ -461,7 +464,7 @@ pub mod classification_nodes {
                         if let Some(error_policy) = &this.error_policy {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("errorPolicy", error_policy);
+                                .append_pair("errorPolicy", &error_policy.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -651,7 +654,7 @@ pub mod classification_nodes {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) project: String,
-            pub(crate) structure_group: String,
+            pub(crate) structure_group: models::TreeStructureGroup,
             pub(crate) path: String,
             pub(crate) depth: Option<i32>,
         }
@@ -767,7 +770,7 @@ pub mod classification_nodes {
             pub(crate) organization: String,
             pub(crate) body: models::WorkItemClassificationNode,
             pub(crate) project: String,
-            pub(crate) structure_group: String,
+            pub(crate) structure_group: models::TreeStructureGroup,
             pub(crate) path: String,
         }
         impl RequestBuilder {
@@ -873,7 +876,7 @@ pub mod classification_nodes {
             pub(crate) organization: String,
             pub(crate) body: models::WorkItemClassificationNode,
             pub(crate) project: String,
-            pub(crate) structure_group: String,
+            pub(crate) structure_group: models::TreeStructureGroup,
             pub(crate) path: String,
         }
         impl RequestBuilder {
@@ -970,7 +973,7 @@ pub mod classification_nodes {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) project: String,
-            pub(crate) structure_group: String,
+            pub(crate) structure_group: models::TreeStructureGroup,
             pub(crate) path: String,
             pub(crate) reclassify_id: Option<i32>,
         }
@@ -1246,7 +1249,7 @@ pub mod queries {
             pub(crate) project: String,
             pub(crate) filter: String,
             pub(crate) top: Option<i32>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::QueryExpand>,
             pub(crate) include_deleted: Option<bool>,
         }
         impl RequestBuilder {
@@ -1255,7 +1258,7 @@ pub mod queries {
                 self.top = Some(top);
                 self
             }
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::QueryExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1298,7 +1301,7 @@ pub mod queries {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(include_deleted) = &this.include_deleted {
                             req.url_mut()
@@ -1382,13 +1385,13 @@ pub mod queries {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) project: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::QueryExpand>,
             pub(crate) depth: Option<i32>,
             pub(crate) include_deleted: Option<bool>,
         }
         impl RequestBuilder {
             #[doc = "Include the query string (wiql), clauses, query result columns, and sort options in the results."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::QueryExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1427,7 +1430,7 @@ pub mod queries {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(depth) = &this.depth {
                             req.url_mut()
@@ -1513,14 +1516,14 @@ pub mod queries {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) query: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::QueryExpand>,
             pub(crate) depth: Option<i32>,
             pub(crate) include_deleted: Option<bool>,
             pub(crate) use_iso_date_format: Option<bool>,
         }
         impl RequestBuilder {
             #[doc = "Include the query string (wiql), clauses, query result columns, and sort options in the results."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::QueryExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -1564,7 +1567,7 @@ pub mod queries {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(depth) = &this.depth {
                             req.url_mut()
@@ -2665,7 +2668,7 @@ pub mod comments {
             body: impl Into<models::CommentCreate>,
             project: impl Into<String>,
             work_item_id: i32,
-            format: impl Into<String>,
+            format: impl Into<models::CommentFormat>,
         ) -> add_work_item_comment::RequestBuilder {
             add_work_item_comment::RequestBuilder {
                 client: self.0.clone(),
@@ -2715,7 +2718,7 @@ pub mod comments {
             project: impl Into<String>,
             work_item_id: i32,
             comment_id: i32,
-            format: impl Into<String>,
+            format: impl Into<models::CommentFormat>,
         ) -> update_work_item_comment::RequestBuilder {
             update_work_item_comment::RequestBuilder {
                 client: self.0.clone(),
@@ -2883,7 +2886,7 @@ pub mod comments {
             pub(crate) body: models::CommentCreate,
             pub(crate) project: String,
             pub(crate) work_item_id: i32,
-            pub(crate) format: String,
+            pub(crate) format: models::CommentFormat,
         }
         impl RequestBuilder {
             #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
@@ -2913,7 +2916,7 @@ pub mod comments {
                         let format = &this.format;
                         req.url_mut()
                             .query_pairs_mut()
-                            .append_pair("format", format);
+                            .append_pair("format", &format.to_string());
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))
                     }
@@ -2991,8 +2994,8 @@ pub mod comments {
             pub(crate) top: Option<i32>,
             pub(crate) continuation_token: Option<String>,
             pub(crate) include_deleted: Option<bool>,
-            pub(crate) expand: Option<String>,
-            pub(crate) order: Option<String>,
+            pub(crate) expand: Option<models::CommentExpandOptions>,
+            pub(crate) order: Option<models::CommentSortOrder>,
         }
         impl RequestBuilder {
             #[doc = "Max number of comments to return."]
@@ -3011,12 +3014,12 @@ pub mod comments {
                 self
             }
             #[doc = "Specifies the additional data retrieval options for work item comments."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::CommentExpandOptions>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
             #[doc = "Order in which the comments should be returned."]
-            pub fn order(mut self, order: impl Into<String>) -> Self {
+            pub fn order(mut self, order: impl Into<models::CommentSortOrder>) -> Self {
                 self.order = Some(order.into());
                 self
             }
@@ -3060,10 +3063,12 @@ pub mod comments {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(order) = &this.order {
-                            req.url_mut().query_pairs_mut().append_pair("order", order);
+                            req.url_mut()
+                                .query_pairs_mut()
+                                .append_pair("order", &order.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -3141,7 +3146,7 @@ pub mod comments {
             pub(crate) project: String,
             pub(crate) work_item_id: i32,
             pub(crate) comment_id: i32,
-            pub(crate) format: String,
+            pub(crate) format: models::CommentFormat,
         }
         impl RequestBuilder {
             #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
@@ -3171,7 +3176,7 @@ pub mod comments {
                         let format = &this.format;
                         req.url_mut()
                             .query_pairs_mut()
-                            .append_pair("format", format);
+                            .append_pair("format", &format.to_string());
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))
                     }
@@ -3249,7 +3254,7 @@ pub mod comments {
             pub(crate) work_item_id: i32,
             pub(crate) ids: String,
             pub(crate) include_deleted: Option<bool>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::CommentExpandOptions>,
         }
         impl RequestBuilder {
             #[doc = "Specify if the deleted comments should be retrieved."]
@@ -3258,7 +3263,7 @@ pub mod comments {
                 self
             }
             #[doc = "Specifies the additional data retrieval options for work item comments."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::CommentExpandOptions>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -3294,7 +3299,7 @@ pub mod comments {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -3472,7 +3477,7 @@ pub mod comments {
             pub(crate) work_item_id: i32,
             pub(crate) comment_id: i32,
             pub(crate) include_deleted: Option<bool>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::CommentExpandOptions>,
         }
         impl RequestBuilder {
             #[doc = "Specify if the deleted comment should be retrieved."]
@@ -3481,7 +3486,7 @@ pub mod comments {
                 self
             }
             #[doc = "Specifies the additional data retrieval options for work item comments."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::CommentExpandOptions>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -3515,7 +3520,7 @@ pub mod comments {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -5323,11 +5328,11 @@ pub mod fields {
             pub(crate) client: super::super::Client,
             pub(crate) organization: String,
             pub(crate) project: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::GetFieldsExpand>,
         }
         impl RequestBuilder {
             #[doc = "Use ExtensionFields to include extension fields, otherwise exclude them. Unless the feature flag for this parameter is enabled, extension fields are always included."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::GetFieldsExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -5356,7 +5361,7 @@ pub mod fields {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -6199,7 +6204,7 @@ pub mod reporting_work_item_revisions {
             pub(crate) include_deleted: Option<bool>,
             pub(crate) include_tag_ref: Option<bool>,
             pub(crate) include_latest_only: Option<bool>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::ReportingRevisionsExpand>,
             pub(crate) include_discussion_changes_only: Option<bool>,
             pub(crate) max_page_size: Option<i32>,
         }
@@ -6248,7 +6253,7 @@ pub mod reporting_work_item_revisions {
                 self
             }
             #[doc = "Return all the fields in work item revisions, including long text fields which are not returned by default"]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::ReportingRevisionsExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -6331,7 +6336,7 @@ pub mod reporting_work_item_revisions {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(include_discussion_changes_only) =
                             &this.include_discussion_changes_only
@@ -6425,7 +6430,7 @@ pub mod reporting_work_item_revisions {
             pub(crate) project: String,
             pub(crate) continuation_token: Option<String>,
             pub(crate) start_date_time: Option<time::OffsetDateTime>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::ReportingRevisionsExpand>,
         }
         impl RequestBuilder {
             #[doc = "Specifies the watermark to start the batch from. Omit this parameter to get the first batch of revisions."]
@@ -6441,7 +6446,7 @@ pub mod reporting_work_item_revisions {
                 self.start_date_time = Some(start_date_time.into());
                 self
             }
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::ReportingRevisionsExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -6484,7 +6489,7 @@ pub mod reporting_work_item_revisions {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))
@@ -7626,8 +7631,8 @@ pub mod work_items {
             pub(crate) project: String,
             pub(crate) fields: Option<String>,
             pub(crate) as_of: Option<time::OffsetDateTime>,
-            pub(crate) expand: Option<String>,
-            pub(crate) error_policy: Option<String>,
+            pub(crate) expand: Option<models::WorkItemExpand>,
+            pub(crate) error_policy: Option<models::WorkItemErrorPolicy>,
         }
         impl RequestBuilder {
             #[doc = "Comma-separated list of requested fields"]
@@ -7641,12 +7646,15 @@ pub mod work_items {
                 self
             }
             #[doc = "The expand parameters for work item attributes. Possible options are { None, Relations, Fields, Links, All }."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::WorkItemExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
             #[doc = "The flag to control error policy in a bulk get work items request. Possible options are {Fail, Omit}."]
-            pub fn error_policy(mut self, error_policy: impl Into<String>) -> Self {
+            pub fn error_policy(
+                mut self,
+                error_policy: impl Into<models::WorkItemErrorPolicy>,
+            ) -> Self {
                 self.error_policy = Some(error_policy.into());
                 self
             }
@@ -7688,12 +7696,12 @@ pub mod work_items {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         if let Some(error_policy) = &this.error_policy {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("errorPolicy", error_policy);
+                                .append_pair("errorPolicy", &error_policy.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -7770,7 +7778,7 @@ pub mod work_items {
             pub(crate) type_: String,
             pub(crate) fields: Option<String>,
             pub(crate) as_of: Option<time::OffsetDateTime>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::WorkItemExpand>,
         }
         impl RequestBuilder {
             #[doc = "Comma-separated list of requested fields"]
@@ -7784,7 +7792,7 @@ pub mod work_items {
                 self
             }
             #[doc = "The expand parameters for work item attributes. Possible options are { None, Relations, Fields, Links, All }."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::WorkItemExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -7824,7 +7832,7 @@ pub mod work_items {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -7904,7 +7912,7 @@ pub mod work_items {
             pub(crate) validate_only: Option<bool>,
             pub(crate) bypass_rules: Option<bool>,
             pub(crate) suppress_notifications: Option<bool>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::WorkItemExpand>,
         }
         impl RequestBuilder {
             #[doc = "Indicate if you only want to validate the changes without saving the work item"]
@@ -7923,7 +7931,7 @@ pub mod work_items {
                 self
             }
             #[doc = "The expand parameters for work item attributes. Possible options are { None, Relations, Fields, Links, All }."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::WorkItemExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -7970,7 +7978,7 @@ pub mod work_items {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))
@@ -8047,7 +8055,7 @@ pub mod work_items {
             pub(crate) project: String,
             pub(crate) fields: Option<String>,
             pub(crate) as_of: Option<time::OffsetDateTime>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::WorkItemExpand>,
         }
         impl RequestBuilder {
             #[doc = "Comma-separated list of requested fields"]
@@ -8061,7 +8069,7 @@ pub mod work_items {
                 self
             }
             #[doc = "The expand parameters for work item attributes. Possible options are { None, Relations, Fields, Links, All }."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::WorkItemExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -8101,7 +8109,7 @@ pub mod work_items {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -8181,7 +8189,7 @@ pub mod work_items {
             pub(crate) validate_only: Option<bool>,
             pub(crate) bypass_rules: Option<bool>,
             pub(crate) suppress_notifications: Option<bool>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::WorkItemExpand>,
         }
         impl RequestBuilder {
             #[doc = "Indicate if you only want to validate the changes without saving the work item"]
@@ -8200,7 +8208,7 @@ pub mod work_items {
                 self
             }
             #[doc = "The expand parameters for work item attributes. Possible options are { None, Relations, Fields, Links, All }."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::WorkItemExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -8247,7 +8255,7 @@ pub mod work_items {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         req.set_body(req_body);
                         Ok(Response(this.client.send(&mut req).await?.into()))
@@ -8681,7 +8689,7 @@ pub mod revisions {
             pub(crate) project: String,
             pub(crate) top: Option<i32>,
             pub(crate) skip: Option<i32>,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::WorkItemExpand>,
         }
         impl RequestBuilder {
             pub fn top(mut self, top: i32) -> Self {
@@ -8692,7 +8700,7 @@ pub mod revisions {
                 self.skip = Some(skip);
                 self
             }
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::WorkItemExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -8731,7 +8739,7 @@ pub mod revisions {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -8808,10 +8816,10 @@ pub mod revisions {
             pub(crate) id: i32,
             pub(crate) revision_number: i32,
             pub(crate) project: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::WorkItemExpand>,
         }
         impl RequestBuilder {
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(mut self, expand: impl Into<models::WorkItemExpand>) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -8840,7 +8848,7 @@ pub mod revisions {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -9191,7 +9199,7 @@ pub mod comments_reactions {
             project: impl Into<String>,
             work_item_id: i32,
             comment_id: i32,
-            reaction_type: impl Into<String>,
+            reaction_type: impl Into<models::CommentReactionType>,
         ) -> create::RequestBuilder {
             create::RequestBuilder {
                 client: self.0.clone(),
@@ -9216,7 +9224,7 @@ pub mod comments_reactions {
             project: impl Into<String>,
             work_item_id: i32,
             comment_id: i32,
-            reaction_type: impl Into<String>,
+            reaction_type: impl Into<models::CommentReactionType>,
         ) -> delete::RequestBuilder {
             delete::RequestBuilder {
                 client: self.0.clone(),
@@ -9368,7 +9376,7 @@ pub mod comments_reactions {
             pub(crate) project: String,
             pub(crate) work_item_id: i32,
             pub(crate) comment_id: i32,
-            pub(crate) reaction_type: String,
+            pub(crate) reaction_type: models::CommentReactionType,
         }
         impl RequestBuilder {
             #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
@@ -9470,7 +9478,7 @@ pub mod comments_reactions {
             pub(crate) project: String,
             pub(crate) work_item_id: i32,
             pub(crate) comment_id: i32,
-            pub(crate) reaction_type: String,
+            pub(crate) reaction_type: models::CommentReactionType,
         }
         impl RequestBuilder {
             #[doc = "Returns a future that sends the request and returns a [`Response`] object that provides low-level access to full response details."]
@@ -9555,7 +9563,7 @@ pub mod comment_reactions_engaged_users {
             project: impl Into<String>,
             work_item_id: i32,
             comment_id: i32,
-            reaction_type: impl Into<String>,
+            reaction_type: impl Into<models::CommentReactionType>,
         ) -> list::RequestBuilder {
             list::RequestBuilder {
                 client: self.0.clone(),
@@ -9609,7 +9617,7 @@ pub mod comment_reactions_engaged_users {
             pub(crate) project: String,
             pub(crate) work_item_id: i32,
             pub(crate) comment_id: i32,
-            pub(crate) reaction_type: String,
+            pub(crate) reaction_type: models::CommentReactionType,
             pub(crate) top: Option<i32>,
             pub(crate) skip: Option<i32>,
         }
@@ -10519,11 +10527,14 @@ pub mod work_item_types_field {
             pub(crate) organization: String,
             pub(crate) project: String,
             pub(crate) type_: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::WorkItemTypeFieldsExpandLevel>,
         }
         impl RequestBuilder {
             #[doc = "Expand level for the API response. Properties: to include allowedvalues, default value, isRequired etc. as a part of response; None: to skip these properties."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(
+                mut self,
+                expand: impl Into<models::WorkItemTypeFieldsExpandLevel>,
+            ) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -10552,7 +10563,7 @@ pub mod work_item_types_field {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);
@@ -10633,11 +10644,14 @@ pub mod work_item_types_field {
             pub(crate) project: String,
             pub(crate) type_: String,
             pub(crate) field: String,
-            pub(crate) expand: Option<String>,
+            pub(crate) expand: Option<models::WorkItemTypeFieldsExpandLevel>,
         }
         impl RequestBuilder {
             #[doc = "Expand level for the API response. Properties: to include allowedvalues, default value, isRequired etc. as a part of response; None: to skip these properties."]
-            pub fn expand(mut self, expand: impl Into<String>) -> Self {
+            pub fn expand(
+                mut self,
+                expand: impl Into<models::WorkItemTypeFieldsExpandLevel>,
+            ) -> Self {
                 self.expand = Some(expand.into());
                 self
             }
@@ -10666,7 +10680,7 @@ pub mod work_item_types_field {
                         if let Some(expand) = &this.expand {
                             req.url_mut()
                                 .query_pairs_mut()
-                                .append_pair("$expand", expand);
+                                .append_pair("$expand", &expand.to_string());
                         }
                         let req_body = azure_core::Bytes::new();
                         req.set_body(req_body);

--- a/azure_devops_rust_api/src/wit/models.rs
+++ b/azure_devops_rust_api/src/wit/models.rs
@@ -155,6 +155,16 @@ pub mod account_recent_activity_work_item_model_base {
         #[serde(rename = "restored")]
         Restored,
     }
+    impl std::fmt::Display for ActivityType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Visited => write!(f, "visited"),
+                Self::Edited => write!(f, "edited"),
+                Self::Deleted => write!(f, "deleted"),
+                Self::Restored => write!(f, "restored"),
+            }
+        }
+    }
 }
 #[doc = "Represents Recent Mention Work Item"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -406,6 +416,14 @@ pub mod comment {
         #[serde(rename = "html")]
         Html,
     }
+    impl std::fmt::Display for Format {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Markdown => write!(f, "markdown"),
+                Self::Html => write!(f, "html"),
+            }
+        }
+    }
 }
 #[doc = "Represents a request to create a work item comment."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -550,6 +568,18 @@ pub mod comment_reaction {
         Smile,
         #[serde(rename = "confused")]
         Confused,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Like => write!(f, "like"),
+                Self::Dislike => write!(f, "dislike"),
+                Self::Heart => write!(f, "heart"),
+                Self::Hooray => write!(f, "hooray"),
+                Self::Smile => write!(f, "smile"),
+                Self::Confused => write!(f, "confused"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1121,6 +1151,18 @@ pub mod json_patch_operation {
         #[serde(rename = "test")]
         Test,
     }
+    impl std::fmt::Display for Op {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Add => write!(f, "add"),
+                Self::Remove => write!(f, "remove"),
+                Self::Replace => write!(f, "replace"),
+                Self::Move => write!(f, "move"),
+                Self::Copy => write!(f, "copy"),
+                Self::Test => write!(f, "test"),
+            }
+        }
+    }
 }
 #[doc = "Link description."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1277,6 +1319,17 @@ pub mod query_batch_get_request {
         #[serde(rename = "minimal")]
         Minimal,
     }
+    impl std::fmt::Display for Expand {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Wiql => write!(f, "wiql"),
+                Self::Clauses => write!(f, "clauses"),
+                Self::All => write!(f, "all"),
+                Self::Minimal => write!(f, "minimal"),
+            }
+        }
+    }
     #[doc = "The flag to control error policy in a query batch request. Possible options are { Fail, Omit }."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum ErrorPolicy {
@@ -1284,6 +1337,14 @@ pub mod query_batch_get_request {
         Fail,
         #[serde(rename = "omit")]
         Omit,
+    }
+    impl std::fmt::Display for ErrorPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Fail => write!(f, "fail"),
+                Self::Omit => write!(f, "omit"),
+            }
+        }
     }
 }
 #[doc = "Represents an item in the work item query hierarchy. This can be either a query or a folder."]
@@ -1480,6 +1541,19 @@ pub mod query_hierarchy_item {
         #[serde(rename = "linksRecursiveDoesNotContain")]
         LinksRecursiveDoesNotContain,
     }
+    impl std::fmt::Display for FilterOptions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::WorkItems => write!(f, "workItems"),
+                Self::LinksOneHopMustContain => write!(f, "linksOneHopMustContain"),
+                Self::LinksOneHopMayContain => write!(f, "linksOneHopMayContain"),
+                Self::LinksOneHopDoesNotContain => write!(f, "linksOneHopDoesNotContain"),
+                Self::LinksRecursiveMustContain => write!(f, "linksRecursiveMustContain"),
+                Self::LinksRecursiveMayContain => write!(f, "linksRecursiveMayContain"),
+                Self::LinksRecursiveDoesNotContain => write!(f, "linksRecursiveDoesNotContain"),
+            }
+        }
+    }
     #[doc = "The recursion option for use in a tree query."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum QueryRecursionOption {
@@ -1487,6 +1561,14 @@ pub mod query_hierarchy_item {
         ParentFirst,
         #[serde(rename = "childFirst")]
         ChildFirst,
+    }
+    impl std::fmt::Display for QueryRecursionOption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ParentFirst => write!(f, "parentFirst"),
+                Self::ChildFirst => write!(f, "childFirst"),
+            }
+        }
     }
     #[doc = "The type of query."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1497,6 +1579,15 @@ pub mod query_hierarchy_item {
         Tree,
         #[serde(rename = "oneHop")]
         OneHop,
+    }
+    impl std::fmt::Display for QueryType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Flat => write!(f, "flat"),
+                Self::Tree => write!(f, "tree"),
+                Self::OneHop => write!(f, "oneHop"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1934,6 +2025,17 @@ pub mod work_item_batch_get_request {
         #[serde(rename = "all")]
         All,
     }
+    impl std::fmt::Display for Expand {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::Relations => write!(f, "relations"),
+                Self::Fields => write!(f, "fields"),
+                Self::Links => write!(f, "links"),
+                Self::All => write!(f, "all"),
+            }
+        }
+    }
     #[doc = "The flag to control error policy in a bulk get work items request. Possible options are {Fail, Omit}."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum ErrorPolicy {
@@ -1941,6 +2043,14 @@ pub mod work_item_batch_get_request {
         Fail,
         #[serde(rename = "omit")]
         Omit,
+    }
+    impl std::fmt::Display for ErrorPolicy {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Fail => write!(f, "fail"),
+                Self::Omit => write!(f, "omit"),
+            }
+        }
     }
 }
 #[doc = "Defines a classification node for work item tracking."]
@@ -2009,6 +2119,14 @@ pub mod work_item_classification_node {
         Area,
         #[serde(rename = "iteration")]
         Iteration,
+    }
+    impl std::fmt::Display for StructureType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Area => write!(f, "area"),
+                Self::Iteration => write!(f, "iteration"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2081,6 +2199,14 @@ pub mod work_item_comment {
         Markdown,
         #[serde(rename = "html")]
         Html,
+    }
+    impl std::fmt::Display for Format {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Markdown => write!(f, "markdown"),
+                Self::Html => write!(f, "html"),
+            }
+        }
     }
 }
 #[doc = "Represents the reference to a specific version of a comment on a Work Item."]
@@ -2448,6 +2574,26 @@ pub mod work_item_field {
         #[serde(rename = "picklistDouble")]
         PicklistDouble,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::String => write!(f, "string"),
+                Self::Integer => write!(f, "integer"),
+                Self::DateTime => write!(f, "dateTime"),
+                Self::PlainText => write!(f, "plainText"),
+                Self::Html => write!(f, "html"),
+                Self::TreePath => write!(f, "treePath"),
+                Self::History => write!(f, "history"),
+                Self::Double => write!(f, "double"),
+                Self::Guid => write!(f, "guid"),
+                Self::Boolean => write!(f, "boolean"),
+                Self::Identity => write!(f, "identity"),
+                Self::PicklistString => write!(f, "picklistString"),
+                Self::PicklistInteger => write!(f, "picklistInteger"),
+                Self::PicklistDouble => write!(f, "picklistDouble"),
+            }
+        }
+    }
     #[doc = "The usage of the field."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum Usage {
@@ -2461,6 +2607,17 @@ pub mod work_item_field {
         Tree,
         #[serde(rename = "workItemTypeExtension")]
         WorkItemTypeExtension,
+    }
+    impl std::fmt::Display for Usage {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::WorkItem => write!(f, "workItem"),
+                Self::WorkItemLink => write!(f, "workItemLink"),
+                Self::Tree => write!(f, "tree"),
+                Self::WorkItemTypeExtension => write!(f, "workItemTypeExtension"),
+            }
+        }
     }
 }
 #[doc = "Describes a field on a work item and it's properties specific to that work item type."]
@@ -2765,6 +2922,15 @@ pub mod work_item_query_clause {
         #[serde(rename = "or")]
         Or,
     }
+    impl std::fmt::Display for LogicalOperator {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::And => write!(f, "and"),
+                Self::Or => write!(f, "or"),
+            }
+        }
+    }
 }
 #[doc = "The result of a work item query."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2834,6 +3000,14 @@ pub mod work_item_query_result {
         #[serde(rename = "workItemLink")]
         WorkItemLink,
     }
+    impl std::fmt::Display for QueryResultType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::WorkItem => write!(f, "workItem"),
+                Self::WorkItemLink => write!(f, "workItemLink"),
+            }
+        }
+    }
     #[doc = "The type of the query"]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum QueryType {
@@ -2843,6 +3017,15 @@ pub mod work_item_query_result {
         Tree,
         #[serde(rename = "oneHop")]
         OneHop,
+    }
+    impl std::fmt::Display for QueryType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Flat => write!(f, "flat"),
+                Self::Tree => write!(f, "tree"),
+                Self::OneHop => write!(f, "oneHop"),
+            }
+        }
     }
 }
 #[doc = "A sort column."]
@@ -3555,6 +3738,14 @@ pub mod work_item_type_template_update_model {
         #[serde(rename = "validate")]
         Validate,
     }
+    impl std::fmt::Display for ActionType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Import => write!(f, "import"),
+                Self::Validate => write!(f, "validate"),
+            }
+        }
+    }
     #[doc = "The type of the template described in the request body."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum TemplateType {
@@ -3562,6 +3753,14 @@ pub mod work_item_type_template_update_model {
         WorkItemType,
         #[serde(rename = "globalWorkflow")]
         GlobalWorkflow,
+    }
+    impl std::fmt::Display for TemplateType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::WorkItemType => write!(f, "workItemType"),
+                Self::GlobalWorkflow => write!(f, "globalWorkflow"),
+            }
+        }
     }
 }
 #[doc = "Describes an update to a work item."]

--- a/azure_devops_rust_api/src/wit/models.rs
+++ b/azure_devops_rust_api/src/wit/models.rs
@@ -297,6 +297,22 @@ impl AttachmentReference {
         Self::default()
     }
 }
+#[doc = "Flag to handle errors in getting some nodes. Possible options are Fail and Omit."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ClassificationNodesErrorPolicy {
+    #[serde(rename = "fail")]
+    Fail,
+    #[serde(rename = "omit")]
+    Omit,
+}
+impl std::fmt::Display for ClassificationNodesErrorPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Fail => write!(f, "fail"),
+            Self::Omit => write!(f, "omit"),
+        }
+    }
+}
 #[doc = "Comment on a Work Item."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Comment {
@@ -435,6 +451,47 @@ pub struct CommentCreate {
 impl CommentCreate {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Specifies the additional data retrieval options for work item comments."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum CommentExpandOptions {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "reactions")]
+    Reactions,
+    #[serde(rename = "renderedText")]
+    RenderedText,
+    #[serde(rename = "renderedTextOnly")]
+    RenderedTextOnly,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for CommentExpandOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Reactions => write!(f, "reactions"),
+            Self::RenderedText => write!(f, "renderedText"),
+            Self::RenderedTextOnly => write!(f, "renderedTextOnly"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
+#[doc = "Format of a work item comment (Markdown or Html)."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum CommentFormat {
+    #[serde(rename = "markdown")]
+    Markdown,
+    #[serde(rename = "html")]
+    Html,
+}
+impl std::fmt::Display for CommentFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Markdown => write!(f, "markdown"),
+            Self::Html => write!(f, "html"),
+        }
     }
 }
 #[doc = "Represents a list of work item comments."]
@@ -596,6 +653,50 @@ pub struct CommentReactionList {
 impl CommentReactionList {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Type of the reaction"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum CommentReactionType {
+    #[serde(rename = "like")]
+    Like,
+    #[serde(rename = "dislike")]
+    Dislike,
+    #[serde(rename = "heart")]
+    Heart,
+    #[serde(rename = "hooray")]
+    Hooray,
+    #[serde(rename = "smile")]
+    Smile,
+    #[serde(rename = "confused")]
+    Confused,
+}
+impl std::fmt::Display for CommentReactionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Like => write!(f, "like"),
+            Self::Dislike => write!(f, "dislike"),
+            Self::Heart => write!(f, "heart"),
+            Self::Hooray => write!(f, "hooray"),
+            Self::Smile => write!(f, "smile"),
+            Self::Confused => write!(f, "confused"),
+        }
+    }
+}
+#[doc = "Order in which the comments should be returned."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum CommentSortOrder {
+    #[serde(rename = "asc")]
+    Asc,
+    #[serde(rename = "desc")]
+    Desc,
+}
+impl std::fmt::Display for CommentSortOrder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Asc => write!(f, "asc"),
+            Self::Desc => write!(f, "desc"),
+        }
     }
 }
 #[doc = "Represents a request to update a work item comment."]
@@ -866,6 +967,25 @@ pub struct FieldUpdate {
 impl FieldUpdate {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Use ExtensionFields to include extension fields, otherwise exclude them. Unless the feature flag for this parameter is enabled, extension fields are always included."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum GetFieldsExpand {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "extensionFields")]
+    ExtensionFields,
+    #[serde(rename = "includeDeleted")]
+    IncludeDeleted,
+}
+impl std::fmt::Display for GetFieldsExpand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::ExtensionFields => write!(f, "extensionFields"),
+            Self::IncludeDeleted => write!(f, "includeDeleted"),
+        }
     }
 }
 #[doc = "Describes Github connection."]
@@ -1347,6 +1467,30 @@ pub mod query_batch_get_request {
         }
     }
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum QueryExpand {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "wiql")]
+    Wiql,
+    #[serde(rename = "clauses")]
+    Clauses,
+    #[serde(rename = "all")]
+    All,
+    #[serde(rename = "minimal")]
+    Minimal,
+}
+impl std::fmt::Display for QueryExpand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Wiql => write!(f, "wiql"),
+            Self::Clauses => write!(f, "clauses"),
+            Self::All => write!(f, "all"),
+            Self::Minimal => write!(f, "minimal"),
+        }
+    }
+}
 #[doc = "Represents an item in the work item query hierarchy. This can be either a query or a folder."]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryHierarchyItem {
@@ -1639,6 +1783,22 @@ impl ReferenceLinks {
         Self::default()
     }
 }
+#[doc = "Return all the fields in work item revisions, including long text fields which are not returned by default"]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ReportingRevisionsExpand {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "fields")]
+    Fields,
+}
+impl std::fmt::Display for ReportingRevisionsExpand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Fields => write!(f, "fields"),
+        }
+    }
+}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct ReportingWorkItemLinksBatch {
     #[serde(flatten)]
@@ -1836,6 +1996,22 @@ pub struct TemporaryQueryResponseModel {
 impl TemporaryQueryResponseModel {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Structure group of the classification node, area or iteration."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TreeStructureGroup {
+    #[serde(rename = "areas")]
+    Areas,
+    #[serde(rename = "iterations")]
+    Iterations,
+}
+impl std::fmt::Display for TreeStructureGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Areas => write!(f, "areas"),
+            Self::Iterations => write!(f, "iterations"),
+        }
     }
 }
 #[doc = "Describes an update request for a work item field."]
@@ -2440,6 +2616,47 @@ pub struct WorkItemDeleteUpdate {
 impl WorkItemDeleteUpdate {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "The flag to control error policy in a bulk get work items request. Possible options are {Fail, Omit}."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum WorkItemErrorPolicy {
+    #[serde(rename = "fail")]
+    Fail,
+    #[serde(rename = "omit")]
+    Omit,
+}
+impl std::fmt::Display for WorkItemErrorPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Fail => write!(f, "fail"),
+            Self::Omit => write!(f, "omit"),
+        }
+    }
+}
+#[doc = "The expand parameters for work item attributes. Possible options are { None, Relations, Fields, Links, All }."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum WorkItemExpand {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "relations")]
+    Relations,
+    #[serde(rename = "fields")]
+    Fields,
+    #[serde(rename = "links")]
+    Links,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for WorkItemExpand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Relations => write!(f, "relations"),
+            Self::Fields => write!(f, "fields"),
+            Self::Links => write!(f, "links"),
+            Self::All => write!(f, "all"),
+        }
     }
 }
 #[doc = "Describes a field on a work item and it's properties specific to that work item type."]
@@ -3628,6 +3845,28 @@ pub struct WorkItemTypeFieldWithReferencesList {
 impl WorkItemTypeFieldWithReferencesList {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+#[doc = "Expand level for the API response. Properties: to include allowedvalues, default value, isRequired etc. as a part of response; None: to skip these properties."]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum WorkItemTypeFieldsExpandLevel {
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "allowedValues")]
+    AllowedValues,
+    #[serde(rename = "dependentFields")]
+    DependentFields,
+    #[serde(rename = "all")]
+    All,
+}
+impl std::fmt::Display for WorkItemTypeFieldsExpandLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::AllowedValues => write!(f, "allowedValues"),
+            Self::DependentFields => write!(f, "dependentFields"),
+            Self::All => write!(f, "all"),
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/azure_devops_rust_api/src/work/models.rs
+++ b/azure_devops_rust_api/src/work/models.rs
@@ -116,6 +116,15 @@ pub mod backlog_configuration {
         #[serde(rename = "asTasks")]
         AsTasks,
     }
+    impl std::fmt::Display for BugsBehavior {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Off => write!(f, "off"),
+                Self::AsRequirements => write!(f, "asRequirements"),
+                Self::AsTasks => write!(f, "asTasks"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BacklogFields {
@@ -246,6 +255,15 @@ pub mod backlog_level_configuration {
         Requirement,
         #[serde(rename = "task")]
         Task,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Portfolio => write!(f, "portfolio"),
+                Self::Requirement => write!(f, "requirement"),
+                Self::Task => write!(f, "task"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -446,6 +464,15 @@ pub mod board_column {
         InProgress,
         #[serde(rename = "outgoing")]
         Outgoing,
+    }
+    impl std::fmt::Display for ColumnType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Incoming => write!(f, "incoming"),
+                Self::InProgress => write!(f, "inProgress"),
+                Self::Outgoing => write!(f, "outgoing"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -716,6 +743,15 @@ pub mod card_field_settings {
         #[serde(rename = "avatarAndFullName")]
         AvatarAndFullName,
     }
+    impl std::fmt::Display for AssignedToDisplayFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::AvatarOnly => write!(f, "avatarOnly"),
+                Self::FullName => write!(f, "fullName"),
+                Self::AvatarAndFullName => write!(f, "avatarAndFullName"),
+            }
+        }
+    }
 }
 #[doc = "Card settings, such as fields and rules"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -783,6 +819,13 @@ pub mod create_plan {
     pub enum Type {
         #[serde(rename = "deliveryTimelineView")]
         DeliveryTimelineView,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::DeliveryTimelineView => write!(f, "deliveryTimelineView"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -991,6 +1034,19 @@ pub mod field_info {
         Boolean,
         #[serde(rename = "double")]
         Double,
+    }
+    impl std::fmt::Display for FieldType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::String => write!(f, "string"),
+                Self::PlainText => write!(f, "plainText"),
+                Self::Integer => write!(f, "integer"),
+                Self::DateTime => write!(f, "dateTime"),
+                Self::TreePath => write!(f, "treePath"),
+                Self::Boolean => write!(f, "boolean"),
+                Self::Double => write!(f, "double"),
+            }
+        }
     }
 }
 #[doc = "An abstracted reference to a field"]
@@ -1388,6 +1444,13 @@ pub mod plan {
         #[serde(rename = "deliveryTimelineView")]
         DeliveryTimelineView,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::DeliveryTimelineView => write!(f, "deliveryTimelineView"),
+            }
+        }
+    }
     #[doc = "Bit flag indicating set of permissions a user has to the plan."]
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub enum UserPermissions {
@@ -1403,6 +1466,18 @@ pub mod plan {
         Manage,
         #[serde(rename = "allPermissions")]
         AllPermissions,
+    }
+    impl std::fmt::Display for UserPermissions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::View => write!(f, "view"),
+                Self::Edit => write!(f, "edit"),
+                Self::Delete => write!(f, "delete"),
+                Self::Manage => write!(f, "manage"),
+                Self::AllPermissions => write!(f, "allPermissions"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -1471,6 +1546,18 @@ pub mod plan_metadata {
         Manage,
         #[serde(rename = "allPermissions")]
         AllPermissions,
+    }
+    impl std::fmt::Display for UserPermissions {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::None => write!(f, "none"),
+                Self::View => write!(f, "view"),
+                Self::Edit => write!(f, "edit"),
+                Self::Delete => write!(f, "delete"),
+                Self::Manage => write!(f, "manage"),
+                Self::AllPermissions => write!(f, "allPermissions"),
+            }
+        }
     }
 }
 #[doc = "Base class for plan view data contracts. Anything common goes here."]
@@ -1975,6 +2062,15 @@ pub mod team_iteration_attributes {
         #[serde(rename = "future")]
         Future,
     }
+    impl std::fmt::Display for TimeFrame {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Past => write!(f, "past"),
+                Self::Current => write!(f, "current"),
+                Self::Future => write!(f, "future"),
+            }
+        }
+    }
 }
 #[doc = "Represents capacity for a specific team member"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2091,6 +2187,15 @@ pub mod team_setting {
         AsRequirements,
         #[serde(rename = "asTasks")]
         AsTasks,
+    }
+    impl std::fmt::Display for BugsBehavior {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Off => write!(f, "off"),
+                Self::AsRequirements => write!(f, "asRequirements"),
+                Self::AsTasks => write!(f, "asTasks"),
+            }
+        }
     }
 }
 #[doc = "Base class for TeamSettings data contracts. Anything common goes here."]
@@ -2235,6 +2340,15 @@ pub mod team_settings_patch {
         #[serde(rename = "asTasks")]
         AsTasks,
     }
+    impl std::fmt::Display for BugsBehavior {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Off => write!(f, "off"),
+                Self::AsRequirements => write!(f, "asRequirements"),
+                Self::AsTasks => write!(f, "asTasks"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TimelineCriteriaStatus {
@@ -2259,6 +2373,15 @@ pub mod timeline_criteria_status {
         #[serde(rename = "unknown")]
         Unknown,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Ok => write!(f, "ok"),
+                Self::InvalidFilterClause => write!(f, "invalidFilterClause"),
+                Self::Unknown => write!(f, "unknown"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct TimelineIterationStatus {
@@ -2280,6 +2403,14 @@ pub mod timeline_iteration_status {
         Ok,
         #[serde(rename = "isOverlapping")]
         IsOverlapping,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Ok => write!(f, "ok"),
+                Self::IsOverlapping => write!(f, "isOverlapping"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -2476,6 +2607,19 @@ pub mod timeline_team_status {
         #[serde(rename = "noIterationsExist")]
         NoIterationsExist,
     }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Ok => write!(f, "ok"),
+                Self::DoesntExistOrAccessDenied => write!(f, "doesntExistOrAccessDenied"),
+                Self::MaxTeamsExceeded => write!(f, "maxTeamsExceeded"),
+                Self::MaxTeamFieldsExceeded => write!(f, "maxTeamFieldsExceeded"),
+                Self::BacklogInError => write!(f, "backlogInError"),
+                Self::MissingTeamFieldValue => write!(f, "missingTeamFieldValue"),
+                Self::NoIterationsExist => write!(f, "noIterationsExist"),
+            }
+        }
+    }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct UpdatePlan {
@@ -2507,6 +2651,13 @@ pub mod update_plan {
     pub enum Type {
         #[serde(rename = "deliveryTimelineView")]
         DeliveryTimelineView,
+    }
+    impl std::fmt::Display for Type {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::DeliveryTimelineView => write!(f, "deliveryTimelineView"),
+            }
+        }
     }
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/vsts-api-patcher/src/patcher.rs
+++ b/vsts-api-patcher/src/patcher.rs
@@ -100,7 +100,6 @@ impl Patcher {
         Patcher::patch_identity_descriptors,
         Patcher::patch_security,
         Patcher::patch_response_schema,
-        Patcher::patch_git_items_recursion_level,
         // This must be done after the other patches
         Patcher::patch_definition_required_fields,
     ];
@@ -1931,82 +1930,6 @@ impl Patcher {
                                 )
                                 .unwrap();
                         }
-                    }
-                }
-                Some(value)
-            }
-            _ => None,
-        }
-    }
-
-    // Patch the git items `recursionLevel` query parameter to use a named
-    // `VersionControlRecursionType` enum definition instead of an inline string enum.
-    //
-    // Before patch: `recursionLevel` parameter has `type: "string"` with an inline enum.
-    // After patch: `recursionLevel` parameter has `schema: { $ref: "#/definitions/VersionControlRecursionType" }`.
-    //
-    // This causes the codegen to generate a typed `VersionControlRecursionType` enum in
-    // models.rs and use it as the parameter type in the client builder setter.
-    fn patch_git_items_recursion_level(
-        &mut self,
-        key: &[&str],
-        value: &JsonValue,
-    ) -> Option<JsonValue> {
-        if !self.spec_path.ends_with("git.json") {
-            return None;
-        }
-        match key {
-            ["paths", "/{organization}/{project}/_apis/git/repositories/{repositoryId}/items", "get", "parameters"]
-            | ["x-ms-paths", "/{organization}/{project}/_apis/git/repositories/{repositoryId}/items?path={path}", "get", "parameters"] =>
-            {
-                let mut value = value.clone();
-                for param in value.members_mut() {
-                    if param["name"].as_str() == Some("recursionLevel")
-                        && param["type"].as_str() == Some("string")
-                    {
-                        println!("Patch git items recursionLevel parameter to use VersionControlRecursionType enum");
-                        self.new_definitions.insert(
-                            "VersionControlRecursionType".to_string(),
-                            json::object! {
-                                "description": "The recursion level for a request.",
-                                "enum": [
-                                    "none",
-                                    "oneLevel",
-                                    "oneLevelPlusNestedEmptyFolders",
-                                    "full"
-                                ],
-                                "x-ms-enum": {
-                                    "name": "VersionControlRecursionType",
-                                    "values": [
-                                        {
-                                            "value": "none",
-                                            "description": "Only return the specified item."
-                                        },
-                                        {
-                                            "value": "oneLevel",
-                                            "description": "Return the specified item and its direct children."
-                                        },
-                                        {
-                                            "value": "oneLevelPlusNestedEmptyFolders",
-                                            "description": "Return the specified item and its direct children, as well as recursive chains of nested child folders that only contain a single folder."
-                                        },
-                                        {
-                                            "value": "full",
-                                            "description": "Return specified item and all descendants."
-                                        }
-                                    ]
-                                }
-                            },
-                        );
-                        param.remove("type");
-                        param.remove("enum");
-                        param.remove("x-ms-enum");
-                        param
-                            .insert(
-                                "schema",
-                                json::object! { "$ref": "#/definitions/VersionControlRecursionType" },
-                            )
-                            .unwrap();
                     }
                 }
                 Some(value)

--- a/vsts-api-patcher/src/patcher.rs
+++ b/vsts-api-patcher/src/patcher.rs
@@ -100,6 +100,7 @@ impl Patcher {
         Patcher::patch_identity_descriptors,
         Patcher::patch_security,
         Patcher::patch_response_schema,
+        Patcher::patch_git_items_recursion_level,
         // This must be done after the other patches
         Patcher::patch_definition_required_fields,
     ];
@@ -1930,6 +1931,82 @@ impl Patcher {
                                 )
                                 .unwrap();
                         }
+                    }
+                }
+                Some(value)
+            }
+            _ => None,
+        }
+    }
+
+    // Patch the git items `recursionLevel` query parameter to use a named
+    // `VersionControlRecursionType` enum definition instead of an inline string enum.
+    //
+    // Before patch: `recursionLevel` parameter has `type: "string"` with an inline enum.
+    // After patch: `recursionLevel` parameter has `schema: { $ref: "#/definitions/VersionControlRecursionType" }`.
+    //
+    // This causes the codegen to generate a typed `VersionControlRecursionType` enum in
+    // models.rs and use it as the parameter type in the client builder setter.
+    fn patch_git_items_recursion_level(
+        &mut self,
+        key: &[&str],
+        value: &JsonValue,
+    ) -> Option<JsonValue> {
+        if !self.spec_path.ends_with("git.json") {
+            return None;
+        }
+        match key {
+            ["paths", "/{organization}/{project}/_apis/git/repositories/{repositoryId}/items", "get", "parameters"]
+            | ["x-ms-paths", "/{organization}/{project}/_apis/git/repositories/{repositoryId}/items?path={path}", "get", "parameters"] =>
+            {
+                let mut value = value.clone();
+                for param in value.members_mut() {
+                    if param["name"].as_str() == Some("recursionLevel")
+                        && param["type"].as_str() == Some("string")
+                    {
+                        println!("Patch git items recursionLevel parameter to use VersionControlRecursionType enum");
+                        self.new_definitions.insert(
+                            "VersionControlRecursionType".to_string(),
+                            json::object! {
+                                "description": "The recursion level for a request.",
+                                "enum": [
+                                    "none",
+                                    "oneLevel",
+                                    "oneLevelPlusNestedEmptyFolders",
+                                    "full"
+                                ],
+                                "x-ms-enum": {
+                                    "name": "VersionControlRecursionType",
+                                    "values": [
+                                        {
+                                            "value": "none",
+                                            "description": "Only return the specified item."
+                                        },
+                                        {
+                                            "value": "oneLevel",
+                                            "description": "Return the specified item and its direct children."
+                                        },
+                                        {
+                                            "value": "oneLevelPlusNestedEmptyFolders",
+                                            "description": "Return the specified item and its direct children, as well as recursive chains of nested child folders that only contain a single folder."
+                                        },
+                                        {
+                                            "value": "full",
+                                            "description": "Return specified item and all descendants."
+                                        }
+                                    ]
+                                }
+                            },
+                        );
+                        param.remove("type");
+                        param.remove("enum");
+                        param.remove("x-ms-enum");
+                        param
+                            .insert(
+                                "schema",
+                                json::object! { "$ref": "#/definitions/VersionControlRecursionType" },
+                            )
+                            .unwrap();
                     }
                 }
                 Some(value)


### PR DESCRIPTION
## Summary

Fixes #78.

The `recursionLevel` query parameter on `git::items::get` and `git::items::list` was the reported case, but the same problem affected **105 parameters across all API areas** — any parameter with `type: string`, an `enum` field, and an `x-ms-enum` extension was being generated as `impl Into<String>` instead of a typed enum.

### Root cause

`WebParameter::type_name()` in the codegen called `get_type_name_for_schema()`, which returned `TypeName::String` for all string-typed parameters and discarded the `enum` / `x-ms-enum` fields entirely.

### Fix

Two changes to the code generator — no spec patches required:

1. **`autorust/codegen/src/spec.rs`**
   - `WebParameter::type_name()` now checks for non-empty `enum_` + `x_ms_enum.name` and returns `TypeName::Reference(name)` instead of `TypeName::String`.
   - New `Spec::inline_parameter_enum_schemas()` collects synthetic `Schema` entries for all inline enum parameters so the models codegen can generate a named enum type for each.

2. **`autorust/codegen/src/codegen_models.rs`**
   - `all_schemas()` calls `inline_parameter_enum_schemas()` to include those synthetic schemas alongside definition-based schemas.
   - All generated enums now implement `std::fmt::Display`, so enum values serialise correctly into URL query/path parameters via `.to_string()`.

### Effect

All 105 affected parameters across `build`, `git`, `release`, `wit`, `tfvc`, `wiki`, `distributedTask`, etc. now use typed enums. Examples:

| Module | Parameter | Before | After |
|--------|-----------|--------|-------|
| `git::items` | `recursionLevel` | `impl Into<String>` | `impl Into<models::VersionControlRecursionType>` |
| `build::builds` | `statusFilter` | `impl Into<String>` | `impl Into<models::BuildStatus>` |
| `build::builds` | `resultFilter` | `impl Into<String>` | `impl Into<models::BuildResult>` |
| `release` | `statusFilter` | `impl Into<String>` | `impl Into<models::ReleaseStatus>` |
| `git::pull_requests` | `searchCriteria.status` | `impl Into<String>` | `impl Into<models::PullRequestStatus>` |
| `tfvc` | `recursionLevel` | `impl Into<String>` | `impl Into<models::VersionControlRecursionType>` |

### Breaking change

Callers passing string literals for any of the 105 affected parameters will need to switch to the enum type. Example:

```rust
// Before
git_client.items_client().list(org, repo, project)
    .recursion_level("Full")

// After
use azure_devops_rust_api::git::models::VersionControlRecursionType;
git_client.items_client().list(org, repo, project)
    .recursion_level(VersionControlRecursionType::Full)
```

## Test plan

- [x] `./build.sh` succeeds
- [x] `cargo clippy --all-features -- --deny warnings` passes
- [x] `cargo clippy --all-features --examples -- --deny warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)