### PR TITLE
Fix clippy useless_borrows_in_formatting warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- Fix `clippy::useless_borrows_in_formatting` warnings from the updated Rust
+  toolchain by removing redundant references in `format!` arguments (codegen,
+  hand-written source, and regenerated modules).
+
 ## [0.38.0]
 
 ### Changes

--- a/autorust/codegen/src/codegen_operations/request_builder_send.rs
+++ b/autorust/codegen/src/codegen_operations/request_builder_send.rs
@@ -41,7 +41,7 @@ impl ToTokens for RequestBuilderSendCode {
         let request_builder = &self.request_builder;
 
         let url_args = self.url_args.iter().map(|url_arg| {
-            quote! { &self.#url_arg }
+            quote! { self.#url_arg }
         });
         let url_str_args = quote! { #(#url_args),* };
 

--- a/azure_devops_rust_api/examples/build_list_continuation_token.rs
+++ b/azure_devops_rust_api/examples/build_list_continuation_token.rs
@@ -42,7 +42,7 @@ async fn get_builds(
 
     let body_data = body.into_string()?;
     let build_list: BuildList = serde_json::from_str(&body_data)
-        .with_context(|| format!("Failed to parse BuildList: {}", &body_data))?;
+        .with_context(|| format!("Failed to parse BuildList: {}", body_data))?;
 
     println!("Received {} builds", build_list.count.unwrap_or(0));
 

--- a/azure_devops_rust_api/src/approvals_and_checks/mod.rs
+++ b/azure_devops_rust_api/src/approvals_and_checks/mod.rs
@@ -289,8 +289,8 @@ pub mod pipeline_permissions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/pipelinepermissions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -391,10 +391,10 @@ pub mod pipeline_permissions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/pipelinepermissions/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.resource_type,
-                    &self.resource_id
+                    self.organization,
+                    self.project,
+                    self.resource_type,
+                    self.resource_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -497,10 +497,10 @@ pub mod pipeline_permissions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/pipelinepermissions/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.resource_type,
-                    &self.resource_id
+                    self.organization,
+                    self.project,
+                    self.resource_type,
+                    self.resource_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -761,8 +761,8 @@ pub mod check_configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/checks/configurations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -860,8 +860,8 @@ pub mod check_configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/checks/configurations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -970,9 +970,9 @@ pub mod check_configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/checks/configurations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1070,9 +1070,9 @@ pub mod check_configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/checks/configurations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1163,9 +1163,9 @@ pub mod check_configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/checks/configurations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1282,8 +1282,8 @@ pub mod check_configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/checks/queryconfigurations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1439,8 +1439,8 @@ pub mod check_evaluations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/checks/runs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1546,9 +1546,9 @@ pub mod check_evaluations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/checks/runs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.check_suite_id
+                    self.organization,
+                    self.project,
+                    self.check_suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1770,8 +1770,8 @@ pub mod approvals {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/approvals",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1868,8 +1868,8 @@ pub mod approvals {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/approvals",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1978,9 +1978,9 @@ pub mod approvals {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/approvals/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.approval_id
+                    self.organization,
+                    self.project,
+                    self.approval_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/artifacts/mod.rs
+++ b/azure_devops_rust_api/src/artifacts/mod.rs
@@ -276,7 +276,7 @@ pub mod service_settings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/packaging/globalpermissions",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -372,7 +372,7 @@ pub mod service_settings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/packaging/globalpermissions",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -569,8 +569,8 @@ pub mod change_tracking {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feedchanges",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -666,9 +666,9 @@ pub mod change_tracking {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feedchanges/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -789,9 +789,9 @@ pub mod change_tracking {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/packagechanges",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -947,8 +947,8 @@ pub mod feed_recycle_bin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feedrecyclebin",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1041,9 +1041,9 @@ pub mod feed_recycle_bin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feedrecyclebin/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1137,9 +1137,9 @@ pub mod feed_recycle_bin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feedrecyclebin/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1535,8 +1535,8 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1631,8 +1631,8 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1738,9 +1738,9 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1836,9 +1836,9 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1929,9 +1929,9 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2081,9 +2081,9 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/permissions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2181,9 +2181,9 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/permissions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2279,9 +2279,9 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/views",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2379,9 +2379,9 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/views",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2478,10 +2478,10 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/views/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.view_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.view_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2580,10 +2580,10 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/views/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.view_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.view_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2675,10 +2675,10 @@ pub mod feed_management {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/views/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.view_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.view_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2988,9 +2988,9 @@ pub mod artifact_details {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/packagemetricsbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3246,9 +3246,9 @@ pub mod artifact_details {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/packages",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3413,10 +3413,10 @@ pub mod artifact_details {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/packages/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3518,10 +3518,10 @@ pub mod artifact_details {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/Packages/{}/versionmetricsbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3652,10 +3652,10 @@ pub mod artifact_details {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/Packages/{}/versions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3786,11 +3786,11 @@ pub mod artifact_details {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/Packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_id,
-                    &self.package_version_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_id,
+                    self.package_version_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3891,11 +3891,11 @@ pub mod artifact_details {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/Packages/{}/Versions/{}/provenance",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_id,
-                    &self.package_version_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_id,
+                    self.package_version_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3991,10 +3991,10 @@ pub mod artifact_details {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/public/packaging/Feeds/{}/Packages/{}/badge",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4283,9 +4283,9 @@ pub mod recycle_bin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/RecycleBin/Packages",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4381,9 +4381,9 @@ pub mod recycle_bin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/RecycleBin/Packages",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4491,10 +4491,10 @@ pub mod recycle_bin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/RecycleBin/Packages/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4605,10 +4605,10 @@ pub mod recycle_bin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/RecycleBin/Packages/{}/Versions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4721,11 +4721,11 @@ pub mod recycle_bin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/RecycleBin/Packages/{}/Versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_id,
-                    &self.package_version_id
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_id,
+                    self.package_version_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4892,9 +4892,9 @@ pub mod retention_policies {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/retentionpolicies",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4992,9 +4992,9 @@ pub mod retention_policies {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/retentionpolicies",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5085,9 +5085,9 @@ pub mod retention_policies {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/Feeds/{}/retentionpolicies",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5220,9 +5220,9 @@ pub mod provenance {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/provenance/session/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.protocol
+                    self.organization,
+                    self.project,
+                    self.protocol
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/artifacts_package_types/mod.rs
+++ b/azure_devops_rust_api/src/artifacts_package_types/mod.rs
@@ -530,11 +530,11 @@ pub mod maven {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/maven/groups/{}/artifacts/{}/upstreaming",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed,
-                    &self.group_id,
-                    &self.artifact_id
+                    self.organization,
+                    self.project,
+                    self.feed,
+                    self.group_id,
+                    self.artifact_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -629,11 +629,11 @@ pub mod maven {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/maven/groups/{}/artifacts/{}/upstreaming",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed,
-                    &self.group_id,
-                    &self.artifact_id
+                    self.organization,
+                    self.project,
+                    self.feed,
+                    self.group_id,
+                    self.artifact_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -746,12 +746,12 @@ pub mod maven {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/maven/groups/{}/artifacts/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed,
-                    &self.group_id,
-                    &self.artifact_id,
-                    &self.version
+                    self.organization,
+                    self.project,
+                    self.feed,
+                    self.group_id,
+                    self.artifact_id,
+                    self.version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -847,12 +847,12 @@ pub mod maven {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/maven/groups/{}/artifacts/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed,
-                    &self.group_id,
-                    &self.artifact_id,
-                    &self.version
+                    self.organization,
+                    self.project,
+                    self.feed,
+                    self.group_id,
+                    self.artifact_id,
+                    self.version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -949,12 +949,12 @@ pub mod maven {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/maven/groups/{}/artifacts/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed,
-                    &self.group_id,
-                    &self.artifact_id,
-                    &self.version
+                    self.organization,
+                    self.project,
+                    self.feed,
+                    self.group_id,
+                    self.artifact_id,
+                    self.version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1056,7 +1056,7 @@ pub mod maven {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/packaging/feeds/{}/maven/RecycleBin/groups/{}/artifacts/{}/versions/{}" , self . client . endpoint () , & self . organization , & self . project , & self . feed , & self . group_id , & self . artifact_id , & self . version)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/packaging/feeds/{}/maven/RecycleBin/groups/{}/artifacts/{}/versions/{}" , self . client . endpoint () , self . organization , self . project , self . feed , self . group_id , self . artifact_id , self . version)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -1149,7 +1149,7 @@ pub mod maven {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/packaging/feeds/{}/maven/RecycleBin/groups/{}/artifacts/{}/versions/{}" , self . client . endpoint () , & self . organization , & self . project , & self . feed , & self . group_id , & self . artifact_id , & self . version)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/packaging/feeds/{}/maven/RecycleBin/groups/{}/artifacts/{}/versions/{}" , self . client . endpoint () , self . organization , self . project , self . feed , self . group_id , self . artifact_id , self . version)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -1242,7 +1242,7 @@ pub mod maven {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/packaging/feeds/{}/maven/RecycleBin/groups/{}/artifacts/{}/versions/{}" , self . client . endpoint () , & self . organization , & self . project , & self . feed , & self . group_id , & self . artifact_id , & self . version)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/packaging/feeds/{}/maven/RecycleBin/groups/{}/artifacts/{}/versions/{}" , self . client . endpoint () , self . organization , self . project , self . feed , self . group_id , self . artifact_id , self . version)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -1337,9 +1337,9 @@ pub mod maven {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/maven/RecycleBin/packagesBatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed
+                    self.organization,
+                    self.project,
+                    self.feed
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1440,13 +1440,13 @@ pub mod maven {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/maven/{}/{}/{}/{}/content",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.group_id,
-                    &self.artifact_id,
-                    &self.version,
-                    &self.file_name
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.group_id,
+                    self.artifact_id,
+                    self.version,
+                    self.file_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1539,9 +1539,9 @@ pub mod maven {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/maven/packagesbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2212,12 +2212,12 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/@{}/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_scope,
-                    &self.unscoped_package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_scope,
+                    self.unscoped_package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2318,12 +2318,12 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/@{}/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_scope,
-                    &self.unscoped_package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_scope,
+                    self.unscoped_package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2422,12 +2422,12 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/@{}/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_scope,
-                    &self.unscoped_package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_scope,
+                    self.unscoped_package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2525,11 +2525,11 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2629,11 +2629,11 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2731,11 +2731,11 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2833,11 +2833,11 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/packages/@{}/{}/upstreaming",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_scope,
-                    &self.unscoped_package_name
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_scope,
+                    self.unscoped_package_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2932,11 +2932,11 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/packages/@{}/{}/upstreaming",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_scope,
-                    &self.unscoped_package_name
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_scope,
+                    self.unscoped_package_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3036,12 +3036,12 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/packages/@{}/{}/versions/{}/content",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_scope,
-                    &self.unscoped_package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_scope,
+                    self.unscoped_package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3138,12 +3138,12 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/packages/@{}/{}/versions/{}/readme",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_scope,
-                    &self.unscoped_package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_scope,
+                    self.unscoped_package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3240,10 +3240,10 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/packages/{}/upstreaming",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3337,10 +3337,10 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/packages/{}/upstreaming",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3439,11 +3439,11 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/packages/{}/versions/{}/content",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3539,11 +3539,11 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/packages/{}/versions/{}/readme",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3636,9 +3636,9 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/packagesbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3743,12 +3743,12 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/RecycleBin/packages/@{}/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_scope,
-                    &self.unscoped_package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_scope,
+                    self.unscoped_package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3845,12 +3845,12 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/RecycleBin/packages/@{}/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_scope,
-                    &self.unscoped_package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_scope,
+                    self.unscoped_package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3947,12 +3947,12 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/RecycleBin/packages/@{}/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_scope,
-                    &self.unscoped_package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_scope,
+                    self.unscoped_package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4056,11 +4056,11 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4156,11 +4156,11 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4256,11 +4256,11 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4356,9 +4356,9 @@ pub mod npm {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/npm/RecycleBin/PackagesBatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4742,10 +4742,10 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/packages/{}/upstreaming",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4839,10 +4839,10 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/packages/{}/upstreaming",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4954,11 +4954,11 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5053,11 +5053,11 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5158,11 +5158,11 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5272,11 +5272,11 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/packages/{}/versions/{}/content",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5369,9 +5369,9 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/packagesbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5475,11 +5475,11 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5575,11 +5575,11 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5675,11 +5675,11 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5775,9 +5775,9 @@ pub mod nu_get {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/nuget/RecycleBin/packagesBatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6163,10 +6163,10 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/packages/{}/upstreaming",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6260,10 +6260,10 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/packages/{}/upstreaming",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6375,11 +6375,11 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6474,11 +6474,11 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6579,11 +6579,11 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6680,12 +6680,12 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/packages/{}/versions/{}/{}/content",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version,
-                    &self.file_name
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version,
+                    self.file_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6778,9 +6778,9 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/packagesbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6884,11 +6884,11 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6984,11 +6984,11 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7084,11 +7084,11 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7184,9 +7184,9 @@ pub mod python {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/pypi/RecycleBin/packagesBatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7508,11 +7508,11 @@ pub mod universal {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/upack/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7607,11 +7607,11 @@ pub mod universal {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/upack/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7712,11 +7712,11 @@ pub mod universal {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/upack/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7809,9 +7809,9 @@ pub mod universal {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/upack/packagesbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7915,11 +7915,11 @@ pub mod universal {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/upack/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8015,11 +8015,11 @@ pub mod universal {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/upack/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8115,11 +8115,11 @@ pub mod universal {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/upack/RecycleBin/packages/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id,
-                    &self.package_name,
-                    &self.package_version
+                    self.organization,
+                    self.project,
+                    self.feed_id,
+                    self.package_name,
+                    self.package_version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8215,9 +8215,9 @@ pub mod universal {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/packaging/feeds/{}/upack/RecycleBin/packagesBatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.feed_id
+                    self.organization,
+                    self.project,
+                    self.feed_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/audit/mod.rs
+++ b/azure_devops_rust_api/src/audit/mod.rs
@@ -245,7 +245,7 @@ pub mod actions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/audit/actions",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -422,7 +422,7 @@ pub mod audit_log {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/audit/auditlog",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -572,7 +572,7 @@ pub mod download_log {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/audit/downloadlog",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -775,7 +775,7 @@ pub mod streams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/audit/streams",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -876,7 +876,7 @@ pub mod streams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/audit/streams",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -972,7 +972,7 @@ pub mod streams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/audit/streams",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1067,8 +1067,8 @@ pub mod streams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/audit/streams/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.stream_id
+                    self.organization,
+                    self.stream_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1168,8 +1168,8 @@ pub mod streams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/audit/streams/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.stream_id
+                    self.organization,
+                    self.stream_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1259,8 +1259,8 @@ pub mod streams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/audit/streams/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.stream_id
+                    self.organization,
+                    self.stream_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/auth.rs
+++ b/azure_devops_rust_api/src/auth.rs
@@ -56,7 +56,7 @@ impl Credential {
             // PAT tokens are passed using Basic authentication.
             Credential::Pat(pat) => Ok(Some(format!(
                 "Basic {}",
-                BASE64_STANDARD.encode(format!(":{}", &pat))
+                BASE64_STANDARD.encode(format!(":{}", pat))
             ))),
             // OAuth tokens are passed using Bearer authentication.
             Credential::TokenCredential(token_credential) => {

--- a/azure_devops_rust_api/src/build/mod.rs
+++ b/azure_devops_rust_api/src/build/mod.rs
@@ -390,10 +390,10 @@ pub mod artifacts {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/artifacts?artifactName={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id,
-                    &self.artifact_name
+                    self.organization,
+                    self.project,
+                    self.build_id,
+                    self.artifact_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -499,7 +499,7 @@ pub mod artifacts {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/build/builds/{}/artifacts?artifactName={}&fileId={}&fileName={}" , self . client . endpoint () , & self . organization , & self . project , & self . build_id , & self . artifact_name , & self . file_id , & self . file_name)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/build/builds/{}/artifacts?artifactName={}&fileId={}&fileName={}" , self . client . endpoint () , self . organization , self . project , self . build_id , self . artifact_name , self . file_id , self . file_name)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -594,9 +594,9 @@ pub mod artifacts {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/artifacts",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -694,9 +694,9 @@ pub mod artifacts {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/artifacts",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -963,9 +963,9 @@ pub mod leases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/retention/leases?userOwnerId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.user_owner_id
+                    self.organization,
+                    self.project,
+                    self.user_owner_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1092,8 +1092,8 @@ pub mod leases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/retention/leases?",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1193,8 +1193,8 @@ pub mod leases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/retention/leases",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1291,8 +1291,8 @@ pub mod leases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/retention/leases",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1385,8 +1385,8 @@ pub mod leases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/retention/leases",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1485,9 +1485,9 @@ pub mod leases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/retention/leases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.lease_id
+                    self.organization,
+                    self.project,
+                    self.lease_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1585,9 +1585,9 @@ pub mod leases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/retention/leases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.lease_id
+                    self.organization,
+                    self.project,
+                    self.lease_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1725,7 +1725,7 @@ pub mod controllers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/build/controllers",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1820,8 +1820,8 @@ pub mod controllers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/build/controllers/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.controller_id
+                    self.organization,
+                    self.controller_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1935,7 +1935,7 @@ pub mod resource_usage {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/build/resourceusage",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2060,7 +2060,7 @@ pub mod history {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/build/retention/history",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2216,9 +2216,9 @@ pub mod badge {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/public/build/definitions/{}/{}/badge",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2334,9 +2334,9 @@ pub mod badge {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/repos/{}/badge",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repo_type
+                    self.organization,
+                    self.project,
+                    self.repo_type
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2492,8 +2492,8 @@ pub mod authorizedresources {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/authorizedresources",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2594,8 +2594,8 @@ pub mod authorizedresources {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/authorizedresources",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3233,8 +3233,8 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3372,8 +3372,8 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3470,8 +3470,8 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3577,9 +3577,9 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3687,9 +3687,9 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3780,9 +3780,9 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3913,9 +3913,9 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/changes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4011,9 +4011,9 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/leases",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4109,9 +4109,9 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/logs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4228,10 +4228,10 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/logs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id,
-                    &self.log_id
+                    self.organization,
+                    self.project,
+                    self.build_id,
+                    self.log_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4338,9 +4338,9 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/workitems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4449,9 +4449,9 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/workitems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4579,8 +4579,8 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/changes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4696,8 +4696,8 @@ pub mod builds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/workitems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4858,13 +4858,13 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/{}/{}/attachments/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id,
-                    &self.timeline_id,
-                    &self.record_id,
-                    &self.type_,
-                    &self.name
+                    self.organization,
+                    self.project,
+                    self.build_id,
+                    self.timeline_id,
+                    self.record_id,
+                    self.type_,
+                    self.name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4961,10 +4961,10 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id,
-                    &self.type_
+                    self.organization,
+                    self.project,
+                    self.build_id,
+                    self.type_
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5165,9 +5165,9 @@ pub mod properties {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/properties",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5265,9 +5265,9 @@ pub mod properties {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/properties",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5374,9 +5374,9 @@ pub mod properties {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/properties",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5474,9 +5474,9 @@ pub mod properties {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/properties",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5610,9 +5610,9 @@ pub mod report {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/report",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5738,10 +5738,10 @@ pub mod stages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/stages/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id,
-                    &self.stage_ref_name
+                    self.organization,
+                    self.project,
+                    self.build_id,
+                    self.stage_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6098,9 +6098,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/tags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6196,9 +6196,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/tags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6294,9 +6294,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/tags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6391,10 +6391,10 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/tags/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id,
-                    &self.tag
+                    self.organization,
+                    self.project,
+                    self.build_id,
+                    self.tag
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6489,10 +6489,10 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/tags/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id,
-                    &self.tag
+                    self.organization,
+                    self.project,
+                    self.build_id,
+                    self.tag
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6597,9 +6597,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/tags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6695,9 +6695,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/tags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6793,9 +6793,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/tags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6890,10 +6890,10 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/tags/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id,
-                    &self.tag
+                    self.organization,
+                    self.project,
+                    self.definition_id,
+                    self.tag
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6988,10 +6988,10 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/tags/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id,
-                    &self.tag
+                    self.organization,
+                    self.project,
+                    self.definition_id,
+                    self.tag
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7084,8 +7084,8 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/tags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7179,9 +7179,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/tags/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.tag
+                    self.organization,
+                    self.project,
+                    self.tag
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7330,10 +7330,10 @@ pub mod timeline {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/builds/{}/timeline/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id,
-                    &self.timeline_id
+                    self.organization,
+                    self.project,
+                    self.build_id,
+                    self.timeline_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7790,8 +7790,8 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7916,8 +7916,8 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8062,9 +8062,9 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8194,9 +8194,9 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8297,9 +8297,9 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8390,9 +8390,9 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8494,9 +8494,9 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/revisions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8659,9 +8659,9 @@ pub mod metrics {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/metrics",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8773,9 +8773,9 @@ pub mod metrics {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/metrics/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.metric_aggregation_type
+                    self.organization,
+                    self.project,
+                    self.metric_aggregation_type
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8918,9 +8918,9 @@ pub mod resources {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/resources",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9022,9 +9022,9 @@ pub mod resources {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/resources",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9203,9 +9203,9 @@ pub mod yaml {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/{}/yaml",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9389,8 +9389,8 @@ pub mod templates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/templates",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9490,9 +9490,9 @@ pub mod templates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/templates/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.template_id
+                    self.organization,
+                    self.project,
+                    self.template_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9594,9 +9594,9 @@ pub mod templates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/templates/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.template_id
+                    self.organization,
+                    self.project,
+                    self.template_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9688,9 +9688,9 @@ pub mod templates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/definitions/templates/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.template_id
+                    self.organization,
+                    self.project,
+                    self.template_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9886,8 +9886,8 @@ pub mod folders {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/folders",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9987,8 +9987,8 @@ pub mod folders {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/folders",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10081,8 +10081,8 @@ pub mod folders {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/folders",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10192,9 +10192,9 @@ pub mod folders {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/folders/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10336,8 +10336,8 @@ pub mod general_settings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/generalsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10438,8 +10438,8 @@ pub mod general_settings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/generalsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10577,9 +10577,9 @@ pub mod latest {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/latest/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition
+                    self.organization,
+                    self.project,
+                    self.definition
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10703,8 +10703,8 @@ pub mod options {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/options",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10847,8 +10847,8 @@ pub mod retention {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/retention",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10949,8 +10949,8 @@ pub mod retention {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/retention",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11091,8 +11091,8 @@ pub mod settings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/settings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11189,8 +11189,8 @@ pub mod settings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/settings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11371,9 +11371,9 @@ pub mod status {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/build/status/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition
+                    self.organization,
+                    self.project,
+                    self.definition
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11658,8 +11658,8 @@ pub mod source_providers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/sourceproviders",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11787,9 +11787,9 @@ pub mod source_providers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/sourceProviders/{}/branches",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.provider_name
+                    self.organization,
+                    self.project,
+                    self.provider_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11925,9 +11925,9 @@ pub mod source_providers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/sourceProviders/{}/filecontents",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.provider_name
+                    self.organization,
+                    self.project,
+                    self.provider_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12068,9 +12068,9 @@ pub mod source_providers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/sourceProviders/{}/pathcontents",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.provider_name
+                    self.organization,
+                    self.project,
+                    self.provider_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12190,10 +12190,10 @@ pub mod source_providers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/sourceProviders/{}/pullrequests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.provider_name,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.provider_name,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12344,9 +12344,9 @@ pub mod source_providers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/sourceProviders/{}/repositories",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.provider_name
+                    self.organization,
+                    self.project,
+                    self.provider_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12464,9 +12464,9 @@ pub mod source_providers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/sourceProviders/{}/webhooks",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.provider_name
+                    self.organization,
+                    self.project,
+                    self.provider_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12581,9 +12581,9 @@ pub mod source_providers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/sourceProviders/{}/webhooks",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.provider_name
+                    self.organization,
+                    self.project,
+                    self.provider_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/core/mod.rs
+++ b/azure_devops_rust_api/src/core/mod.rs
@@ -252,7 +252,7 @@ pub mod processes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/process/processes",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -347,8 +347,8 @@ pub mod processes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/process/processes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id
+                    self.organization,
+                    self.process_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -627,7 +627,7 @@ pub mod projects {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -724,7 +724,7 @@ pub mod projects {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -842,8 +842,8 @@ pub mod projects {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id
+                    self.organization,
+                    self.project_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -940,8 +940,8 @@ pub mod projects {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id
+                    self.organization,
+                    self.project_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1036,8 +1036,8 @@ pub mod projects {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id
+                    self.organization,
+                    self.project_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1141,8 +1141,8 @@ pub mod projects {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/properties",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id
+                    self.organization,
+                    self.project_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1234,8 +1234,8 @@ pub mod projects {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/properties",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id
+                    self.organization,
+                    self.project_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1375,8 +1375,8 @@ pub mod avatar {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/avatar",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id
+                    self.organization,
+                    self.project_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1469,8 +1469,8 @@ pub mod avatar {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/avatar",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id
+                    self.organization,
+                    self.project_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1633,8 +1633,8 @@ pub mod categorized_teams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/categorizedteams/",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id
+                    self.organization,
+                    self.project_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1920,8 +1920,8 @@ pub mod teams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/teams",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id
+                    self.organization,
+                    self.project_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2018,8 +2018,8 @@ pub mod teams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/teams",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id
+                    self.organization,
+                    self.project_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2126,9 +2126,9 @@ pub mod teams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/teams/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id,
-                    &self.team_id
+                    self.organization,
+                    self.project_id,
+                    self.team_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2226,9 +2226,9 @@ pub mod teams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/teams/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id,
-                    &self.team_id
+                    self.organization,
+                    self.project_id,
+                    self.team_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2319,9 +2319,9 @@ pub mod teams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/teams/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id,
-                    &self.team_id
+                    self.organization,
+                    self.project_id,
+                    self.team_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2440,9 +2440,9 @@ pub mod teams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/projects/{}/teams/{}/members",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project_id,
-                    &self.team_id
+                    self.organization,
+                    self.project_id,
+                    self.team_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2580,7 +2580,7 @@ pub mod teams {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/teams",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/dashboard/mod.rs
+++ b/azure_devops_rust_api/src/dashboard/mod.rs
@@ -263,8 +263,8 @@ pub mod widget_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/dashboard/widgettypes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -363,9 +363,9 @@ pub mod widget_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/dashboard/widgettypes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.contribution_id
+                    self.organization,
+                    self.project,
+                    self.contribution_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -602,9 +602,9 @@ pub mod dashboards {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -702,9 +702,9 @@ pub mod dashboards {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -802,9 +802,9 @@ pub mod dashboards {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -901,10 +901,10 @@ pub mod dashboards {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1003,10 +1003,10 @@ pub mod dashboards {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1098,10 +1098,10 @@ pub mod dashboards {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1436,10 +1436,10 @@ pub mod widgets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}/widgets",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1538,10 +1538,10 @@ pub mod widgets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}/widgets",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1659,10 +1659,10 @@ pub mod widgets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}/widgets",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1780,10 +1780,10 @@ pub mod widgets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}/widgets",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1881,11 +1881,11 @@ pub mod widgets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}/widgets/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id,
-                    &self.widget_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id,
+                    self.widget_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1985,11 +1985,11 @@ pub mod widgets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}/widgets/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id,
-                    &self.widget_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id,
+                    self.widget_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2089,11 +2089,11 @@ pub mod widgets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}/widgets/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id,
-                    &self.widget_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id,
+                    self.widget_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2191,11 +2191,11 @@ pub mod widgets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/dashboard/dashboards/{}/widgets/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.dashboard_id,
-                    &self.widget_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.dashboard_id,
+                    self.widget_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/distributed_task/mod.rs
+++ b/azure_devops_rust_api/src/distributed_task/mod.rs
@@ -299,10 +299,10 @@ pub mod events {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/hubs/{}/plans/{}/events",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_identifier,
-                    &self.hub_name,
-                    &self.plan_id
+                    self.organization,
+                    self.scope_identifier,
+                    self.hub_name,
+                    self.plan_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -452,11 +452,11 @@ pub mod oidctoken {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/hubs/{}/plans/{}/jobs/{}/oidctoken",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_identifier,
-                    &self.hub_name,
-                    &self.plan_id,
-                    &self.job_id
+                    self.organization,
+                    self.scope_identifier,
+                    self.hub_name,
+                    self.plan_id,
+                    self.job_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -618,10 +618,10 @@ pub mod logs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/hubs/{}/plans/{}/logs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_identifier,
-                    &self.hub_name,
-                    &self.plan_id
+                    self.organization,
+                    self.scope_identifier,
+                    self.hub_name,
+                    self.plan_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -721,11 +721,11 @@ pub mod logs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/hubs/{}/plans/{}/logs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_identifier,
-                    &self.hub_name,
-                    &self.plan_id,
-                    &self.log_id
+                    self.organization,
+                    self.scope_identifier,
+                    self.hub_name,
+                    self.plan_id,
+                    self.log_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -863,11 +863,11 @@ pub mod records {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/hubs/{}/plans/{}/timelines/{}/records",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_identifier,
-                    &self.hub_name,
-                    &self.plan_id,
-                    &self.timeline_id
+                    self.organization,
+                    self.scope_identifier,
+                    self.hub_name,
+                    self.plan_id,
+                    self.timeline_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1117,7 +1117,7 @@ pub mod pools {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools?",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1230,7 +1230,7 @@ pub mod pools {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1326,7 +1326,7 @@ pub mod pools {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1446,8 +1446,8 @@ pub mod pools {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id
+                    self.organization,
+                    self.pool_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1544,8 +1544,8 @@ pub mod pools {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id
+                    self.organization,
+                    self.pool_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1635,8 +1635,8 @@ pub mod pools {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id
+                    self.organization,
+                    self.pool_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1900,9 +1900,9 @@ pub mod queues {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/queues?queueNames={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.queue_names
+                    self.organization,
+                    self.project,
+                    self.queue_names
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2016,9 +2016,9 @@ pub mod queues {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/queues?queueIds={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.queue_ids
+                    self.organization,
+                    self.project,
+                    self.queue_ids
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2138,8 +2138,8 @@ pub mod queues {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/queues?",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2253,8 +2253,8 @@ pub mod queues {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/queues",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2363,8 +2363,8 @@ pub mod queues {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/queues",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2474,9 +2474,9 @@ pub mod queues {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/queues/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.queue_id
+                    self.organization,
+                    self.project,
+                    self.queue_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2567,9 +2567,9 @@ pub mod queues {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/queues/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.queue_id
+                    self.organization,
+                    self.project,
+                    self.queue_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2865,8 +2865,8 @@ pub mod variablegroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/variablegroups?",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2962,7 +2962,7 @@ pub mod variablegroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/variablegroups",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3058,7 +3058,7 @@ pub mod variablegroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/variablegroups",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3158,8 +3158,8 @@ pub mod variablegroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/variablegroups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_id
+                    self.organization,
+                    self.group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3254,8 +3254,8 @@ pub mod variablegroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/variablegroups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_id
+                    self.organization,
+                    self.group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3358,8 +3358,8 @@ pub mod variablegroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/variablegroups",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3455,9 +3455,9 @@ pub mod variablegroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/variablegroups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.group_id
+                    self.organization,
+                    self.project,
+                    self.group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3623,7 +3623,7 @@ pub mod agentclouds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/agentclouds",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3719,7 +3719,7 @@ pub mod agentclouds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/agentclouds",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3814,8 +3814,8 @@ pub mod agentclouds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/agentclouds/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.agent_cloud_id
+                    self.organization,
+                    self.agent_cloud_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3912,8 +3912,8 @@ pub mod agentclouds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/agentclouds/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.agent_cloud_id
+                    self.organization,
+                    self.agent_cloud_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4008,8 +4008,8 @@ pub mod agentclouds {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/agentclouds/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.agent_cloud_id
+                    self.organization,
+                    self.agent_cloud_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4130,8 +4130,8 @@ pub mod requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/agentclouds/{}/requests",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.agent_cloud_id
+                    self.organization,
+                    self.agent_cloud_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4249,7 +4249,7 @@ pub mod agentcloudtypes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/agentcloudtypes",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4552,8 +4552,8 @@ pub mod agents {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools/{}/agents",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id
+                    self.organization,
+                    self.pool_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4650,8 +4650,8 @@ pub mod agents {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools/{}/agents",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id
+                    self.organization,
+                    self.pool_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4799,9 +4799,9 @@ pub mod agents {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools/{}/agents/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id,
-                    &self.agent_id
+                    self.organization,
+                    self.pool_id,
+                    self.agent_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4899,9 +4899,9 @@ pub mod agents {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools/{}/agents/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id,
-                    &self.agent_id
+                    self.organization,
+                    self.pool_id,
+                    self.agent_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4999,9 +4999,9 @@ pub mod agents {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools/{}/agents/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id,
-                    &self.agent_id
+                    self.organization,
+                    self.pool_id,
+                    self.agent_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5092,9 +5092,9 @@ pub mod agents {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/pools/{}/agents/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id,
-                    &self.agent_id
+                    self.organization,
+                    self.pool_id,
+                    self.agent_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5223,7 +5223,7 @@ pub mod yamlschema {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/yamlschema",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5496,8 +5496,8 @@ pub mod deploymentgroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/deploymentgroups",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5594,8 +5594,8 @@ pub mod deploymentgroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/deploymentgroups",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5716,9 +5716,9 @@ pub mod deploymentgroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/deploymentgroups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.deployment_group_id
+                    self.organization,
+                    self.project,
+                    self.deployment_group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5816,9 +5816,9 @@ pub mod deploymentgroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/deploymentgroups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.deployment_group_id
+                    self.organization,
+                    self.project,
+                    self.deployment_group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5909,9 +5909,9 @@ pub mod deploymentgroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/deploymentgroups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.deployment_group_id
+                    self.organization,
+                    self.project,
+                    self.deployment_group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6227,9 +6227,9 @@ pub mod targets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/deploymentgroups/{}/targets",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.deployment_group_id
+                    self.organization,
+                    self.project,
+                    self.deployment_group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6327,9 +6327,9 @@ pub mod targets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/deploymentgroups/{}/targets",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.deployment_group_id
+                    self.organization,
+                    self.project,
+                    self.deployment_group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6437,10 +6437,10 @@ pub mod targets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/deploymentgroups/{}/targets/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.deployment_group_id,
-                    &self.target_id
+                    self.organization,
+                    self.project,
+                    self.deployment_group_id,
+                    self.target_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6532,10 +6532,10 @@ pub mod targets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/deploymentgroups/{}/targets/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.deployment_group_id,
-                    &self.target_id
+                    self.organization,
+                    self.project,
+                    self.deployment_group_id,
+                    self.target_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6773,8 +6773,8 @@ pub mod environments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/environments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6872,8 +6872,8 @@ pub mod environments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/environments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6980,9 +6980,9 @@ pub mod environments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/environments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.environment_id
+                    self.organization,
+                    self.project,
+                    self.environment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7080,9 +7080,9 @@ pub mod environments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/environments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.environment_id
+                    self.organization,
+                    self.project,
+                    self.environment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7173,9 +7173,9 @@ pub mod environments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/environments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.environment_id
+                    self.organization,
+                    self.project,
+                    self.environment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7329,9 +7329,9 @@ pub mod environmentdeployment_records {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/environments/{}/environmentdeploymentrecords",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.environment_id
+                    self.organization,
+                    self.project,
+                    self.environment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7496,9 +7496,9 @@ pub mod kubernetes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/environments/{}/providers/kubernetes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.environment_id
+                    self.organization,
+                    self.project,
+                    self.environment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7595,10 +7595,10 @@ pub mod kubernetes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/environments/{}/providers/kubernetes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.environment_id,
-                    &self.resource_id
+                    self.organization,
+                    self.project,
+                    self.environment_id,
+                    self.resource_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7690,10 +7690,10 @@ pub mod kubernetes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/environments/{}/providers/kubernetes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.environment_id,
-                    &self.resource_id
+                    self.organization,
+                    self.project,
+                    self.environment_id,
+                    self.resource_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7889,8 +7889,8 @@ pub mod taskgroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/taskgroups",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8060,9 +8060,9 @@ pub mod taskgroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/taskgroups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.task_group_id
+                    self.organization,
+                    self.project,
+                    self.task_group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8160,9 +8160,9 @@ pub mod taskgroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/taskgroups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.task_group_id
+                    self.organization,
+                    self.project,
+                    self.task_group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8264,9 +8264,9 @@ pub mod taskgroups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/distributedtask/taskgroups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.task_group_id
+                    self.organization,
+                    self.project,
+                    self.task_group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8435,7 +8435,7 @@ pub mod elasticpools {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/elasticpools",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8579,7 +8579,7 @@ pub mod elasticpools {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/elasticpools",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8675,8 +8675,8 @@ pub mod elasticpools {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/elasticpools/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id
+                    self.organization,
+                    self.pool_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8773,8 +8773,8 @@ pub mod elasticpools {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/elasticpools/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id
+                    self.organization,
+                    self.pool_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8903,8 +8903,8 @@ pub mod elasticpoollogs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/elasticpools/{}/logs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id
+                    self.organization,
+                    self.pool_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9052,8 +9052,8 @@ pub mod nodes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/elasticpools/{}/nodes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id
+                    self.organization,
+                    self.pool_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9151,9 +9151,9 @@ pub mod nodes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/distributedtask/elasticpools/{}/nodes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.pool_id,
-                    &self.elastic_node_id
+                    self.organization,
+                    self.pool_id,
+                    self.elastic_node_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/extension_management/mod.rs
+++ b/azure_devops_rust_api/src/extension_management/mod.rs
@@ -361,7 +361,7 @@ pub mod installed_extensions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/extensionmanagement/installedextensions",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -458,7 +458,7 @@ pub mod installed_extensions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/extensionmanagement/installedextensions",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -565,9 +565,9 @@ pub mod installed_extensions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/extensionmanagement/installedextensionsbyname/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.publisher_name,
-                    &self.extension_name
+                    self.organization,
+                    self.publisher_name,
+                    self.extension_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -678,9 +678,9 @@ pub mod installed_extensions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/extensionmanagement/installedextensionsbyname/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.publisher_name,
-                    &self.extension_name
+                    self.organization,
+                    self.publisher_name,
+                    self.extension_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -781,10 +781,10 @@ pub mod installed_extensions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/extensionmanagement/installedextensionsbyname/{}/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.publisher_name,
-                    &self.extension_name,
-                    &self.version
+                    self.organization,
+                    self.publisher_name,
+                    self.extension_name,
+                    self.version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/favorite/mod.rs
+++ b/azure_devops_rust_api/src/favorite/mod.rs
@@ -430,9 +430,9 @@ pub mod favorites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/favorite/favorites?ownerScopeType={}&ownerScopeId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.owner_scope_type,
-                    &self.owner_scope_id
+                    self.organization,
+                    self.owner_scope_type,
+                    self.owner_scope_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -538,9 +538,9 @@ pub mod favorites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/favorite/favorites?ownerScopeType={}&ownerScopeId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.owner_scope_type,
-                    &self.owner_scope_id
+                    self.organization,
+                    self.owner_scope_type,
+                    self.owner_scope_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -667,7 +667,7 @@ pub mod favorites {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/favorite/favorites?artifactType={}&artifactId={}&artifactScopeType={}" , self . client . endpoint () , & self . organization , & self . artifact_type , & self . artifact_id , & self . artifact_scope_type)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/favorite/favorites?artifactType={}&artifactId={}&artifactScopeType={}" , self . client . endpoint () , self . organization , self . artifact_type , self . artifact_id , self . artifact_scope_type)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -783,7 +783,7 @@ pub mod favorites {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/favorite/favorites/{}?ownerScopeType={}&ownerScopeId={}&artifactType={}&artifactScopeType={}" , self . client . endpoint () , & self . organization , & self . favorite_id , & self . owner_scope_type , & self . owner_scope_id , & self . artifact_type , & self . artifact_scope_type)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/favorite/favorites/{}?ownerScopeType={}&ownerScopeId={}&artifactType={}&artifactScopeType={}" , self . client . endpoint () , self . organization , self . favorite_id , self . owner_scope_type , self . owner_scope_id , self . artifact_type , self . artifact_scope_type)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -918,7 +918,7 @@ pub mod favorites {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/favorite/favorites/{}?ownerScopeType={}&ownerScopeId={}&artifactScopeType={}&artifactType={}" , self . client . endpoint () , & self . organization , & self . favorite_id , & self . owner_scope_type , & self . owner_scope_id , & self . artifact_scope_type , & self . artifact_type)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/favorite/favorites/{}?ownerScopeType={}&ownerScopeId={}&artifactScopeType={}&artifactType={}" , self . client . endpoint () , self . organization , self . favorite_id , self . owner_scope_type , self . owner_scope_id , self . artifact_scope_type , self . artifact_type)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -1052,7 +1052,7 @@ pub mod favorites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/favorite/favorites",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1148,7 +1148,7 @@ pub mod favorites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/favorite/favorites",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1274,8 +1274,8 @@ pub mod favorites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/favorite/favorites/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.favorite_id
+                    self.organization,
+                    self.favorite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1385,8 +1385,8 @@ pub mod favorites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/favorite/favorites/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.favorite_id
+                    self.organization,
+                    self.favorite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/git/mod.rs
+++ b/azure_devops_rust_api/src/git/mod.rs
@@ -521,10 +521,10 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}?includeParent={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.include_parent
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.include_parent
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -622,8 +622,8 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/deletedrepositories",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -722,8 +722,8 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/recycleBin/repositories",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -822,9 +822,9 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/recycleBin/repositories/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -915,9 +915,9 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/recycleBin/repositories/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1048,8 +1048,8 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1157,8 +1157,8 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1254,9 +1254,9 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1354,9 +1354,9 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1447,9 +1447,9 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2059,9 +2059,9 @@ pub mod commits {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/commits?",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2195,9 +2195,9 @@ pub mod commits {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/commits",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2305,10 +2305,10 @@ pub mod commits {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/commits/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.commit_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.commit_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2427,10 +2427,10 @@ pub mod commits {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/commits/{}/changes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.commit_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.commit_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2561,9 +2561,9 @@ pub mod commits {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/commitsbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2912,10 +2912,10 @@ pub mod items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/items?path={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3154,9 +3154,9 @@ pub mod items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/items",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3254,9 +3254,9 @@ pub mod items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/itemsbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3465,10 +3465,10 @@ pub mod stats {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/stats/branches?name={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.name
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3617,9 +3617,9 @@ pub mod stats {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/stats/branches",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3821,8 +3821,8 @@ pub mod refs_favorites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/favorites/refs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3919,8 +3919,8 @@ pub mod refs_favorites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/favorites/refs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4016,9 +4016,9 @@ pub mod refs_favorites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/favorites/refs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.favorite_id
+                    self.organization,
+                    self.project,
+                    self.favorite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4109,9 +4109,9 @@ pub mod refs_favorites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/favorites/refs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.favorite_id
+                    self.organization,
+                    self.project,
+                    self.favorite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4310,8 +4310,8 @@ pub mod policy_configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/policy/configurations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4792,8 +4792,8 @@ pub mod pull_requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/pullrequests",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4889,9 +4889,9 @@ pub mod pull_requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/pullrequests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5203,9 +5203,9 @@ pub mod pull_requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullrequests",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5315,9 +5315,9 @@ pub mod pull_requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullrequests",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5470,10 +5470,10 @@ pub mod pull_requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullrequests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5595,10 +5595,10 @@ pub mod pull_requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullrequests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5750,9 +5750,9 @@ pub mod annotated_tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/annotatedtags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5849,10 +5849,10 @@ pub mod annotated_tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/annotatedtags/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.object_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.object_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6017,9 +6017,9 @@ pub mod blobs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/blobs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6160,10 +6160,10 @@ pub mod blobs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/blobs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.sha1
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.sha1
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6339,9 +6339,9 @@ pub mod cherry_picks {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/cherryPicks",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6439,9 +6439,9 @@ pub mod cherry_picks {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/cherryPicks",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6538,10 +6538,10 @@ pub mod cherry_picks {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/cherryPicks/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.cherry_pick_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.cherry_pick_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6731,10 +6731,10 @@ pub mod statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/commits/{}/statuses",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.commit_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.commit_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6833,10 +6833,10 @@ pub mod statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/commits/{}/statuses",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.commit_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.commit_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7083,9 +7083,9 @@ pub mod diffs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/diffs/commits",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7291,9 +7291,9 @@ pub mod import_requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/importRequests",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7391,9 +7391,9 @@ pub mod import_requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/importRequests",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7490,10 +7490,10 @@ pub mod import_requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/importRequests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.import_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.import_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7592,10 +7592,10 @@ pub mod import_requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/importRequests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.import_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.import_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7725,9 +7725,9 @@ pub mod pull_request_query {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullrequestquery",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7934,10 +7934,10 @@ pub mod pull_request_attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8033,11 +8033,11 @@ pub mod pull_request_attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.file_name
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.file_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8137,11 +8137,11 @@ pub mod pull_request_attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.file_name
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.file_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8234,11 +8234,11 @@ pub mod pull_request_attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.file_name
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.file_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8421,10 +8421,10 @@ pub mod pull_request_commits {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/commits",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8544,11 +8544,11 @@ pub mod pull_request_commits {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/iterations/{}/commits",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8717,10 +8717,10 @@ pub mod pull_request_iterations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/iterations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8822,11 +8822,11 @@ pub mod pull_request_iterations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/iterations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8999,11 +8999,11 @@ pub mod pull_request_iteration_changes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/iterations/{}/changes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9252,11 +9252,11 @@ pub mod pull_request_iteration_statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/iterations/{}/statuses",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9357,11 +9357,11 @@ pub mod pull_request_iteration_statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/iterations/{}/statuses",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9456,11 +9456,11 @@ pub mod pull_request_iteration_statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/iterations/{}/statuses",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9562,12 +9562,12 @@ pub mod pull_request_iteration_statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/iterations/{}/statuses/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.iteration_id,
-                    &self.status_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.iteration_id,
+                    self.status_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9661,12 +9661,12 @@ pub mod pull_request_iteration_statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/iterations/{}/statuses/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.iteration_id,
-                    &self.status_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.iteration_id,
+                    self.status_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9891,10 +9891,10 @@ pub mod pull_request_labels {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/labels",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10005,10 +10005,10 @@ pub mod pull_request_labels {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/labels",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10117,11 +10117,11 @@ pub mod pull_request_labels {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/labels/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.label_id_or_name
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.label_id_or_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10225,11 +10225,11 @@ pub mod pull_request_labels {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/labels/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.label_id_or_name
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.label_id_or_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10386,10 +10386,10 @@ pub mod pull_request_properties {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/properties",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10488,10 +10488,10 @@ pub mod pull_request_properties {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/properties",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10804,10 +10804,10 @@ pub mod pull_request_reviewers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/reviewers",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10910,10 +10910,10 @@ pub mod pull_request_reviewers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/reviewers",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11013,10 +11013,10 @@ pub mod pull_request_reviewers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/reviewers",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11110,10 +11110,10 @@ pub mod pull_request_reviewers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/reviewers",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11214,11 +11214,11 @@ pub mod pull_request_reviewers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/reviewers/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.reviewer_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.reviewer_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11318,11 +11318,11 @@ pub mod pull_request_reviewers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/reviewers/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.reviewer_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.reviewer_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11422,11 +11422,11 @@ pub mod pull_request_reviewers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/reviewers/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.reviewer_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.reviewer_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11519,11 +11519,11 @@ pub mod pull_request_reviewers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/reviewers/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.reviewer_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.reviewer_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11654,10 +11654,10 @@ pub mod pull_request_share {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/share",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11892,10 +11892,10 @@ pub mod pull_request_statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/statuses",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11995,10 +11995,10 @@ pub mod pull_request_statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/statuses",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12092,10 +12092,10 @@ pub mod pull_request_statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/statuses",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12196,11 +12196,11 @@ pub mod pull_request_statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/statuses/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.status_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.status_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12293,11 +12293,11 @@ pub mod pull_request_statuses {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/statuses/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.status_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.status_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12536,10 +12536,10 @@ pub mod pull_request_threads {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12642,10 +12642,10 @@ pub mod pull_request_threads {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12769,11 +12769,11 @@ pub mod pull_request_threads {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.thread_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.thread_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12877,11 +12877,11 @@ pub mod pull_request_threads {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.thread_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.thread_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -13130,11 +13130,11 @@ pub mod pull_request_thread_comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.thread_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.thread_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -13234,11 +13234,11 @@ pub mod pull_request_thread_comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.thread_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.thread_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -13337,12 +13337,12 @@ pub mod pull_request_thread_comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.thread_id,
-                    &self.comment_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.thread_id,
+                    self.comment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -13443,12 +13443,12 @@ pub mod pull_request_thread_comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.thread_id,
-                    &self.comment_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.thread_id,
+                    self.comment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -13542,12 +13542,12 @@ pub mod pull_request_thread_comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id,
-                    &self.thread_id,
-                    &self.comment_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id,
+                    self.thread_id,
+                    self.comment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -13740,7 +13740,7 @@ pub mod pull_request_comment_likes {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments/{}/likes" , self . client . endpoint () , & self . organization , & self . project , & self . repository_id , & self . pull_request_id , & self . thread_id , & self . comment_id)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments/{}/likes" , self . client . endpoint () , self . organization , self . project , self . repository_id , self . pull_request_id , self . thread_id , self . comment_id)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -13831,7 +13831,7 @@ pub mod pull_request_comment_likes {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments/{}/likes" , self . client . endpoint () , & self . organization , & self . project , & self . repository_id , & self . pull_request_id , & self . thread_id , & self . comment_id)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments/{}/likes" , self . client . endpoint () , self . organization , self . project , self . repository_id , self . pull_request_id , self . thread_id , self . comment_id)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -13924,7 +13924,7 @@ pub mod pull_request_comment_likes {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments/{}/likes" , self . client . endpoint () , & self . organization , & self . project , & self . repository_id , & self . pull_request_id , & self . thread_id , & self . comment_id)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/threads/{}/comments/{}/likes" , self . client . endpoint () , self . organization , self . project , self . repository_id , self . pull_request_id , self . thread_id , self . comment_id)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -14055,10 +14055,10 @@ pub mod pull_request_work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pullRequests/{}/workitems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.pull_request_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.pull_request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -14353,9 +14353,9 @@ pub mod pushes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pushes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -14453,9 +14453,9 @@ pub mod pushes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pushes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -14574,10 +14574,10 @@ pub mod pushes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/pushes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.push_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.push_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -14860,9 +14860,9 @@ pub mod refs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/refs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -14974,9 +14974,9 @@ pub mod refs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/refs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -15091,9 +15091,9 @@ pub mod refs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/refs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -15269,9 +15269,9 @@ pub mod reverts {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/reverts",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -15369,9 +15369,9 @@ pub mod reverts {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/reverts",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -15468,10 +15468,10 @@ pub mod reverts {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/reverts/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.revert_id
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.revert_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -15596,9 +15596,9 @@ pub mod suggestions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/suggestions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id
+                    self.organization,
+                    self.project,
+                    self.repository_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -15775,10 +15775,10 @@ pub mod trees {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/trees/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_id,
-                    &self.sha1
+                    self.organization,
+                    self.project,
+                    self.repository_id,
+                    self.sha1
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -15939,10 +15939,10 @@ pub mod merge_bases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/commits/{}/mergebases",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_name_or_id,
-                    &self.commit_id
+                    self.organization,
+                    self.project,
+                    self.repository_name_or_id,
+                    self.commit_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -16150,10 +16150,10 @@ pub mod forks {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/forks/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_name_or_id,
-                    &self.collection_id
+                    self.organization,
+                    self.project,
+                    self.repository_name_or_id,
+                    self.collection_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -16274,9 +16274,9 @@ pub mod forks {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/forkSyncRequests",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_name_or_id
+                    self.organization,
+                    self.project,
+                    self.repository_name_or_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -16386,9 +16386,9 @@ pub mod forks {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/forkSyncRequests",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_name_or_id
+                    self.organization,
+                    self.project,
+                    self.repository_name_or_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -16496,10 +16496,10 @@ pub mod forks {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/forkSyncRequests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_name_or_id,
-                    &self.fork_sync_operation_id
+                    self.organization,
+                    self.project,
+                    self.repository_name_or_id,
+                    self.fork_sync_operation_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -16664,9 +16664,9 @@ pub mod merges {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/merges",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_name_or_id
+                    self.organization,
+                    self.project,
+                    self.repository_name_or_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -16774,10 +16774,10 @@ pub mod merges {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/git/repositories/{}/merges/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository_name_or_id,
-                    &self.merge_operation_id
+                    self.organization,
+                    self.project,
+                    self.repository_name_or_id,
+                    self.merge_operation_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/graph/mod.rs
+++ b/azure_devops_rust_api/src/graph/mod.rs
@@ -264,8 +264,8 @@ pub mod descriptors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/descriptors/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.storage_key
+                    self.organization,
+                    self.storage_key
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -496,7 +496,7 @@ pub mod groups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/groups",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -614,7 +614,7 @@ pub mod groups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/groups",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -709,8 +709,8 @@ pub mod groups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/groups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_descriptor
+                    self.organization,
+                    self.group_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -807,8 +807,8 @@ pub mod groups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/groups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_descriptor
+                    self.organization,
+                    self.group_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -898,8 +898,8 @@ pub mod groups {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/groups/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_descriptor
+                    self.organization,
+                    self.group_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1126,8 +1126,8 @@ pub mod memberships {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/Memberships/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor
+                    self.organization,
+                    self.subject_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1223,9 +1223,9 @@ pub mod memberships {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/memberships/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor,
-                    &self.container_descriptor
+                    self.organization,
+                    self.subject_descriptor,
+                    self.container_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1321,9 +1321,9 @@ pub mod memberships {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/memberships/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor,
-                    &self.container_descriptor
+                    self.organization,
+                    self.subject_descriptor,
+                    self.container_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1414,9 +1414,9 @@ pub mod memberships {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/memberships/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor,
-                    &self.container_descriptor
+                    self.organization,
+                    self.subject_descriptor,
+                    self.container_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1510,9 +1510,9 @@ pub mod memberships {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/memberships/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor,
-                    &self.container_descriptor
+                    self.organization,
+                    self.subject_descriptor,
+                    self.container_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1636,8 +1636,8 @@ pub mod membership_states {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/membershipstates/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor
+                    self.organization,
+                    self.subject_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1751,7 +1751,7 @@ pub mod request_access {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/requestaccess",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1956,7 +1956,7 @@ pub mod service_principals {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/serviceprincipals",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2064,7 +2064,7 @@ pub mod service_principals {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/serviceprincipals",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2159,8 +2159,8 @@ pub mod service_principals {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/serviceprincipals/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.service_principal_descriptor
+                    self.organization,
+                    self.service_principal_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2250,8 +2250,8 @@ pub mod service_principals {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/serviceprincipals/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.service_principal_descriptor
+                    self.organization,
+                    self.service_principal_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2374,8 +2374,8 @@ pub mod storage_keys {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/storagekeys/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor
+                    self.organization,
+                    self.subject_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2497,7 +2497,7 @@ pub mod subject_lookup {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/subjectlookup",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2619,7 +2619,7 @@ pub mod subject_query {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/subjectquery",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2787,8 +2787,8 @@ pub mod avatars {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/Subjects/{}/avatars",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor
+                    self.organization,
+                    self.subject_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2880,8 +2880,8 @@ pub mod avatars {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/Subjects/{}/avatars",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor
+                    self.organization,
+                    self.subject_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2974,8 +2974,8 @@ pub mod avatars {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/Subjects/{}/avatars",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor
+                    self.organization,
+                    self.subject_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3208,7 +3208,7 @@ pub mod users {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/users",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3315,7 +3315,7 @@ pub mod users {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/users",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3410,8 +3410,8 @@ pub mod users {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/users/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.user_descriptor
+                    self.organization,
+                    self.user_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3508,8 +3508,8 @@ pub mod users {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/users/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.user_descriptor
+                    self.organization,
+                    self.user_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3599,8 +3599,8 @@ pub mod users {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/users/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.user_descriptor
+                    self.organization,
+                    self.user_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3721,8 +3721,8 @@ pub mod provider_info {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/graph/Users/{}/providerinfo",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.user_descriptor
+                    self.organization,
+                    self.user_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/hooks/mod.rs
+++ b/azure_devops_rust_api/src/hooks/mod.rs
@@ -301,7 +301,7 @@ pub mod consumers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/consumers",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -406,8 +406,8 @@ pub mod consumers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/consumers/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.consumer_id
+                    self.organization,
+                    self.consumer_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -512,8 +512,8 @@ pub mod consumers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/consumers/{}/actions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.consumer_id
+                    self.organization,
+                    self.consumer_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -619,9 +619,9 @@ pub mod consumers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/consumers/{}/actions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.consumer_id,
-                    &self.consumer_action_id
+                    self.organization,
+                    self.consumer_id,
+                    self.consumer_action_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -795,7 +795,7 @@ pub mod notifications {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/notificationsquery",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -923,8 +923,8 @@ pub mod notifications {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/subscriptions/{}/notifications",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subscription_id
+                    self.organization,
+                    self.subscription_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1020,9 +1020,9 @@ pub mod notifications {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/subscriptions/{}/notifications/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subscription_id,
-                    &self.notification_id
+                    self.organization,
+                    self.subscription_id,
+                    self.notification_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1129,7 +1129,7 @@ pub mod notifications {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/testnotifications",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1323,7 +1323,7 @@ pub mod publishers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/publishers",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1418,8 +1418,8 @@ pub mod publishers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/publishers/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.publisher_id
+                    self.organization,
+                    self.publisher_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1517,8 +1517,8 @@ pub mod publishers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/publishers/{}/eventtypes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.publisher_id
+                    self.organization,
+                    self.publisher_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1615,9 +1615,9 @@ pub mod publishers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/publishers/{}/eventtypes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.publisher_id,
-                    &self.event_type_id
+                    self.organization,
+                    self.publisher_id,
+                    self.event_type_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1714,8 +1714,8 @@ pub mod publishers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/publishers/{}/inputValuesQuery",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.publisher_id
+                    self.organization,
+                    self.publisher_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1811,7 +1811,7 @@ pub mod publishers {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/publishersquery",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2053,7 +2053,7 @@ pub mod subscriptions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/subscriptions",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2149,7 +2149,7 @@ pub mod subscriptions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/subscriptions",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2244,8 +2244,8 @@ pub mod subscriptions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/subscriptions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subscription_id
+                    self.organization,
+                    self.subscription_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2342,8 +2342,8 @@ pub mod subscriptions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/subscriptions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subscription_id
+                    self.organization,
+                    self.subscription_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2433,8 +2433,8 @@ pub mod subscriptions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/subscriptions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subscription_id
+                    self.organization,
+                    self.subscription_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2533,7 +2533,7 @@ pub mod subscriptions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/subscriptionsquery",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2669,8 +2669,8 @@ pub mod diagnostics {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/subscriptions/{}/diagnostics",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subscription_id
+                    self.organization,
+                    self.subscription_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2771,8 +2771,8 @@ pub mod diagnostics {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/hooks/subscriptions/{}/diagnostics",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subscription_id
+                    self.organization,
+                    self.subscription_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/ims/mod.rs
+++ b/azure_devops_rust_api/src/ims/mod.rs
@@ -302,7 +302,7 @@ pub mod identities {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/identities",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/member_entitlement_management/mod.rs
+++ b/azure_devops_rust_api/src/member_entitlement_management/mod.rs
@@ -310,7 +310,7 @@ pub mod group_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/groupentitlements",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -422,7 +422,7 @@ pub mod group_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/groupentitlements",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -518,8 +518,8 @@ pub mod group_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/groupentitlements/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_id
+                    self.organization,
+                    self.group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -632,8 +632,8 @@ pub mod group_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/groupentitlements/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_id
+                    self.organization,
+                    self.group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -757,8 +757,8 @@ pub mod group_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/groupentitlements/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_id
+                    self.organization,
+                    self.group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -942,8 +942,8 @@ pub mod members {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/GroupEntitlements/{}/members",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_id
+                    self.organization,
+                    self.group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1034,9 +1034,9 @@ pub mod members {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/GroupEntitlements/{}/members/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_id,
-                    &self.member_id
+                    self.organization,
+                    self.group_id,
+                    self.member_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1130,9 +1130,9 @@ pub mod members {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/GroupEntitlements/{}/members/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.group_id,
-                    &self.member_id
+                    self.organization,
+                    self.group_id,
+                    self.member_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1294,7 +1294,7 @@ pub mod member_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/memberentitlements",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1488,7 +1488,7 @@ pub mod service_principal_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceprincipalentitlements",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1593,7 +1593,7 @@ pub mod service_principal_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceprincipalentitlements",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1694,8 +1694,8 @@ pub mod service_principal_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceprincipalentitlements/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.service_principal_id
+                    self.organization,
+                    self.service_principal_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1798,8 +1798,8 @@ pub mod service_principal_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceprincipalentitlements/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.service_principal_id
+                    self.organization,
+                    self.service_principal_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1892,8 +1892,8 @@ pub mod service_principal_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceprincipalentitlements/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.service_principal_id
+                    self.organization,
+                    self.service_principal_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2148,7 +2148,7 @@ pub mod user_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/userentitlements",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2248,7 +2248,7 @@ pub mod user_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/userentitlements",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2367,7 +2367,7 @@ pub mod user_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/userentitlements",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2463,8 +2463,8 @@ pub mod user_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/userentitlements/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.user_id
+                    self.organization,
+                    self.user_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2564,8 +2564,8 @@ pub mod user_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/userentitlements/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.user_id
+                    self.organization,
+                    self.user_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2656,8 +2656,8 @@ pub mod user_entitlements {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/userentitlements/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.user_id
+                    self.organization,
+                    self.user_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2786,7 +2786,7 @@ pub mod user_entitlement_summary {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/userentitlementsummary",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/operations/mod.rs
+++ b/azure_devops_rust_api/src/operations/mod.rs
@@ -243,8 +243,8 @@ pub mod operations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/operations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.operation_id
+                    self.organization,
+                    self.operation_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/permissions_report/mod.rs
+++ b/azure_devops_rust_api/src/permissions_report/mod.rs
@@ -259,7 +259,7 @@ pub mod permissions_report {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/permissionsreport",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -355,7 +355,7 @@ pub mod permissions_report {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/permissionsreport",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -450,8 +450,8 @@ pub mod permissions_report {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/permissionsreport/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.id
+                    self.organization,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -570,8 +570,8 @@ pub mod permissions_report_download {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/permissionsreport/{}/download",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.id
+                    self.organization,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/pipelines/mod.rs
+++ b/azure_devops_rust_api/src/pipelines/mod.rs
@@ -318,8 +318,8 @@ pub mod pipelines {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -416,8 +416,8 @@ pub mod pipelines {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -524,9 +524,9 @@ pub mod pipelines {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.pipeline_id
+                    self.organization,
+                    self.project,
+                    self.pipeline_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -668,9 +668,9 @@ pub mod preview {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/{}/preview",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.pipeline_id
+                    self.organization,
+                    self.project,
+                    self.pipeline_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -840,9 +840,9 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/{}/runs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.pipeline_id
+                    self.organization,
+                    self.project,
+                    self.pipeline_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -949,9 +949,9 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/{}/runs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.pipeline_id
+                    self.organization,
+                    self.project,
+                    self.pipeline_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1046,10 +1046,10 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/{}/runs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.pipeline_id,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.pipeline_id,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1198,10 +1198,10 @@ pub mod artifacts {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/{}/runs/{}/artifacts",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.pipeline_id,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.pipeline_id,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1368,10 +1368,10 @@ pub mod logs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/{}/runs/{}/logs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.pipeline_id,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.pipeline_id,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1478,11 +1478,11 @@ pub mod logs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/pipelines/{}/runs/{}/logs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.pipeline_id,
-                    &self.run_id,
-                    &self.log_id
+                    self.organization,
+                    self.project,
+                    self.pipeline_id,
+                    self.run_id,
+                    self.log_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/policy/mod.rs
+++ b/azure_devops_rust_api/src/policy/mod.rs
@@ -368,8 +368,8 @@ pub mod configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/configurations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -467,8 +467,8 @@ pub mod configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/configurations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -564,9 +564,9 @@ pub mod configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/configurations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.configuration_id
+                    self.organization,
+                    self.project,
+                    self.configuration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -664,9 +664,9 @@ pub mod configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/configurations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.configuration_id
+                    self.organization,
+                    self.project,
+                    self.configuration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -757,9 +757,9 @@ pub mod configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/configurations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.configuration_id
+                    self.organization,
+                    self.project,
+                    self.configuration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -936,9 +936,9 @@ pub mod revisions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/configurations/{}/revisions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.configuration_id
+                    self.organization,
+                    self.project,
+                    self.configuration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1036,10 +1036,10 @@ pub mod revisions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/configurations/{}/revisions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.configuration_id,
-                    &self.revision_id
+                    self.organization,
+                    self.project,
+                    self.configuration_id,
+                    self.revision_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1246,8 +1246,8 @@ pub mod evaluations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/evaluations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1347,9 +1347,9 @@ pub mod evaluations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/evaluations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.evaluation_id
+                    self.organization,
+                    self.project,
+                    self.evaluation_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1449,9 +1449,9 @@ pub mod evaluations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/evaluations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.evaluation_id
+                    self.organization,
+                    self.project,
+                    self.evaluation_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1592,8 +1592,8 @@ pub mod types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/types",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1689,9 +1689,9 @@ pub mod types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/policy/types/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.type_id
+                    self.organization,
+                    self.project,
+                    self.type_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/processadmin/mod.rs
+++ b/azure_devops_rust_api/src/processadmin/mod.rs
@@ -258,9 +258,9 @@ pub mod behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processadmin/{}/behaviors?behaviorRefName={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.behavior_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.behavior_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -355,8 +355,8 @@ pub mod behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processadmin/{}/behaviors",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id
+                    self.organization,
+                    self.process_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -509,8 +509,8 @@ pub mod processes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processadmin/processes/export/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.id
+                    self.organization,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -629,7 +629,7 @@ pub mod processes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processadmin/processes/import",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -724,8 +724,8 @@ pub mod processes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processadmin/processes/status/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.id
+                    self.organization,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/processes/mod.rs
+++ b/azure_devops_rust_api/src/processes/mod.rs
@@ -422,7 +422,7 @@ pub mod groups {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}/sections/{}/groups/{}?removeFromPageId={}&removeFromSectionId={}" , self . client . endpoint () , & self . organization , & self . process_id , & self . wit_ref_name , & self . page_id , & self . section_id , & self . group_id , & self . remove_from_page_id , & self . remove_from_section_id)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}/sections/{}/groups/{}?removeFromPageId={}&removeFromSectionId={}" , self . client . endpoint () , self . organization , self . process_id , self . wit_ref_name , self . page_id , self . section_id , self . group_id , self . remove_from_page_id , self . remove_from_section_id)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -518,7 +518,7 @@ pub mod groups {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}/sections/{}/groups" , self . client . endpoint () , & self . organization , & self . process_id , & self . wit_ref_name , & self . page_id , & self . section_id)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}/sections/{}/groups" , self . client . endpoint () , self . organization , self . process_id , self . wit_ref_name , self . page_id , self . section_id)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -620,7 +620,7 @@ pub mod groups {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}/sections/{}/groups/{}" , self . client . endpoint () , & self . organization , & self . process_id , & self . wit_ref_name , & self . page_id , & self . section_id , & self . group_id)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}/sections/{}/groups/{}" , self . client . endpoint () , self . organization , self . process_id , self . wit_ref_name , self . page_id , self . section_id , self . group_id)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -717,7 +717,7 @@ pub mod groups {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}/sections/{}/groups/{}" , self . client . endpoint () , & self . organization , & self . process_id , & self . wit_ref_name , & self . page_id , & self . section_id , & self . group_id)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}/sections/{}/groups/{}" , self . client . endpoint () , self . organization , self . process_id , self . wit_ref_name , self . page_id , self . section_id , self . group_id)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -807,7 +807,7 @@ pub mod groups {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}/sections/{}/groups/{}" , self . client . endpoint () , & self . organization , & self . process_id , & self . wit_ref_name , & self . page_id , & self . section_id , & self . group_id)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}/sections/{}/groups/{}" , self . client . endpoint () , self . organization , self . process_id , self . wit_ref_name , self . page_id , self . section_id , self . group_id)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -998,7 +998,7 @@ pub mod processes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1094,7 +1094,7 @@ pub mod processes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1199,8 +1199,8 @@ pub mod processes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_type_id
+                    self.organization,
+                    self.process_type_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1297,8 +1297,8 @@ pub mod processes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_type_id
+                    self.organization,
+                    self.process_type_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1388,8 +1388,8 @@ pub mod processes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_type_id
+                    self.organization,
+                    self.process_type_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1602,8 +1602,8 @@ pub mod behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/behaviors",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id
+                    self.organization,
+                    self.process_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1700,8 +1700,8 @@ pub mod behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/behaviors",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id
+                    self.organization,
+                    self.process_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1807,9 +1807,9 @@ pub mod behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/behaviors/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.behavior_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.behavior_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1907,9 +1907,9 @@ pub mod behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/behaviors/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.behavior_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.behavior_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2000,9 +2000,9 @@ pub mod behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/behaviors/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.behavior_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.behavior_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2219,8 +2219,8 @@ pub mod work_item_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workitemtypes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id
+                    self.organization,
+                    self.process_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2318,8 +2318,8 @@ pub mod work_item_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workitemtypes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id
+                    self.organization,
+                    self.process_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2426,9 +2426,9 @@ pub mod work_item_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workitemtypes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2526,9 +2526,9 @@ pub mod work_item_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workitemtypes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2619,9 +2619,9 @@ pub mod work_item_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workitemtypes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2842,9 +2842,9 @@ pub mod fields {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/fields",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2946,9 +2946,9 @@ pub mod fields {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/fields",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3062,10 +3062,10 @@ pub mod fields {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/fields/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.field_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.field_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3168,10 +3168,10 @@ pub mod fields {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/fields/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.field_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.field_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3264,10 +3264,10 @@ pub mod fields {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/fields/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.field_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.field_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3395,9 +3395,9 @@ pub mod layout {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3613,10 +3613,10 @@ pub mod controls {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/groups/{}/controls",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.group_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.group_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3727,11 +3727,11 @@ pub mod controls {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/groups/{}/controls/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.group_id,
-                    &self.control_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.group_id,
+                    self.control_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3831,11 +3831,11 @@ pub mod controls {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/groups/{}/controls/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.group_id,
-                    &self.control_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.group_id,
+                    self.control_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3928,11 +3928,11 @@ pub mod controls {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/groups/{}/controls/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.group_id,
-                    &self.control_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.group_id,
+                    self.control_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4107,9 +4107,9 @@ pub mod pages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4205,9 +4205,9 @@ pub mod pages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4299,10 +4299,10 @@ pub mod pages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/pages/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.page_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.page_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4476,9 +4476,9 @@ pub mod system_controls {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/systemcontrols",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4577,10 +4577,10 @@ pub mod system_controls {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/systemcontrols/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.control_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.control_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4677,10 +4677,10 @@ pub mod system_controls {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/layout/systemcontrols/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.control_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.control_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4894,9 +4894,9 @@ pub mod rules {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/rules",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4994,9 +4994,9 @@ pub mod rules {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/rules",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5093,10 +5093,10 @@ pub mod rules {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/rules/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.rule_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.rule_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5195,10 +5195,10 @@ pub mod rules {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/rules/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.rule_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.rule_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5290,10 +5290,10 @@ pub mod rules {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/rules/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.rule_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.rule_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5537,9 +5537,9 @@ pub mod states {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/states",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5641,9 +5641,9 @@ pub mod states {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/states",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5744,10 +5744,10 @@ pub mod states {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/states/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.state_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.state_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5850,10 +5850,10 @@ pub mod states {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/states/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.state_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.state_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5956,10 +5956,10 @@ pub mod states {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/states/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.state_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.state_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6052,10 +6052,10 @@ pub mod states {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workItemTypes/{}/states/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name,
-                    &self.state_id
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name,
+                    self.state_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6272,9 +6272,9 @@ pub mod work_item_types_behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workitemtypesbehaviors/{}/behaviors",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name_for_behaviors
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name_for_behaviors
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6373,9 +6373,9 @@ pub mod work_item_types_behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workitemtypesbehaviors/{}/behaviors",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name_for_behaviors
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name_for_behaviors
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6473,9 +6473,9 @@ pub mod work_item_types_behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workitemtypesbehaviors/{}/behaviors",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name_for_behaviors
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name_for_behaviors
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6572,10 +6572,10 @@ pub mod work_item_types_behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workitemtypesbehaviors/{}/behaviors/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name_for_behaviors,
-                    &self.behavior_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name_for_behaviors,
+                    self.behavior_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6667,10 +6667,10 @@ pub mod work_item_types_behaviors {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/{}/workitemtypesbehaviors/{}/behaviors/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.process_id,
-                    &self.wit_ref_name_for_behaviors,
-                    &self.behavior_ref_name
+                    self.organization,
+                    self.process_id,
+                    self.wit_ref_name_for_behaviors,
+                    self.behavior_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6853,7 +6853,7 @@ pub mod lists {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/lists",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6949,7 +6949,7 @@ pub mod lists {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/lists",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7044,8 +7044,8 @@ pub mod lists {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/lists/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.list_id
+                    self.organization,
+                    self.list_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7142,8 +7142,8 @@ pub mod lists {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/lists/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.list_id
+                    self.organization,
+                    self.list_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7233,8 +7233,8 @@ pub mod lists {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/processes/lists/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.list_id
+                    self.organization,
+                    self.list_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/profile/mod.rs
+++ b/azure_devops_rust_api/src/profile/mod.rs
@@ -284,7 +284,7 @@ pub mod profiles {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/_apis/profile/profiles/{}",
                     self.client.endpoint(),
-                    &self.id
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/release/mod.rs
+++ b/azure_devops_rust_api/src/release/mod.rs
@@ -526,9 +526,9 @@ pub mod releases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/releases/{}?",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id
+                    self.organization,
+                    self.project,
+                    self.release_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -868,8 +868,8 @@ pub mod releases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/releases",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -966,8 +966,8 @@ pub mod releases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/releases",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1067,9 +1067,9 @@ pub mod releases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/releases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id
+                    self.organization,
+                    self.project,
+                    self.release_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1167,9 +1167,9 @@ pub mod releases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/releases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id
+                    self.organization,
+                    self.project,
+                    self.release_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1267,9 +1267,9 @@ pub mod releases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/releases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id
+                    self.organization,
+                    self.project,
+                    self.release_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1377,10 +1377,10 @@ pub mod releases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/Release/releases/{}/environments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id,
-                    &self.environment_id
+                    self.organization,
+                    self.project,
+                    self.release_id,
+                    self.environment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1479,10 +1479,10 @@ pub mod releases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/Release/releases/{}/environments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id,
-                    &self.environment_id
+                    self.organization,
+                    self.project,
+                    self.release_id,
+                    self.environment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1598,7 +1598,7 @@ pub mod releases {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/release/releases/{}/environments/{}/deployPhases/{}/tasks/{}/logs" , self . client . endpoint () , & self . organization , & self . project , & self . release_id , & self . environment_id , & self . release_deploy_phase_id , & self . task_id)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/release/releases/{}/environments/{}/deployPhases/{}/tasks/{}/logs" , self . client . endpoint () , self . organization , self . project , self . release_id , self . environment_id , self . release_deploy_phase_id , self . task_id)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -1691,9 +1691,9 @@ pub mod releases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/releases/{}/logs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id
+                    self.organization,
+                    self.project,
+                    self.release_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1939,8 +1939,8 @@ pub mod approvals {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/approvals",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2038,9 +2038,9 @@ pub mod approvals {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/approvals/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.approval_id
+                    self.organization,
+                    self.project,
+                    self.approval_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2456,8 +2456,8 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/definitions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2554,8 +2554,8 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/definitions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2652,8 +2652,8 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/definitions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2760,9 +2760,9 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/definitions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2875,9 +2875,9 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/definitions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2979,9 +2979,9 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/Release/definitions/{}/revisions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id
+                    self.organization,
+                    self.project,
+                    self.definition_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3077,10 +3077,10 @@ pub mod definitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/Release/definitions/{}/revisions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition_id,
-                    &self.revision
+                    self.organization,
+                    self.project,
+                    self.definition_id,
+                    self.revision
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3395,8 +3395,8 @@ pub mod deployments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/deployments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3599,9 +3599,9 @@ pub mod folders {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/folders/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3699,9 +3699,9 @@ pub mod folders {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/folders/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3799,9 +3799,9 @@ pub mod folders {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/folders/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3892,9 +3892,9 @@ pub mod folders {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/folders/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4027,9 +4027,9 @@ pub mod gates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/release/gates/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.gate_step_id
+                    self.organization,
+                    self.project,
+                    self.gate_step_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4278,7 +4278,7 @@ pub mod attachments {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/release/releases/{}/environments/{}/attempts/{}/plan/{}/attachments/{}" , self . client . endpoint () , & self . organization , & self . project , & self . release_id , & self . environment_id , & self . attempt_id , & self . plan_id , & self . type_)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/release/releases/{}/environments/{}/attempts/{}/plan/{}/attachments/{}" , self . client . endpoint () , self . organization , self . project , self . release_id , self . environment_id , self . attempt_id , self . plan_id , self . type_)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -4376,7 +4376,7 @@ pub mod attachments {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/release/releases/{}/environments/{}/attempts/{}/plan/{}/timelines/{}/records/{}/attachments/{}/{}" , self . client . endpoint () , & self . organization , & self . project , & self . release_id , & self . environment_id , & self . attempt_id , & self . plan_id , & self . timeline_id , & self . record_id , & self . type_ , & self . name)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/release/releases/{}/environments/{}/attempts/{}/plan/{}/timelines/{}/records/{}/attachments/{}/{}" , self . client . endpoint () , self . organization , self . project , self . release_id , self . environment_id , self . attempt_id , self . plan_id , self . timeline_id , self . record_id , self . type_ , self . name)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -4475,7 +4475,7 @@ pub mod attachments {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/release/releases/{}/environments/{}/attempts/{}/timelines/{}/attachments/{}" , self . client . endpoint () , & self . organization , & self . project , & self . release_id , & self . environment_id , & self . attempt_id , & self . timeline_id , & self . type_)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/release/releases/{}/environments/{}/attempts/{}/timelines/{}/attachments/{}" , self . client . endpoint () , self . organization , self . project , self . release_id , self . environment_id , self . attempt_id , self . timeline_id , self . type_)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -4572,7 +4572,7 @@ pub mod attachments {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/release/releases/{}/environments/{}/attempts/{}/timelines/{}/records/{}/attachments/{}/{}" , self . client . endpoint () , & self . organization , & self . project , & self . release_id , & self . environment_id , & self . attempt_id , & self . timeline_id , & self . record_id , & self . type_ , & self . name)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/release/releases/{}/environments/{}/attempts/{}/timelines/{}/records/{}/attachments/{}/{}" , self . client . endpoint () , self . organization , self . project , self . release_id , self . environment_id , self . attempt_id , self . timeline_id , self . record_id , self . type_ , self . name)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -4746,9 +4746,9 @@ pub mod manual_interventions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/Release/releases/{}/manualinterventions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id
+                    self.organization,
+                    self.project,
+                    self.release_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4846,10 +4846,10 @@ pub mod manual_interventions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/Release/releases/{}/manualinterventions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id,
-                    &self.manual_intervention_id
+                    self.organization,
+                    self.project,
+                    self.release_id,
+                    self.manual_intervention_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4948,10 +4948,10 @@ pub mod manual_interventions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/Release/releases/{}/manualinterventions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id,
-                    &self.manual_intervention_id
+                    self.organization,
+                    self.project,
+                    self.release_id,
+                    self.manual_intervention_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/search/mod.rs
+++ b/azure_devops_rust_api/src/search/mod.rs
@@ -262,7 +262,7 @@ pub mod package_search_results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/search/packagesearchresults",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -389,8 +389,8 @@ pub mod code_search_results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/search/codesearchresults",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -518,9 +518,9 @@ pub mod repositories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/search/status/repositories/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.repository
+                    self.organization,
+                    self.project,
+                    self.repository
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -645,8 +645,8 @@ pub mod tfvc {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/search/status/tfvc",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -773,8 +773,8 @@ pub mod wiki_search_results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/search/wikisearchresults",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -903,8 +903,8 @@ pub mod work_item_search_results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/search/workitemsearchresults",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/security/mod.rs
+++ b/azure_devops_rust_api/src/security/mod.rs
@@ -265,8 +265,8 @@ pub mod access_control_entries {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/accesscontrolentries/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.security_namespace_id
+                    self.organization,
+                    self.security_namespace_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -380,8 +380,8 @@ pub mod access_control_entries {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/accesscontrolentries/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.security_namespace_id
+                    self.organization,
+                    self.security_namespace_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -586,8 +586,8 @@ pub mod access_control_lists {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/accesscontrollists/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.security_namespace_id
+                    self.organization,
+                    self.security_namespace_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -679,8 +679,8 @@ pub mod access_control_lists {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/accesscontrollists/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.security_namespace_id
+                    self.organization,
+                    self.security_namespace_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -798,8 +798,8 @@ pub mod access_control_lists {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/accesscontrollists/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.security_namespace_id
+                    self.organization,
+                    self.security_namespace_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1002,9 +1002,9 @@ pub mod permissions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/permissions/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.security_namespace_id,
-                    &self.permissions
+                    self.organization,
+                    self.security_namespace_id,
+                    self.permissions
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1114,9 +1114,9 @@ pub mod permissions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/permissions/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.security_namespace_id,
-                    &self.permissions
+                    self.organization,
+                    self.security_namespace_id,
+                    self.permissions
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1215,7 +1215,7 @@ pub mod permissions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/security/permissionevaluationbatch",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1352,8 +1352,8 @@ pub mod security_namespaces {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/securitynamespaces/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.security_namespace_id
+                    self.organization,
+                    self.security_namespace_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/security_roles/mod.rs
+++ b/azure_devops_rust_api/src/security_roles/mod.rs
@@ -338,7 +338,7 @@ pub mod roleassignments {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/securityroles/scopes/{}/roleassignments/resources/{}?inheritPermissions={}" , self . client . endpoint () , & self . organization , & self . scope_id , & self . resource_id , & self . inherit_permissions)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/_apis/securityroles/scopes/{}/roleassignments/resources/{}?inheritPermissions={}" , self . client . endpoint () , self . organization , self . scope_id , self . resource_id , self . inherit_permissions)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -436,9 +436,9 @@ pub mod roleassignments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/securityroles/scopes/{}/roleassignments/resources/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_id,
-                    &self.resource_id
+                    self.organization,
+                    self.scope_id,
+                    self.resource_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -552,9 +552,9 @@ pub mod roleassignments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/securityroles/scopes/{}/roleassignments/resources/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_id,
-                    &self.resource_id
+                    self.organization,
+                    self.scope_id,
+                    self.resource_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -647,9 +647,9 @@ pub mod roleassignments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/securityroles/scopes/{}/roleassignments/resources/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_id,
-                    &self.resource_id
+                    self.organization,
+                    self.scope_id,
+                    self.resource_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -751,10 +751,10 @@ pub mod roleassignments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/securityroles/scopes/{}/roleassignments/resources/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_id,
-                    &self.resource_id,
-                    &self.identity_id
+                    self.organization,
+                    self.scope_id,
+                    self.resource_id,
+                    self.identity_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -846,10 +846,10 @@ pub mod roleassignments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/securityroles/scopes/{}/roleassignments/resources/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_id,
-                    &self.resource_id,
-                    &self.identity_id
+                    self.organization,
+                    self.scope_id,
+                    self.resource_id,
+                    self.identity_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -970,8 +970,8 @@ pub mod roledefinitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/securityroles/scopes/{}/roledefinitions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.scope_id
+                    self.organization,
+                    self.scope_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/service_endpoint/mod.rs
+++ b/azure_devops_rust_api/src/service_endpoint/mod.rs
@@ -275,9 +275,9 @@ pub mod endpointproxy {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/serviceendpoint/endpointproxy?endpointId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.endpoint_id
+                    self.organization,
+                    self.project,
+                    self.endpoint_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -373,8 +373,8 @@ pub mod endpointproxy {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/serviceendpoint/endpointproxy",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -735,8 +735,8 @@ pub mod endpoints {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/serviceendpoint/endpoints?",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -832,7 +832,7 @@ pub mod endpoints {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceendpoint/endpoints",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -928,7 +928,7 @@ pub mod endpoints {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceendpoint/endpoints",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1036,8 +1036,8 @@ pub mod endpoints {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceendpoint/endpoints/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.endpoint_id
+                    self.organization,
+                    self.endpoint_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1129,8 +1129,8 @@ pub mod endpoints {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceendpoint/endpoints/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.endpoint_id
+                    self.organization,
+                    self.endpoint_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1239,8 +1239,8 @@ pub mod endpoints {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceendpoint/endpoints/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.endpoint_id
+                    self.organization,
+                    self.endpoint_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1394,8 +1394,8 @@ pub mod endpoints {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/serviceendpoint/endpoints",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1497,8 +1497,8 @@ pub mod endpoints {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/serviceendpoint/endpoints",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1608,9 +1608,9 @@ pub mod endpoints {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/serviceendpoint/endpoints/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.endpoint_id
+                    self.organization,
+                    self.project,
+                    self.endpoint_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1749,7 +1749,7 @@ pub mod types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/serviceendpoint/types",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1904,9 +1904,9 @@ pub mod executionhistory {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/serviceendpoint/{}/executionhistory",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.endpoint_id
+                    self.organization,
+                    self.project,
+                    self.endpoint_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/symbol/mod.rs
+++ b/azure_devops_rust_api/src/symbol/mod.rs
@@ -402,9 +402,9 @@ pub mod requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/requests?requestName={}&collection={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.request_name,
-                    &self.collection
+                    self.organization,
+                    self.request_name,
+                    self.collection
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -503,7 +503,7 @@ pub mod requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/requests",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -599,7 +599,7 @@ pub mod requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/requests",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -700,7 +700,7 @@ pub mod requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/requests",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -805,7 +805,7 @@ pub mod requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/requests",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -903,8 +903,8 @@ pub mod requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/requests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.request_id
+                    self.organization,
+                    self.request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1006,8 +1006,8 @@ pub mod requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/requests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.request_id
+                    self.organization,
+                    self.request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1104,8 +1104,8 @@ pub mod requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/requests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.request_id
+                    self.organization,
+                    self.request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1206,8 +1206,8 @@ pub mod requests {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/requests/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.request_id
+                    self.organization,
+                    self.request_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1322,7 +1322,7 @@ pub mod availability {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/availability",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1450,7 +1450,7 @@ pub mod client {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/client",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1546,8 +1546,8 @@ pub mod client {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/client/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.client_type
+                    self.organization,
+                    self.client_type
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1667,9 +1667,9 @@ pub mod contents {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/requests/{}/contents/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.request_id,
-                    &self.debug_entry_id
+                    self.organization,
+                    self.request_id,
+                    self.debug_entry_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1788,8 +1788,8 @@ pub mod symsrv {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/symbol/symsrv/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.debug_entry_client_key
+                    self.organization,
+                    self.debug_entry_client_key
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/test/mod.rs
+++ b/azure_devops_rust_api/src/test/mod.rs
@@ -575,10 +575,10 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/runs?minLastUpdatedDate={}&maxLastUpdatedDate={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.min_last_updated_date,
-                    &self.max_last_updated_date
+                    self.organization,
+                    self.project,
+                    self.min_last_updated_date,
+                    self.max_last_updated_date
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -758,8 +758,8 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/runs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -856,8 +856,8 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/runs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -964,9 +964,9 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/runs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1064,9 +1064,9 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/runs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1157,9 +1157,9 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/runs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1258,9 +1258,9 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/runs/{}/Statistics",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1588,11 +1588,11 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/Results/{}/attachments?testSubResultId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.test_sub_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.test_sub_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1699,11 +1699,11 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/Results/{}/attachments?testSubResultId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.test_sub_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.test_sub_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1805,12 +1805,12 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/Results/{}/attachments/{}?testSubResultId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.attachment_id,
-                    &self.test_sub_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.attachment_id,
+                    self.test_sub_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1906,9 +1906,9 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2009,9 +2009,9 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2107,10 +2107,10 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.attachment_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.attachment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2207,10 +2207,10 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/Results/{}/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2312,10 +2312,10 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/Results/{}/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2412,11 +2412,11 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/Results/{}/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.attachment_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.attachment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2575,8 +2575,8 @@ pub mod code_coverage {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/codecoverage",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2677,9 +2677,9 @@ pub mod code_coverage {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/codecoverage",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2968,10 +2968,10 @@ pub mod points {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Plans/{}/Suites/{}/points",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3080,11 +3080,11 @@ pub mod points {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Plans/{}/Suites/{}/points/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id,
-                    &self.point_ids
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id,
+                    self.point_ids
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3184,11 +3184,11 @@ pub mod points {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Plans/{}/Suites/{}/points/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id,
-                    &self.point_ids
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id,
+                    self.point_ids
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3307,8 +3307,8 @@ pub mod points {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/points",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3540,10 +3540,10 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Plans/{}/suites/{}/testcases",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3641,11 +3641,11 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Plans/{}/suites/{}/testcases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id,
-                    &self.test_case_ids
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id,
+                    self.test_case_ids
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3744,11 +3744,11 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Plans/{}/suites/{}/testcases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id,
-                    &self.test_case_ids
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id,
+                    self.test_case_ids
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3848,11 +3848,11 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Plans/{}/suites/{}/testcases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id,
-                    &self.test_case_ids
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id,
+                    self.test_case_ids
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3945,11 +3945,11 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Plans/{}/suites/{}/testcases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id,
-                    &self.test_case_ids
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id,
+                    self.test_case_ids
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4095,8 +4095,8 @@ pub mod result_retention_settings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/resultretentionsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4197,8 +4197,8 @@ pub mod result_retention_settings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/resultretentionsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4325,8 +4325,8 @@ pub mod test_history {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Results/testhistory",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4569,9 +4569,9 @@ pub mod results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/results",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4669,9 +4669,9 @@ pub mod results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/results",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4769,9 +4769,9 @@ pub mod results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/results",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4882,10 +4882,10 @@ pub mod results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/results/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5056,10 +5056,10 @@ pub mod iterations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/Results/{}/iterations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5173,11 +5173,11 @@ pub mod iterations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/Runs/{}/Results/{}/iterations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5298,9 +5298,9 @@ pub mod test_cases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/test/testcases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.test_case_id
+                    self.organization,
+                    self.project,
+                    self.test_case_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5539,9 +5539,9 @@ pub mod session {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/test/session",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5639,9 +5639,9 @@ pub mod session {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/test/session",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5739,9 +5739,9 @@ pub mod session {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/test/session",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/test_plan/mod.rs
+++ b/azure_devops_rust_api/src/test_plan/mod.rs
@@ -404,11 +404,11 @@ pub mod suite_test_case {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/Suites/{}/TestCase?testCaseIds={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id,
-                    &self.test_case_ids
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id,
+                    self.test_case_ids
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -595,10 +595,10 @@ pub mod suite_test_case {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/Suites/{}/TestCase",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -697,10 +697,10 @@ pub mod suite_test_case {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/Suites/{}/TestCase",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -799,10 +799,10 @@ pub mod suite_test_case {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/Suites/{}/TestCase",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -899,10 +899,10 @@ pub mod suite_test_case {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/Suites/{}/TestCase",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1025,11 +1025,11 @@ pub mod suite_test_case {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/Suites/{}/TestCase/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id,
-                    &self.test_case_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id,
+                    self.test_case_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1285,10 +1285,10 @@ pub mod test_point {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/Suites/{}/TestPoint?",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1413,10 +1413,10 @@ pub mod test_point {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/Suites/{}/TestPoint",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1538,10 +1538,10 @@ pub mod test_point {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/Suites/{}/TestPoint",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1780,7 +1780,7 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/testplan/suites",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1909,9 +1909,9 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/suites",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id
+                    self.organization,
+                    self.project,
+                    self.plan_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2009,9 +2009,9 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/suites",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id
+                    self.organization,
+                    self.project,
+                    self.plan_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2119,10 +2119,10 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/suites/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2221,10 +2221,10 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/suites/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2316,10 +2316,10 @@ pub mod test_suites {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/{}/suites/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.plan_id,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2534,8 +2534,8 @@ pub mod configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/configurations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2632,8 +2632,8 @@ pub mod configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/configurations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2735,8 +2735,8 @@ pub mod configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/configurations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2831,8 +2831,8 @@ pub mod configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/configurations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2931,9 +2931,9 @@ pub mod configurations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/configurations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.test_configuration_id
+                    self.organization,
+                    self.project,
+                    self.test_configuration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3180,8 +3180,8 @@ pub mod test_plans {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/plans",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3278,8 +3278,8 @@ pub mod test_plans {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/plans",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3375,9 +3375,9 @@ pub mod test_plans {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/plans/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id
+                    self.organization,
+                    self.project,
+                    self.plan_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3475,9 +3475,9 @@ pub mod test_plans {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/plans/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id
+                    self.organization,
+                    self.project,
+                    self.plan_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3568,9 +3568,9 @@ pub mod test_plans {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/plans/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.plan_id
+                    self.organization,
+                    self.project,
+                    self.plan_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3735,8 +3735,8 @@ pub mod test_plan_clone {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/CloneOperation",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3838,9 +3838,9 @@ pub mod test_plan_clone {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Plans/CloneOperation/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.clone_operation_id
+                    self.organization,
+                    self.project,
+                    self.clone_operation_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4002,9 +4002,9 @@ pub mod test_suite_entry {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/suiteentry/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4102,9 +4102,9 @@ pub mod test_suite_entry {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/suiteentry/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.suite_id
+                    self.organization,
+                    self.project,
+                    self.suite_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4266,8 +4266,8 @@ pub mod test_suite_clone {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Suites/CloneOperation",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4369,9 +4369,9 @@ pub mod test_suite_clone {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/Suites/CloneOperation/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.clone_operation_id
+                    self.organization,
+                    self.project,
+                    self.clone_operation_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4492,9 +4492,9 @@ pub mod test_cases {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/testcases/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.test_case_id
+                    self.organization,
+                    self.project,
+                    self.test_case_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4644,8 +4644,8 @@ pub mod test_case_clone {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/TestCases/CloneTestCaseOperation",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4747,9 +4747,9 @@ pub mod test_case_clone {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/TestCases/CloneTestCaseOperation/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.clone_operation_id
+                    self.organization,
+                    self.project,
+                    self.clone_operation_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4962,8 +4962,8 @@ pub mod variables {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/variables",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5060,8 +5060,8 @@ pub mod variables {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/variables",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5157,9 +5157,9 @@ pub mod variables {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/variables/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.test_variable_id
+                    self.organization,
+                    self.project,
+                    self.test_variable_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5257,9 +5257,9 @@ pub mod variables {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/variables/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.test_variable_id
+                    self.organization,
+                    self.project,
+                    self.test_variable_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5350,9 +5350,9 @@ pub mod variables {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testplan/variables/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.test_variable_id
+                    self.organization,
+                    self.project,
+                    self.test_variable_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/test_results/mod.rs
+++ b/azure_devops_rust_api/src/test_results/mod.rs
@@ -411,10 +411,10 @@ pub mod codecoverage {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/codecoverage?buildId={}&flags={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id,
-                    &self.flags
+                    self.organization,
+                    self.project,
+                    self.build_id,
+                    self.flags
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -524,8 +524,8 @@ pub mod codecoverage {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/codecoverage",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -630,8 +630,8 @@ pub mod codecoverage {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/codecoverage",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -735,9 +735,9 @@ pub mod codecoverage {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/codecoverage",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1139,10 +1139,10 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs?minLastUpdatedDate={}&maxLastUpdatedDate={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.min_last_updated_date,
-                    &self.max_last_updated_date
+                    self.organization,
+                    self.project,
+                    self.min_last_updated_date,
+                    self.max_last_updated_date
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1315,8 +1315,8 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1413,8 +1413,8 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1530,9 +1530,9 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1630,9 +1630,9 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1723,9 +1723,9 @@ pub mod runs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2015,12 +2015,12 @@ pub mod testlog {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/testlog?subResultId={}&type={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.result_id,
-                    &self.sub_result_id,
-                    &self.type_
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.result_id,
+                    self.sub_result_id,
+                    self.type_
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2175,10 +2175,10 @@ pub mod testlog {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/testlog",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2332,9 +2332,9 @@ pub mod testlog {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/testlog",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2492,8 +2492,8 @@ pub mod testlog {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testlog",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2801,7 +2801,7 @@ pub mod testlogstoreendpoint {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/testresults/runs/{}/results/{}/testlogstoreendpoint?subResultId={}&type={}&filePath={}" , self . client . endpoint () , & self . organization , & self . project , & self . run_id , & self . result_id , & self . sub_result_id , & self . type_ , & self . file_path)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/testresults/runs/{}/results/{}/testlogstoreendpoint?subResultId={}&type={}&filePath={}" , self . client . endpoint () , self . organization , self . project , self . run_id , self . result_id , self . sub_result_id , self . type_ , self . file_path)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -2911,10 +2911,10 @@ pub mod testlogstoreendpoint {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/testlogstoreendpoint",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3031,10 +3031,10 @@ pub mod testlogstoreendpoint {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/testlogstoreendpoint",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3144,9 +3144,9 @@ pub mod testlogstoreendpoint {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/testlogstoreendpoint",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3275,9 +3275,9 @@ pub mod testlogstoreendpoint {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/testlogstoreendpoint",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3391,8 +3391,8 @@ pub mod testlogstoreendpoint {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testlogstoreendpoint",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3503,8 +3503,8 @@ pub mod testlogstoreendpoint {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testlogstoreendpoint",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3884,11 +3884,11 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/attachments?testSubResultId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.test_sub_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.test_sub_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3995,11 +3995,11 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/attachments?testSubResultId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.test_sub_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.test_sub_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4117,11 +4117,11 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/attachments?iterationId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4220,7 +4220,7 @@ pub mod attachments {
                 })
             }
             fn url(&self) -> azure_core::Result<azure_core::http::Url> {
-                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/testresults/runs/{}/results/{}/attachments/{}?testSubResultId={}" , self . client . endpoint () , & self . organization , & self . project , & self . run_id , & self . test_case_result_id , & self . attachment_id , & self . test_sub_result_id)) ? ;
+                let mut url = azure_core :: http :: Url :: parse (& format ! ("{}/{}/{}/_apis/testresults/runs/{}/results/{}/attachments/{}?testSubResultId={}" , self . client . endpoint () , self . organization , self . project , self . run_id , self . test_case_result_id , self . attachment_id , self . test_sub_result_id)) ? ;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
                     url.query_pairs_mut()
@@ -4320,12 +4320,12 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/attachments/{}?iterationId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.attachment_id,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.attachment_id,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4421,9 +4421,9 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4524,9 +4524,9 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4622,10 +4622,10 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.attachment_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.attachment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4717,10 +4717,10 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.attachment_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.attachment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4820,10 +4820,10 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4925,10 +4925,10 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5025,11 +5025,11 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.attachment_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.attachment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5122,11 +5122,11 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id,
-                    &self.attachment_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id,
+                    self.attachment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5345,10 +5345,10 @@ pub mod testattachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/testattachments?filename={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.filename
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.filename
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5447,9 +5447,9 @@ pub mod testattachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/testattachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5551,9 +5551,9 @@ pub mod testattachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/testattachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5650,9 +5650,9 @@ pub mod testattachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/testattachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5748,9 +5748,9 @@ pub mod testattachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/uploadbuildattachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.build_id
+                    self.organization,
+                    self.project,
+                    self.build_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5920,10 +5920,10 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/tags?releaseId={}&releaseEnvId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id,
-                    &self.release_env_id
+                    self.organization,
+                    self.project,
+                    self.release_id,
+                    self.release_env_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6021,9 +6021,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/tags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6123,8 +6123,8 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/tags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6273,10 +6273,10 @@ pub mod tagsummary {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/tagsummary?releaseId={}&releaseEnvId={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.release_id,
-                    &self.release_env_id
+                    self.organization,
+                    self.project,
+                    self.release_id,
+                    self.release_env_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6376,8 +6376,8 @@ pub mod tagsummary {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/tagsummary",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6580,9 +6580,9 @@ pub mod workitems {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testmethods/workitems?testName={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.test_name
+                    self.organization,
+                    self.project,
+                    self.test_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6737,8 +6737,8 @@ pub mod workitems {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/results/workitems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6835,10 +6835,10 @@ pub mod workitems {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/workitems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6935,8 +6935,8 @@ pub mod workitems {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testmethods/workitems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7039,8 +7039,8 @@ pub mod workitems {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testmethods/workitems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7164,8 +7164,8 @@ pub mod filecoverage {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/codecoverage/filecoverage",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7310,9 +7310,9 @@ pub mod status {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/codecoverage/status/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.definition
+                    self.organization,
+                    self.project,
+                    self.definition
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7500,8 +7500,8 @@ pub mod metrics {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/metrics",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7700,8 +7700,8 @@ pub mod resultdetailsbybuild {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultdetailsbybuild",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7907,8 +7907,8 @@ pub mod resultdetailsbyrelease {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultdetailsbyrelease",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8066,8 +8066,8 @@ pub mod resultgroupsbybuild {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultgroupsbybuild",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8237,8 +8237,8 @@ pub mod resultgroupsbyrelease {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultgroupsbyrelease",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8458,8 +8458,8 @@ pub mod results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/results",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8598,8 +8598,8 @@ pub mod results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/results/query",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8748,9 +8748,9 @@ pub mod results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8848,9 +8848,9 @@ pub mod results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8948,9 +8948,9 @@ pub mod results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9060,10 +9060,10 @@ pub mod results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9186,8 +9186,8 @@ pub mod history {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/results/history",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9353,8 +9353,8 @@ pub mod result_meta_data {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/results/resultmetadata",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9453,9 +9453,9 @@ pub mod result_meta_data {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/results/resultmetadata/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.test_case_reference_id
+                    self.organization,
+                    self.project,
+                    self.test_case_reference_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9581,8 +9581,8 @@ pub mod test_history {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/results/testhistory",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9755,8 +9755,8 @@ pub mod resultsbybuild {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultsbybuild",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9959,8 +9959,8 @@ pub mod resultsbypipeline {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultsbypipeline",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10145,8 +10145,8 @@ pub mod resultsbyrelease {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultsbyrelease",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10350,8 +10350,8 @@ pub mod resultsgroup_details {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultsgroupdetails",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10611,8 +10611,8 @@ pub mod resultsummarybybuild {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultsummarybybuild",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10790,8 +10790,8 @@ pub mod resultsummarybypipeline {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultsummarybypipeline",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11140,8 +11140,8 @@ pub mod resultsummarybyrelease {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultsummarybyrelease",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11238,8 +11238,8 @@ pub mod resultsummarybyrelease {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultsummarybyrelease",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11376,8 +11376,8 @@ pub mod resultsummarybyrequirement {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resultsummarybyrequirement",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11504,8 +11504,8 @@ pub mod result_trend_by_build {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resulttrendbybuild",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11632,8 +11632,8 @@ pub mod result_trend_by_release {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/resulttrendbyrelease",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11762,9 +11762,9 @@ pub mod message_logs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/messagelogs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11891,9 +11891,9 @@ pub mod result_document {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/resultdocument",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12018,10 +12018,10 @@ pub mod bugs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/bugs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_case_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_case_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12180,10 +12180,10 @@ pub mod similar_test_results {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/results/{}/similartestresults",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id,
-                    &self.test_result_id
+                    self.organization,
+                    self.project,
+                    self.run_id,
+                    self.test_result_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12308,9 +12308,9 @@ pub mod runsummary {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/runsummary",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12435,9 +12435,9 @@ pub mod statistics {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/runs/{}/statistics",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.run_id
+                    self.organization,
+                    self.project,
+                    self.run_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12590,8 +12590,8 @@ pub mod settings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/settings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12688,8 +12688,8 @@ pub mod settings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/settings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12849,8 +12849,8 @@ pub mod testfailuretype {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testfailuretype",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -12948,8 +12948,8 @@ pub mod testfailuretype {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testfailuretype",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -13040,9 +13040,9 @@ pub mod testfailuretype {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testfailuretype/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.failure_type_id
+                    self.organization,
+                    self.project,
+                    self.failure_type_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -13203,8 +13203,8 @@ pub mod testsettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -13299,8 +13299,8 @@ pub mod testsettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -13395,8 +13395,8 @@ pub mod testsettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/testresults/testsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/tfvc/mod.rs
+++ b/azure_devops_rust_api/src/tfvc/mod.rs
@@ -426,7 +426,7 @@ pub mod shelvesets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tfvc/shelvesets?",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -627,7 +627,7 @@ pub mod shelvesets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tfvc/shelvesets",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -748,7 +748,7 @@ pub mod shelvesets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tfvc/shelvesets/changes",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -850,7 +850,7 @@ pub mod shelvesets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tfvc/shelvesets/workitems",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1043,9 +1043,9 @@ pub mod branches {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/branches?path={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1184,8 +1184,8 @@ pub mod branches {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/branches?",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1307,8 +1307,8 @@ pub mod branches {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/branches",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1591,9 +1591,9 @@ pub mod items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/items?path={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1688,8 +1688,8 @@ pub mod items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/itembatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1868,8 +1868,8 @@ pub mod items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/items",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2141,8 +2141,8 @@ pub mod changesets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tfvc/changesets/{}/changes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.id
+                    self.organization,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2240,8 +2240,8 @@ pub mod changesets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tfvc/changesets/{}/workItems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.id
+                    self.organization,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2338,7 +2338,7 @@ pub mod changesets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tfvc/changesetsbatch",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2600,8 +2600,8 @@ pub mod changesets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/changesets",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2698,8 +2698,8 @@ pub mod changesets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/changesets",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3007,9 +3007,9 @@ pub mod changesets {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/changesets/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3203,8 +3203,8 @@ pub mod labels {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tfvc/labels/{}/items",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.label_id
+                    self.organization,
+                    self.label_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3399,8 +3399,8 @@ pub mod labels {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/labels",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3574,9 +3574,9 @@ pub mod labels {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/tfvc/labels/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.label_id
+                    self.organization,
+                    self.project,
+                    self.label_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/token_admin/mod.rs
+++ b/azure_devops_rust_api/src/token_admin/mod.rs
@@ -276,8 +276,8 @@ pub mod personal_access_tokens {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tokenadmin/personalaccesstokens/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.subject_descriptor
+                    self.organization,
+                    self.subject_descriptor
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -395,7 +395,7 @@ pub mod revocation_rules {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tokenadmin/revocationrules",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -527,7 +527,7 @@ pub mod revocations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tokenadmin/revocations",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/tokens/mod.rs
+++ b/azure_devops_rust_api/src/tokens/mod.rs
@@ -353,7 +353,7 @@ pub mod pats {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tokens/pats?",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -452,7 +452,7 @@ pub mod pats {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tokens/pats",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -548,7 +548,7 @@ pub mod pats {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tokens/pats",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -644,7 +644,7 @@ pub mod pats {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tokens/pats",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -738,7 +738,7 @@ pub mod pats {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/tokens/pats",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/wiki/mod.rs
+++ b/azure_devops_rust_api/src/wiki/mod.rs
@@ -325,8 +325,8 @@ pub mod wikis {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -423,8 +423,8 @@ pub mod wikis {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -520,9 +520,9 @@ pub mod wikis {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -620,9 +620,9 @@ pub mod wikis {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -718,9 +718,9 @@ pub mod wikis {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -919,9 +919,9 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1126,9 +1126,9 @@ pub mod page_moves {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}/pagemoves",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1487,9 +1487,9 @@ pub mod pages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}/pages",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1663,9 +1663,9 @@ pub mod pages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}/pages",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1835,9 +1835,9 @@ pub mod pages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}/pages",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1969,10 +1969,10 @@ pub mod pages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}/pages/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2094,10 +2094,10 @@ pub mod pages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}/pages/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2215,10 +2215,10 @@ pub mod pages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}/pages/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2359,10 +2359,10 @@ pub mod page_stats {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}/pages/{}/stats",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier,
-                    &self.page_id
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier,
+                    self.page_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2545,9 +2545,9 @@ pub mod pages_batch {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wiki/wikis/{}/pagesbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.wiki_identifier
+                    self.organization,
+                    self.project,
+                    self.wiki_identifier
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/wit/mod.rs
+++ b/azure_devops_rust_api/src/wit/mod.rs
@@ -476,9 +476,9 @@ pub mod classification_nodes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/classificationnodes?ids={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.ids
+                    self.organization,
+                    self.project,
+                    self.ids
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -588,8 +588,8 @@ pub mod classification_nodes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/classificationnodes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -701,10 +701,10 @@ pub mod classification_nodes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/classificationnodes/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.structure_group,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.structure_group,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -807,10 +807,10 @@ pub mod classification_nodes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/classificationnodes/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.structure_group,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.structure_group,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -913,10 +913,10 @@ pub mod classification_nodes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/classificationnodes/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.structure_group,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.structure_group,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1020,10 +1020,10 @@ pub mod classification_nodes {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/classificationnodes/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.structure_group,
-                    &self.path
+                    self.organization,
+                    self.project,
+                    self.structure_group,
+                    self.path
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1318,9 +1318,9 @@ pub mod queries {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/queries?$filter={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.filter
+                    self.organization,
+                    self.project,
+                    self.filter
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1452,8 +1452,8 @@ pub mod queries {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/queries",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1594,9 +1594,9 @@ pub mod queries {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/queries/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.query
+                    self.organization,
+                    self.project,
+                    self.query
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1705,9 +1705,9 @@ pub mod queries {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/queries/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.query
+                    self.organization,
+                    self.project,
+                    self.query
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1817,9 +1817,9 @@ pub mod queries {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/queries/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.query
+                    self.organization,
+                    self.project,
+                    self.query
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1910,9 +1910,9 @@ pub mod queries {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/queries/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.query
+                    self.organization,
+                    self.project,
+                    self.query
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2015,8 +2015,8 @@ pub mod queries {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/queriesbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2223,9 +2223,9 @@ pub mod recyclebin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/recyclebin?ids={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.ids
+                    self.organization,
+                    self.project,
+                    self.ids
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2326,8 +2326,8 @@ pub mod recyclebin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/recyclebin",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2424,9 +2424,9 @@ pub mod recyclebin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/recyclebin/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2524,9 +2524,9 @@ pub mod recyclebin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/recyclebin/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2617,9 +2617,9 @@ pub mod recyclebin {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/recyclebin/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2926,10 +2926,10 @@ pub mod comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments?format={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.format
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.format
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3080,9 +3080,9 @@ pub mod comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments?",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id
+                    self.organization,
+                    self.project,
+                    self.work_item_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3186,11 +3186,11 @@ pub mod comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments/{}?format={}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.comment_id,
-                    &self.format
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.comment_id,
+                    self.format
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3311,9 +3311,9 @@ pub mod comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id
+                    self.organization,
+                    self.project,
+                    self.work_item_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3411,9 +3411,9 @@ pub mod comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id
+                    self.organization,
+                    self.project,
+                    self.work_item_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3532,10 +3532,10 @@ pub mod comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.comment_id
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.comment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3634,10 +3634,10 @@ pub mod comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.comment_id
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.comment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3729,10 +3729,10 @@ pub mod comments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.comment_id
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.comment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3849,7 +3849,7 @@ pub mod artifact_link_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/wit/artifactlinktypes",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3981,7 +3981,7 @@ pub mod work_item_icons {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/wit/workitemicons",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4096,8 +4096,8 @@ pub mod work_item_icons {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/wit/workitemicons/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.icon
+                    self.organization,
+                    self.icon
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4230,7 +4230,7 @@ pub mod work_item_relation_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/wit/workitemrelationtypes",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4326,8 +4326,8 @@ pub mod work_item_relation_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/wit/workitemrelationtypes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.relation
+                    self.organization,
+                    self.relation
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4467,7 +4467,7 @@ pub mod work_item_transitions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/wit/workitemtransitions",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4587,7 +4587,7 @@ pub mod account_my_work_recent_activity {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/_apis/work/accountmyworkrecentactivity",
                     self.client.endpoint(),
-                    &self.organization
+                    self.organization
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4719,8 +4719,8 @@ pub mod artifact_uri_query {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/artifacturiquery",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4930,8 +4930,8 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/attachments",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5047,9 +5047,9 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5159,9 +5159,9 @@ pub mod attachments {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/attachments/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5373,8 +5373,8 @@ pub mod fields {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/fields",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5471,8 +5471,8 @@ pub mod fields {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/fields",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5568,9 +5568,9 @@ pub mod fields {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/fields/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.field_name_or_ref_name
+                    self.organization,
+                    self.project,
+                    self.field_name_or_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5668,9 +5668,9 @@ pub mod fields {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/fields/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.field_name_or_ref_name
+                    self.organization,
+                    self.project,
+                    self.field_name_or_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5761,9 +5761,9 @@ pub mod fields {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/fields/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.field_name_or_ref_name
+                    self.organization,
+                    self.project,
+                    self.field_name_or_ref_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5894,8 +5894,8 @@ pub mod project_process_migration {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/projectprocessmigration",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6071,8 +6071,8 @@ pub mod reporting_work_item_links {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/reporting/workitemlinks",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6361,8 +6361,8 @@ pub mod reporting_work_item_revisions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/reporting/workitemrevisions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6500,8 +6500,8 @@ pub mod reporting_work_item_revisions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/reporting/workitemrevisions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6646,8 +6646,8 @@ pub mod work_item_revisions_discussions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/reporting/workItemRevisions/discussions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6768,8 +6768,8 @@ pub mod send_mail {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/sendmail",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6955,8 +6955,8 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/tags",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7053,9 +7053,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/tags/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.tag_id_or_name
+                    self.organization,
+                    self.project,
+                    self.tag_id_or_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7153,9 +7153,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/tags/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.tag_id_or_name
+                    self.organization,
+                    self.project,
+                    self.tag_id_or_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7246,9 +7246,9 @@ pub mod tags {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/tags/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.tag_id_or_name
+                    self.organization,
+                    self.project,
+                    self.tag_id_or_name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7380,8 +7380,8 @@ pub mod temp_queries {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/tempqueries",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7713,8 +7713,8 @@ pub mod work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7844,9 +7844,9 @@ pub mod work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitems/${}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.type_
+                    self.organization,
+                    self.project,
+                    self.type_
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7989,9 +7989,9 @@ pub mod work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitems/${}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.type_
+                    self.organization,
+                    self.project,
+                    self.type_
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8121,9 +8121,9 @@ pub mod work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitems/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8266,9 +8266,9 @@ pub mod work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitems/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8375,9 +8375,9 @@ pub mod work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitems/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8474,8 +8474,8 @@ pub mod work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitemsbatch",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8572,8 +8572,8 @@ pub mod work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitemsdelete",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8751,9 +8751,9 @@ pub mod revisions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/revisions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -8860,10 +8860,10 @@ pub mod revisions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/revisions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id,
-                    &self.revision_number
+                    self.organization,
+                    self.project,
+                    self.id,
+                    self.revision_number
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9029,9 +9029,9 @@ pub mod updates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/updates",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9128,10 +9128,10 @@ pub mod updates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/updates/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id,
-                    &self.update_number
+                    self.organization,
+                    self.project,
+                    self.id,
+                    self.update_number
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9310,10 +9310,10 @@ pub mod comments_reactions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments/{}/reactions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.comment_id
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.comment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9411,11 +9411,11 @@ pub mod comments_reactions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments/{}/reactions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.comment_id,
-                    &self.reaction_type
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.comment_id,
+                    self.reaction_type
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9513,11 +9513,11 @@ pub mod comments_reactions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments/{}/reactions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.comment_id,
-                    &self.reaction_type
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.comment_id,
+                    self.reaction_type
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9672,11 +9672,11 @@ pub mod comment_reactions_engaged_users {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments/{}/reactions/{}/users",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.comment_id,
-                    &self.reaction_type
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.comment_id,
+                    self.reaction_type
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9821,10 +9821,10 @@ pub mod comments_versions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments/{}/versions",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.comment_id
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.comment_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -9922,11 +9922,11 @@ pub mod comments_versions {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workItems/{}/comments/{}/versions/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.work_item_id,
-                    &self.comment_id,
-                    &self.version
+                    self.organization,
+                    self.project,
+                    self.work_item_id,
+                    self.comment_id,
+                    self.version
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10069,8 +10069,8 @@ pub mod work_item_type_categories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitemtypecategories",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10167,9 +10167,9 @@ pub mod work_item_type_categories {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitemtypecategories/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.category
+                    self.organization,
+                    self.project,
+                    self.category
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10309,8 +10309,8 @@ pub mod work_item_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitemtypes",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10406,9 +10406,9 @@ pub mod work_item_types {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitemtypes/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.type_
+                    self.organization,
+                    self.project,
+                    self.type_
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10575,9 +10575,9 @@ pub mod work_item_types_field {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitemtypes/{}/fields",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.type_
+                    self.organization,
+                    self.project,
+                    self.type_
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10692,10 +10692,10 @@ pub mod work_item_types_field {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitemtypes/{}/fields/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.type_,
-                    &self.field
+                    self.organization,
+                    self.project,
+                    self.type_,
+                    self.field
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -10824,9 +10824,9 @@ pub mod work_item_type_states {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/wit/workitemtypes/{}/states",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.type_
+                    self.organization,
+                    self.project,
+                    self.type_
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11058,9 +11058,9 @@ pub mod templates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/wit/templates",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11159,9 +11159,9 @@ pub mod templates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/wit/templates",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11258,10 +11258,10 @@ pub mod templates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/wit/templates/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.template_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.template_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11360,10 +11360,10 @@ pub mod templates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/wit/templates/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.template_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.template_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11455,10 +11455,10 @@ pub mod templates {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/wit/templates/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.template_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.template_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11663,9 +11663,9 @@ pub mod wiql {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/wit/wiql",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11784,10 +11784,10 @@ pub mod wiql {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/wit/wiql/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -11904,10 +11904,10 @@ pub mod wiql {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/wit/wiql/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {

--- a/azure_devops_rust_api/src/work/mod.rs
+++ b/azure_devops_rust_api/src/work/mod.rs
@@ -306,8 +306,8 @@ pub mod boardcolumns {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/work/boardcolumns",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -432,8 +432,8 @@ pub mod boardrows {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/work/boardrows",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -559,9 +559,9 @@ pub mod iterationcapacities {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/work/iterations/{}/iterationcapacities",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -761,8 +761,8 @@ pub mod plans {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/work/plans",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -857,8 +857,8 @@ pub mod plans {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/work/plans",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -952,9 +952,9 @@ pub mod plans {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/work/plans/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1050,9 +1050,9 @@ pub mod plans {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/work/plans/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1143,9 +1143,9 @@ pub mod plans {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/work/plans/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1312,9 +1312,9 @@ pub mod deliverytimeline {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/work/plans/{}/deliverytimeline",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1435,8 +1435,8 @@ pub mod processconfiguration {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/_apis/work/processconfiguration",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project
+                    self.organization,
+                    self.project
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1561,9 +1561,9 @@ pub mod backlogconfiguration {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/backlogconfiguration",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1734,9 +1734,9 @@ pub mod backlogs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/backlogs",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1834,10 +1834,10 @@ pub mod backlogs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/backlogs/{}/workItems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.backlog_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.backlog_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -1937,10 +1937,10 @@ pub mod backlogs {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/backlogs/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2113,9 +2113,9 @@ pub mod boards {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2212,10 +2212,10 @@ pub mod boards {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2314,10 +2314,10 @@ pub mod boards {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2469,10 +2469,10 @@ pub mod boardusersettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/boardusersettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2571,10 +2571,10 @@ pub mod boardusersettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/boardusersettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2746,10 +2746,10 @@ pub mod cardrulesettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/cardrulesettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2848,10 +2848,10 @@ pub mod cardrulesettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/cardrulesettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -2944,9 +2944,9 @@ pub mod cardrulesettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/taskboard/cardrulesettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3121,10 +3121,10 @@ pub mod cardsettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/cardsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3223,10 +3223,10 @@ pub mod cardsettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/cardsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3319,9 +3319,9 @@ pub mod cardsettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/taskboard/cardsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3557,11 +3557,11 @@ pub mod chartimages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/chartimages/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board,
-                    &self.name
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board,
+                    self.name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3699,11 +3699,11 @@ pub mod chartimages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/iterations/{}/chartimages/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id,
-                    &self.name
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id,
+                    self.name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -3851,10 +3851,10 @@ pub mod chartimages {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/iterations/chartimages/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.name
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4038,10 +4038,10 @@ pub mod charts {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/charts",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4140,11 +4140,11 @@ pub mod charts {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/charts/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board,
-                    &self.name
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board,
+                    self.name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4244,11 +4244,11 @@ pub mod charts {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/charts/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board,
-                    &self.name
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board,
+                    self.name
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4402,10 +4402,10 @@ pub mod columns {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/columns",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4504,10 +4504,10 @@ pub mod columns {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/columns",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4661,10 +4661,10 @@ pub mod rows {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/rows",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4763,10 +4763,10 @@ pub mod rows {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/{}/rows",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.board
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.board
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -4908,9 +4908,9 @@ pub mod boardparents {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/boards/boardparents",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5064,10 +5064,10 @@ pub mod workitemsorder {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/iterations/{}/workitemsorder",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5165,9 +5165,9 @@ pub mod workitemsorder {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/workitemsorder",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5309,9 +5309,9 @@ pub mod taskboard_columns {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/taskboardcolumns",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5409,9 +5409,9 @@ pub mod taskboard_columns {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/taskboardcolumns",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5563,10 +5563,10 @@ pub mod taskboard_work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/taskboardworkitems/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5662,11 +5662,11 @@ pub mod taskboard_work_items {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/taskboardworkitems/{}/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id,
-                    &self.work_item_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id,
+                    self.work_item_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5816,9 +5816,9 @@ pub mod teamsettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -5916,9 +5916,9 @@ pub mod teamsettings {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6146,9 +6146,9 @@ pub mod iterations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6247,9 +6247,9 @@ pub mod iterations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6346,10 +6346,10 @@ pub mod iterations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6441,10 +6441,10 @@ pub mod iterations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6544,10 +6544,10 @@ pub mod iterations {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations/{}/workitems",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6754,10 +6754,10 @@ pub mod capacities {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations/{}/capacities",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6861,10 +6861,10 @@ pub mod capacities {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations/{}/capacities",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -6966,11 +6966,11 @@ pub mod capacities {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations/{}/capacities/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id,
-                    &self.team_member_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id,
+                    self.team_member_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7074,11 +7074,11 @@ pub mod capacities {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations/{}/capacities/{}",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id,
-                    &self.team_member_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id,
+                    self.team_member_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7233,10 +7233,10 @@ pub mod teamdaysoff {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations/{}/teamdaysoff",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7335,10 +7335,10 @@ pub mod teamdaysoff {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/iterations/{}/teamdaysoff",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team,
-                    &self.iteration_id
+                    self.organization,
+                    self.project,
+                    self.team,
+                    self.iteration_id
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7484,9 +7484,9 @@ pub mod teamfieldvalues {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/teamfieldvalues",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {
@@ -7584,9 +7584,9 @@ pub mod teamfieldvalues {
                 let mut url = azure_core::http::Url::parse(&format!(
                     "{}/{}/{}/{}/_apis/work/teamsettings/teamfieldvalues",
                     self.client.endpoint(),
-                    &self.organization,
-                    &self.project,
-                    &self.team
+                    self.organization,
+                    self.project,
+                    self.team
                 ))?;
                 let has_api_version_already = url.query_pairs().any(|(k, _)| k == "api-version");
                 if !has_api_version_already {


### PR DESCRIPTION
Remove redundant references in format! arguments flagged by the updated Rust toolchain (clippy 1.97). Fixes the codegen (request_builder_send.rs url args), hand-written auth.rs and example, and regenerates all modules.