### PR TITLE
Bump syn from 2.0.118 to 3.0.3 in /autorust

### DIFF
--- a/autorust/Cargo.lock
+++ b/autorust/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "syn 2.0.118",
+ "syn 3.0.3",
  "thiserror 2.0.20",
  "toml",
 ]

--- a/autorust/codegen/Cargo.toml
+++ b/autorust/codegen/Cargo.toml
@@ -21,7 +21,7 @@ comrak = "0.54"
 serde = "1"
 http-types = "2"
 once_cell = "1"
-syn = { version = "2", features = ["parsing"] }
+syn = { version = "3", features = ["parsing"] }
 camino = "1"
 askama = "0.16"
 toml = "1.1"

--- a/autorust/codegen/src/codegen.rs
+++ b/autorust/codegen/src/codegen.rs
@@ -16,7 +16,7 @@ use syn::{
     punctuated::Punctuated,
     token::{Gt, Impl, Lt},
     AngleBracketedGenericArguments, GenericArgument, Path, PathArguments, PathSegment, TraitBound,
-    TraitBoundModifier, Type, TypeImplTrait, TypeParamBound, TypePath, TypeReference,
+    TraitBoundModifiers, Type, TypeImplTrait, TypeParamBound, TypePath, TypeReference,
 };
 
 /// code generation context
@@ -299,21 +299,22 @@ impl TypeNameCode {
         if self.allow_qualify_models && self.qualify_models {
             tp.path.segments.insert(0, id_models().into());
         }
-        let mut tp = Type::from(tp);
+        let mut tp = Type::Path(tp);
         for _ in 0..self.vec_count {
             tp = generic_type(tp_vec(), tp);
         }
         if self.force_value {
-            tp = Type::from(tp_json_value())
+            tp = Type::Path(tp_json_value())
         }
         if self.is_reference() {
             let tr = TypeReference {
+                attrs: Vec::new(),
                 and_token: Default::default(),
                 lifetime: Default::default(),
                 mutability: Default::default(),
                 elem: Box::new(tp),
             };
-            tp = Type::from(tr);
+            tp = Type::Reference(tr);
         }
         if self.boxed {
             tp = generic_type(tp_box(), tp);
@@ -327,13 +328,15 @@ impl TypeNameCode {
                 let bound = TraitBound {
                     path: path.path,
                     paren_token: None,
-                    modifier: TraitBoundModifier::None,
+                    modifiers: TraitBoundModifiers::default(),
+                    maybe: None,
                     lifetimes: None,
                 };
                 let bound = TypeParamBound::Trait(bound);
                 let mut bounds = Punctuated::new();
                 bounds.push(bound);
                 tp = Type::ImplTrait(TypeImplTrait {
+                    attrs: Vec::new(),
                     bounds,
                     impl_token: Impl::default(),
                 });
@@ -378,7 +381,7 @@ fn generic_type(mut wrap_tp: TypePath, tp: Type) -> Type {
     if let Some(v) = wrap_tp.path.segments.last_mut() {
         v.arguments = arguments
     }
-    Type::from(wrap_tp)
+    Type::Path(wrap_tp)
 }
 
 impl From<TypePath> for TypeNameCode {
@@ -434,7 +437,11 @@ fn segments_to_type_path(segments: Vec<PathSegment>) -> TypePath {
         segments: punctuated,
         leading_colon: None,
     };
-    TypePath { path, qself: None }
+    TypePath {
+        attrs: Vec::new(),
+        path,
+        qself: None,
+    }
 }
 
 fn idents_to_type_path(idents: Vec<Ident>) -> TypePath {


### PR DESCRIPTION
Bumps `syn` from 2.0.118 to 3.0.3 in `autorust/codegen`.

This supersedes #813: the plain dependabot bump does not compile, because syn 3.0 is a major release with breaking changes to the AST types that `autorust/codegen` uses directly. This PR includes the version bump **plus** the source migration needed to build.

## syn 3.0 API migration (`autorust/codegen/src/codegen.rs`)
- `TraitBoundModifier` enum replaced by the new `TraitBoundModifiers` struct; `TraitBound.modifier` split into `modifiers` plus a separate `maybe: Option<Token![?]>` field.
- `attrs` is now a mandatory field on every `Type` variant — added to the `TypeReference`, `TypeImplTrait`, and `TypePath` literals.
- The `From<...> for Type` impls were removed — replaced `Type::from(...)` with the explicit `Type::Path(...)` / `Type::Reference(...)` variants.

## Verification
- `cargo build --release` (autorust) — passes
- `./build.sh` (patch → generate → compile crate) — passes
- Regenerated `azure_devops_rust_api/src` output is **byte-identical** to the committed source (the upgrade changes nothing about generated code)
- `cargo clippy --all-features -- --deny warnings` — clean
- `cargo clippy --all-features --examples -- --deny warnings` — clean
- `cargo test -p autorust_codegen --lib` — 73 passed

Note: `syn` is a build-time-only dependency of the code generator and is not part of the published `azure_devops_rust_api` crate's dependency tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)